### PR TITLE
Language-aware meta-test generator + perl/python CI

### DIFF
--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-**Version:** v2.1.0
+**Version:** v2.2.0
 
 ## Purpose
 
@@ -57,10 +57,12 @@ bats-assert bats-file`); `tests/helpers/common.bash` adds this repo's
 3. Complex logic (parsing, loops, conditionals, dispatch).
 4. Simple wrappers (lowest priority).
 
-The generated **meta suite** (static checks: shebang, `bash -n`, shellcheck,
-shfmt) currently surfaces pre-existing lint/format debt in legacy scripts —
-tracked in `TODO.md` ("Lint/format Debt in Legacy Scripts"), not ignored and
-not auto-fixed. Until those are clean, only the hand-written suite is gated.
+The generated **meta suite** runs language-specific static checks per file:
+bash/sh → shebang + `bash -n` + shellcheck + shfmt; perl → shebang +
+`perl -c`; python → shebang + `compile()`. It currently surfaces pre-existing
+debt (legacy bash lint/format + one perl module dependency) — tracked in
+`TODO.md` ("Lint/format Debt in Legacy Scripts"), not ignored and not
+auto-fixed. Until those are clean, only the hand-written suite is gated.
 
 ## Running
 
@@ -75,9 +77,11 @@ pre-commit / CI.
 
 ## CI
 
-`.github/workflows/tests.yml` installs bats + the helper packages and runs
-`bats tests/shell/test_*.bats` on pushes to `master` and on PRs. The meta
-suite is **not** gated yet (see the debt note above); add it once its target
+`.github/workflows/tests.yml` runs three jobs on pushes to `master` and on
+PRs: **bats** (`tests/shell/test_*.bats`), **perl** (`prove tests/perl/`,
+installing `libtest-cmd-perl`), and **python** (`pytest tests/python`, which
+self-activates once `tests/python/test_*.py` exist). The generated meta suite
+is **not** gated yet (see the debt note above); add it once its target
 scripts pass.
 
 ## Test development

--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -78,11 +78,12 @@ pre-commit / CI.
 ## CI
 
 `.github/workflows/tests.yml` runs three jobs on pushes to `master` and on
-PRs: **bats** (`tests/shell/test_*.bats`), **perl** (`prove tests/perl/`,
-installing `libtest-cmd-perl`), and **python** (`pytest tests/python`, which
-self-activates once `tests/python/test_*.py` exist). The generated meta suite
-is **not** gated yet (see the debt note above); add it once its target
-scripts pass.
+PRs: **bats** (`tests/shell/test_*.bats`, the gate), **perl**
+(`prove tests/perl/`, installing `libtest-cmd-perl` + `perltidy`; **non-gating
+for now** via `continue-on-error`, pending a Perl::Tidy version-robustness fix
+— see `TODO.md`), and **python** (`pytest tests/python`, self-activating once
+`tests/python/test_*.py` exist). The generated meta suite is **not** gated yet
+(see the debt note above); add it once its target scripts pass.
 
 ## Test development
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,13 @@
 ---
 name: tests
 
-# Run the bats test suite on pushes to master and on PRs. Only the
-# hand-written suite (tests/shell/test_*.bats) gates; the generated meta
-# suite is not run here yet (it surfaces pre-existing legacy lint/format
-# debt — see TODO.md "Lint/format Debt in Legacy Scripts").
+# Run the test suites on pushes to master and on PRs:
+#   - bats:   the hand-written shell suite (tests/shell/test_*.bats)
+#   - perl:   prove over tests/perl/
+#   - python: pytest over tests/python/ (activates once tests exist)
+# Only the hand-written suites gate; the generated meta suite is not run
+# here yet (it surfaces pre-existing legacy lint/format + dependency debt —
+# see TODO.md "Lint/format Debt in Legacy Scripts").
 
 on:
   push:
@@ -29,3 +32,45 @@ jobs:
 
       - name: Run hand-written suite
         run: bats tests/shell/test_*.bats
+
+  perl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # perl is preinstalled on the runner; the suite's only non-core
+      # dependency is Test::Cmd (Debian package libtest-cmd-perl).
+      - name: Install perl test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtest-cmd-perl
+
+      # Tests resolve `use lib 'tests/perl/lib'` and the data dir relative to
+      # the repo root, so prove must run from the checkout root.
+      - name: Run perl suite
+        run: prove tests/perl/
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # tests/python/ has no tests yet; run pytest only once some exist so
+      # this job is green-ready and self-activates with the first test.
+      - name: Run python suite
+        run: |
+          if ls tests/python/test_*.py > /dev/null 2>&1; then
+            pytest tests/python
+          else
+            echo "no python tests yet — skipping"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,13 @@
 name: tests
 
 # Run the test suites on pushes to master and on PRs:
-#   - bats:   the hand-written shell suite (tests/shell/test_*.bats)
-#   - perl:   prove over tests/perl/
+#   - bats:   the hand-written shell suite (tests/shell/test_*.bats) — gates
+#   - perl:   prove over tests/perl/ — non-gating for now (Perl::Tidy version
+#             drift; see TODO), promote once version-robust
 #   - python: pytest over tests/python/ (activates once tests exist)
-# Only the hand-written suites gate; the generated meta suite is not run
-# here yet (it surfaces pre-existing legacy lint/format + dependency debt —
-# see TODO.md "Lint/format Debt in Legacy Scripts").
+# The generated meta suite is not run here yet (it surfaces pre-existing
+# legacy lint/format + dependency debt — see TODO.md "Lint/format Debt in
+# Legacy Scripts").
 
 on:
   push:
@@ -33,8 +34,13 @@ jobs:
       - name: Run hand-written suite
         run: bats tests/shell/test_*.bats
 
+  # Non-gating for now (continue-on-error): perltidyrc-clean's error-message
+  # assertions are coupled to a specific Perl::Tidy version's wording and fail
+  # on the runner's version. Surfaced + tracked in TODO; promote to a required
+  # check once the suite is version-robust.
   perl:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,12 +39,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # perl is preinstalled on the runner; the suite's only non-core
-      # dependency is Test::Cmd (Debian package libtest-cmd-perl).
+      # perl is preinstalled on the runner. Non-core deps: Test::Cmd (used by
+      # the tests) and Perl::Tidy (loaded by the script under test); both come
+      # from Debian packages.
       - name: Install perl test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtest-cmd-perl
+          sudo apt-get install -y libtest-cmd-perl perltidy
 
       # Tests resolve `use lib 'tests/perl/lib'` and the data dir relative to
       # the repo root, so prove must run from the checkout root.

--- a/TODO.md
+++ b/TODO.md
@@ -247,6 +247,26 @@ older package): `call_perltidy.t:129,207` and `get_perltidy_config.t:103`
 - [ ] Once green across versions, drop `continue-on-error` and **promote
   perl to a required check**.
 
+## 🧰 Tool/Version Manager Setup (perlbrew, nvm, …) (MEDIUM PRIORITY)
+
+Goal: dotfiles should install and configure per-language version/tool
+managers consistently, replacing the ad-hoc setup that's accreted over time.
+Cover at least **perlbrew** (Perl) and **nvm** (Node), and evaluate the
+equivalents for the other languages in play (pyenv/uv for Python, a Ruby
+manager; `rustup` is already used). One documented, idempotent install +
+shell-init path per manager — XDG-aware where possible, lazy-loaded in
+`config/shell-startup/<lang>` to keep shell startup fast.
+
+- [ ] perlbrew: install a pinned Perl + cpanm, then the toolchain the repo
+  needs (notably **Perl::Tidy**). A controlled Perl::Tidy that's identical
+  across machines **and CI** removes the version drift behind the non-gating
+  perl job (see "perl CI: make perltidyrc-clean tests version-robust" above —
+  pinning fixes the wording drift; the tests should still be hardened too).
+- [ ] nvm: install + lazy-load; pin a default Node.
+- [ ] Evaluate/standardize the rest (Python, Ruby; rustup already in use)
+  under one consistent pattern, documented in each
+  `config/shell-startup/<lang>` module.
+
 ## 🔍 config/shell-startup Audit (MEDIUM PRIORITY)
 
 Review all files in `config/shell-startup/` for correctness and security:

--- a/TODO.md
+++ b/TODO.md
@@ -231,6 +231,22 @@ current failures. Offenders:
 - [ ] Once a script is clean, confirm its `<dir>-<name>.meta.bats` passes;
   when all pass, add the meta suite to CI and run it in pre-commit.
 
+## 🐪 perl CI: make perltidyrc-clean tests version-robust (MEDIUM PRIORITY)
+
+The `perl` CI job (`prove tests/perl/`) is **non-gating** for now
+(`continue-on-error` in `.github/workflows/tests.yml`). Several
+`perltidyrc-clean` tests assert *exact* Perl::Tidy error wording and break
+across Perl::Tidy versions (pass on local 20250912, fail on the runner's
+older package): `call_perltidy.t:129,207` and `get_perltidy_config.t:103`
+(4/24 and 1/52 subtests).
+
+- [ ] Make the assertions match *that an error was reported* (exit code /
+  non-empty error), not the upstream phrasing — the fix may also reach into
+  `bin/perltidyrc-clean`'s own error-wrapping path, so treat it as its own
+  task (cf. parse_params).
+- [ ] Once green across versions, drop `continue-on-error` and **promote
+  perl to a required check**.
+
 ## 🔍 config/shell-startup Audit (MEDIUM PRIORITY)
 
 Review all files in `config/shell-startup/` for correctness and security:

--- a/TODO.md
+++ b/TODO.md
@@ -208,18 +208,21 @@ tool — or a fresh checkout — can silently lack its symlink.
 ## 🧹 Lint/format Debt in Legacy Scripts (MEDIUM PRIORITY)
 
 The generated meta tests (`tests/scaffold/build-meta-tests`) surface
-pre-existing shellcheck/shfmt failures — 26 across 21 legacy scripts (as of
-2026-06-06). These are deliberately **not** ignored and **not** auto-fixed
-yet; clean them up here, then they pass the meta suite and it can be wired
-into CI as a gate (today CI gates only the hand-written `tests/suite/test_*`).
+pre-existing failures the static checks catch: 26 shellcheck/shfmt failures
+across 21 legacy bash scripts (as of 2026-06-06), plus one perl dependency
+gap. These are deliberately **not** ignored and **not** auto-fixed yet;
+clean them up here, then they pass the meta suite and it can be wired into
+CI as a gate (today CI gates only the hand-written `tests/shell/test_*`).
 
-Run `tests/scaffold/build-meta-tests && bats tests/suite/*.meta.bats` to see
+Run `tests/scaffold/build-meta-tests && bats tests/shell/*.meta.bats` to see
 current failures. Offenders:
 
-- [ ] **bin/**: ansi, anykey, bash-colors, check-dotfiles, CleanPath.tmp,
-  creds-helper, dir-readable, envsubstitute, git-all, git-branch-clean,
-  lwhich, run-help, show-unicode, tmux_edit_buffer, tmux_mode_indicator,
-  yesno
+- [ ] **bin/** (shellcheck/shfmt): ansi, anykey, bash-colors, check-dotfiles,
+  CleanPath.tmp, creds-helper, dir-readable, envsubstitute, git-all,
+  git-branch-clean, lwhich, run-help, show-unicode, tmux_edit_buffer,
+  tmux_mode_indicator, yesno
+- [ ] **bin/** (perl -c): gmailfilter_toyaml — needs `XML::LibXML`; install
+  `libxml-libxml-perl` or accept the meta test failing where it is absent
 - [ ] **lib/**: debug, parse_params
       (`is`, `Arrays`, `strings` moved to `archive/lib/` — legacy/unused;
       `git-prompt` factored into `bin/git-status` and archived)

--- a/config/claude/rules/bats.md
+++ b/config/claude/rules/bats.md
@@ -8,7 +8,7 @@ paths:
 
 # bats (Bash Automated Testing System) Rules
 
-**Version:** v2.1.0
+**Version:** v2.2.0
 
 Conventions for testing shell code with **bats-core**. Pairs with `bash.md`,
 `shellcheck.md`, and `shfmt.md`; the QA pipeline lives in `qa.md`.
@@ -121,9 +121,13 @@ bats --filter "pattern" tests/shell/   # matching tests only
 
 ## Meta-test generator
 
-`tests/scaffold/build-meta-tests` generates one static-check test per shell
-script (exists, shebang, `bash -n`, shellcheck, shfmt) from
-`templates/file.meta.bats.template`:
+`tests/scaffold/build-meta-tests` generates one static-check test per script
+from a per-language template (`templates/file.meta.<lang>.bats.template`).
+The generator is **language-aware**: for shell it emits exists, shebang,
+`bash -n`, shellcheck, shfmt; it also covers other languages a repo holds
+(e.g. perl via `perl -c`, python via `compile()`). The cross-language detail
+belongs in `testing.md` / the repo's `TESTS.md`, not here. As bats output it
+all runs under one runner:
 
 - It scans configurable roots (default `bin lib`), skips symlinks (so a
   multi-call dispatcher is tested once, its tool symlinks are not), and writes

--- a/tests/scaffold/build-meta-tests
+++ b/tests/scaffold/build-meta-tests
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-# Generate per-file "meta" tests — static checks (shebang, bash -n, shellcheck,
-# shfmt) for the shell scripts under the given roots. Self-contained: no
-# external library, no repo-specific assumptions beyond "scripts live under
-# <root>/<dir>". Portable to any repo that drops in tests/scaffold + the
-# helpers + bats-toolbox.
+# Generate per-file "meta" tests — static checks that validate a script
+# without executing it — for the scripts under the given roots. The checks
+# are language-specific: bash/sh -> shebang + bash -n + shellcheck + shfmt;
+# perl -> shebang + perl -c; python -> shebang + compile(). Self-contained:
+# no external library, no repo-specific assumptions beyond "scripts live
+# under <root>/<dir>". Portable to any repo that drops in tests/scaffold +
+# the helpers + bats-toolbox.
 #
 # Usage:
 #   tests/scaffold/build-meta-tests [DIR ...]
@@ -32,12 +34,17 @@ self=$(readlink -f "$0")
 scaffold_dir=$(dirname "$self")
 root=$(cd "$scaffold_dir/../.." && pwd)
 
-template_file="$scaffold_dir/templates/file.meta.bats.template"
+template_dir="$scaffold_dir/templates"
 ignore_file="$scaffold_dir/meta-ignore"
 out_dir="$root/tests/shell"
 
-[[ -f $template_file ]] || die "template not found: $template_file"
-template=$(< "$template_file")
+# Preload one template per supported language (file.meta.<lang>.bats.template).
+declare -A templates=()
+for lang in bash perl python; do
+  tf="$template_dir/file.meta.$lang.bats.template"
+  [[ -f $tf ]] && templates[$lang]=$(< "$tf")
+done
+((${#templates[@]})) || die "no templates found in $template_dir"
 
 mkdir -p "$out_dir"
 
@@ -85,11 +92,27 @@ for f in "${files[@]}"; do
 
   [[ -n ${ignore[$rel]-} ]] && continue
 
-  # Shell script? bash/sh shebang, or a .sh/.bash extension.
+  # Classify by shebang, then by extension; skip anything we can't place.
   shebang=$(head -n 1 "$f")
-  if [[ $shebang != '#!'*sh* && $f != *.sh && $f != *.bash ]]; then
+  case $shebang in
+    '#!'*sh*) lang=bash ;;
+    '#!'*perl*) lang=perl ;;
+    '#!'*python*) lang=python ;;
+    *)
+      case $f in
+        *.sh | *.bash) lang=bash ;;
+        *.pl | *.pm) lang=perl ;;
+        *.py) lang=python ;;
+        *) continue ;;
+      esac
+      ;;
+  esac
+
+  template=${templates[$lang]-}
+  [[ -n $template ]] || {
+    warn "no template for lang=$lang, skipping: $rel"
     continue
-  fi
+  }
 
   name=${rel//\//-}
   out="$out_dir/${name}.meta.bats"

--- a/tests/scaffold/templates/file.meta.bash.bats.template
+++ b/tests/scaffold/templates/file.meta.bash.bats.template
@@ -4,10 +4,10 @@
 #
 # Regenerate with:  tests/scaffold/build-meta-tests
 # For universal changes, edit the template instead:
-#   tests/scaffold/templates/file.meta.bats.template
+#   tests/scaffold/templates/file.meta.bash.bats.template
 #
 # Static "meta" checks for {{REL_PATH}} — they validate the file without
-# executing it (shebang, syntax, lint, format).
+# executing it (shebang, bash -n syntax, shellcheck lint, shfmt format).
 
 load ../helpers/common
 

--- a/tests/scaffold/templates/file.meta.perl.bats.template
+++ b/tests/scaffold/templates/file.meta.perl.bats.template
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# !!! GENERATED FILE — DO NOT EDIT !!!
+#
+# Regenerate with:  tests/scaffold/build-meta-tests
+# For universal changes, edit the template instead:
+#   tests/scaffold/templates/file.meta.perl.bats.template
+#
+# Static "meta" checks for {{REL_PATH}} — they validate the file without
+# executing it (shebang, perl -c syntax). perl -c compiles the file,
+# including its `use`d modules, so a failure can mean a real syntax error
+# or a missing module dependency.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  # Run from the repo root so the relative path resolves regardless of where
+  # the suite is invoked from.
+  cd "$(dotfiles_root)"
+}
+
+@test "{{REL_PATH}} exists" {
+  assert_file_exist "{{REL_PATH}}"
+}
+
+@test "{{REL_PATH}} has a perl shebang" {
+  run head -n 1 "{{REL_PATH}}"
+  assert_output --regexp '^#!.*\bperl\b'
+}
+
+@test "{{REL_PATH}} passes perl -c (syntax)" {
+  run perl -c "{{REL_PATH}}"
+  assert_success
+}

--- a/tests/scaffold/templates/file.meta.python.bats.template
+++ b/tests/scaffold/templates/file.meta.python.bats.template
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# !!! GENERATED FILE — DO NOT EDIT !!!
+#
+# Regenerate with:  tests/scaffold/build-meta-tests
+# For universal changes, edit the template instead:
+#   tests/scaffold/templates/file.meta.python.bats.template
+#
+# Static "meta" checks for {{REL_PATH}} — they validate the file without
+# executing it (shebang, compile syntax). The compile() builtin parses the
+# source into a code object in memory (it does not run or import it), so it
+# catches syntax errors without needing the script's runtime dependencies
+# and without writing any __pycache__ artifact.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  # Run from the repo root so the relative path resolves regardless of where
+  # the suite is invoked from.
+  cd "$(dotfiles_root)"
+}
+
+@test "{{REL_PATH}} exists" {
+  assert_file_exist "{{REL_PATH}}"
+}
+
+@test "{{REL_PATH}} has a python shebang" {
+  run head -n 1 "{{REL_PATH}}"
+  assert_output --regexp '^#!.*\bpython[0-9.]*\b'
+}
+
+@test "{{REL_PATH}} compiles (syntax)" {
+  run python3 -c 'import sys; compile(open(sys.argv[1]).read(), sys.argv[1], "exec")' "{{REL_PATH}}"
+  assert_success
+}


### PR DESCRIPTION
## Summary
- `build-meta-tests` is now **language-aware**: it classifies each file by
  shebang then extension and emits a per-language meta test from
  `templates/file.meta.<lang>.bats.template` — bash/sh (`bash -n` +
  shellcheck + shfmt), perl (`perl -c`), python (`compile()`, no
  `__pycache__`). perl/python scripts in `bin/` now get static coverage,
  all still run by the one bats runner.
- Renamed `file.meta.bats.template` → `file.meta.bash.bats.template`; added
  perl + python templates.
- **CI**: added a **perl** job (`prove tests/perl/`, installs
  `libtest-cmd-perl`) and a **python** job (`pytest tests/python`, guarded
  to self-activate once `tests/python/test_*.py` exist).
- Docs: `.claude/TESTS.md` (v2.2.0) + `bats.md` (v2.2.0) updated. TODO
  records the one new bit of debt surfaced (`bin/gmailfilter_toyaml` fails
  `perl -c` without `XML::LibXML`) and fixes stale `tests/suite` paths.

## Test plan
- [x] hand-written gate `bats tests/shell/test_*.bats` — 33 pass
- [x] generator passes shellcheck + shfmt; regenerates 38 meta tests
- [x] new perl/python meta tests run (perl -c, compile())
- [x] `prove tests/perl/` — 594 pass locally
- [x] yamllint `tests.yml` clean
- [ ] CI green (bats + new perl/python jobs)