### PR TITLE
Fix typo in shell-startup comment

### DIFF
--- a/shell-startup
+++ b/shell-startup
@@ -35,7 +35,7 @@ unsetfuncs() { _unset_funcs+=("$@"); }
 
 #-----------------------------------------------------------------------------
 # Assume that this file is in the dotfiles directory, then check if we are
-# linnked to the dotfiles directory.  If we are, then use the real directory
+# linked to the dotfiles directory.  If we are, then use the real directory
 # as the dotfiles directory.
 
 declare -x DOTFILES="$HOME"


### PR DESCRIPTION
## Summary
- fix spelling of `linked` in `shell-startup`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424364a28483219bbfbb9b53b8fb8d