### PR TITLE
TODO: shell-startup follow-ups (grok, hook-dir rename, run_hook)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -114,11 +114,12 @@ Deferred from the shell-startup trim (PR #16):
   module (guarded like the others). First decide how to stop the grok
   installer re-appending it to `shell-startup` (retarget it, or accept
   periodic cleanup). *[needs thought]*
-- [ ] **Consider renaming the hook dirs.** `{,.}shell_startup.d` hold *hooks*
-  while `config/shell-startup` holds always-loaded files; renaming the hook
-  dirs to `{,.}shell_startup_hooks.d` would make that distinction obvious. If
-  done, update `load_files`, the pre-setup hook path, and `run_hook`'s default
-  `$dfdir`.
+- [ ] **Rename the hook dirs — before the startup tests are finalized.**
+  `{,.}shell_startup.d` hold *hooks* while `config/shell-startup` holds
+  always-loaded files; rename the hook dirs to `{,.}shell_startup_hooks.d` to
+  make that obvious. Do this before the containerized startup tests are done
+  so they target the final names. Update `load_files`, the pre-setup hook
+  path, `run_hook`'s default `$dfdir`, and the directories themselves.
 - [ ] **Test `run_hook`, then comment it out.** It works now but is called
   nowhere; with the containerized startup-test work, add a test covering the
   default + a custom `$dfdir` and a missing hook (returns non-zero), then

--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,26 @@ findings. Research how to actually use each and whether to formalize it.
 - [ ] If a tool adds no actionable value, consider disabling its check to cut
   PR-check noise; if it does, document the triage workflow.
 
+## 🧹 shell-startup Follow-ups (LOW PRIORITY)
+
+Deferred from the shell-startup trim (PR #16):
+
+- [ ] **Move the grok installer block out.** The `>>> grok installer >>>`
+  block (PATH + completion) at the end of `shell-startup` runs after Cleanup
+  and isn't a pre-load global — move it to a `config/shell-startup/grok`
+  module (guarded like the others). First decide how to stop the grok
+  installer re-appending it to `shell-startup` (retarget it, or accept
+  periodic cleanup). *[needs thought]*
+- [ ] **Consider renaming the hook dirs.** `{,.}shell_startup.d` hold *hooks*
+  while `config/shell-startup` holds always-loaded files; renaming the hook
+  dirs to `{,.}shell_startup_hooks.d` would make that distinction obvious. If
+  done, update `load_files`, the pre-setup hook path, and `run_hook`'s default
+  `$dfdir`.
+- [ ] **Test `run_hook`, then comment it out.** It works now but is called
+  nowhere; with the containerized startup-test work, add a test covering the
+  default + a custom `$dfdir` and a missing hook (returns non-zero), then
+  comment `run_hook` out — leaving it in place for possible future use.
+
 ## 🐚 Test dotfiles Startup in Containers (MEDIUM PRIORITY)
 
 Goal: confirm the **dotfiles startup actually functions** in a fresh,


### PR DESCRIPTION
## Summary
- Add a TODO capturing the deferred shell-startup items: move the grok installer block to a module, consider renaming the hook dirs to `{,.}shell_startup_hooks.d`, and test `run_hook` then comment it out.

## Test plan
- [ ] Docs-only; wrap sane; no behavior change.