### PR TITLE
Pin dulwich >=1.2.5 (Dependabot high-severity alerts)

### DIFF
--- a/config/pypoetry/pyproject.toml
+++ b/config/pypoetry/pyproject.toml
@@ -10,3 +10,4 @@ package-mode = false
 python = "3.12.3"
 poetry = "2.3.4"
 idna = ">=3.15"
+dulwich = ">=1.2.5"


### PR DESCRIPTION
## Summary
- Add a `dulwich >= 1.2.5` constraint to `config/pypoetry/pyproject.toml` (transitive via poetry; matches the existing `idna` constraint).
- Closes GHSA-9277-mp7x-85jf (command injection) and GHSA-897w-fcg9-f6xj (arbitrary file write).

## Test plan
- [ ] `pyproject.toml` parses; `dulwich >= 1.2.5` present
- [ ] Dependabot alerts auto-close after merge to master