### PR TITLE
Move BATS_LIB_PATH into 010-general, guarded by bats presence

### DIFF
--- a/config/shell-startup/010-general
+++ b/config/shell-startup/010-general
@@ -212,3 +212,12 @@ findword() {
 if command -v gh &> /dev/null; then
   alias ghlastactionid="gh run list --limit 1 --json 'databaseId' --jq '.[0].databaseId'"
 fi
+
+#-----------------------------------------------------------------------------
+# bats: expose this repo's first-class helper lib (lib/bats) ahead of the
+# system libs so any repo can `bats_load_library bats-toolbox`. Only when
+# bats is installed and the lib dir exists; honour an existing BATS_LIB_PATH.
+
+if command -v bats &> /dev/null && [[ -d "$DOTFILES/lib/bats" ]]; then
+  export BATS_LIB_PATH="$DOTFILES/lib/bats:${BATS_LIB_PATH:-/usr/lib/bats}"
+fi

--- a/shell-startup
+++ b/shell-startup
@@ -59,11 +59,6 @@ export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
-# bats helper libraries: put this repo's first-class lib (lib/bats) ahead
-# of the system libs so any repo can `bats_load_library bats-toolbox`.
-# Honour an existing BATS_LIB_PATH (e.g. one set by bats-action in CI).
-export BATS_LIB_PATH="$DOTFILES/lib/bats:${BATS_LIB_PATH:-/usr/lib/bats}"
-
 ##############################################################################
 # Functions
 


### PR DESCRIPTION
## Summary
- Relocate the `BATS_LIB_PATH` export from core `shell-startup` into the `config/shell-startup/010-general` module (the only bats-related setting).
- Set it only when bats is installed (`command -v bats`) and `$DOTFILES/lib/bats` exists; honour an existing `BATS_LIB_PATH`.

## Test plan
- [ ] In a shell with bats installed: `BATS_LIB_PATH` = `$DOTFILES/lib/bats:/usr/lib/bats`
- [ ] With bats absent or `lib/bats` missing: `BATS_LIB_PATH` stays unset
- [ ] `bash -n shell-startup config/shell-startup/010-general`