### PR TITLE
Fix heading typo in util_lib

### DIFF
--- a/lib/util_lib
+++ b/lib/util_lib
@@ -43,7 +43,7 @@ and can be used in any bash based script.
 
 This file will run various checks, detailed below.
 
-=head2 Enviroment Check
+=head2 Environment Check
 
 If this file is not being called in a bash environment, or as a bash script,
 it will exit with an error message.


### PR DESCRIPTION
## Summary
- fix 'Enviroment Check' typo in util_lib POD docs

## Testing
- `pytest -q` *(fails: VaultKeyError raised during tests)*

------
https://chatgpt.com/codex/tasks/task_e_684243e58b3483219b6f91b6a7ae1fbc