### PR TITLE
Cover run_hook with tests, then make it dormant

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -137,10 +137,12 @@ Deferred from the shell-startup trim (PR #16):
   make that obvious. Do this before the containerized startup tests are done
   so they target the final names. Update `load_files`, the pre-setup hook
   path, `run_hook`'s default `$dfdir`, and the directories themselves.
-- [ ] **Test `run_hook`, then comment it out.** It works now but is called
-  nowhere; with the containerized startup-test work, add a test covering the
-  default + a custom `$dfdir` and a missing hook (returns non-zero), then
-  comment `run_hook` out — leaving it in place for possible future use.
+- [x] **Test `run_hook`, then comment it out.** Added
+  `tests/shell/test_run_hook.bats` (custom `$dfdir`, default
+  `$DOTFILES/shell_startup.d` fallback, missing hook, failing hook) — verified
+  passing with `run_hook` active, then commented `run_hook` out in
+  `shell-startup` and set the tests to `skip` (preserved for future use;
+  remove the skip + uncomment to reactivate).
 
 ## 🐚 Test dotfiles Startup in Containers (MEDIUM PRIORITY)
 

--- a/shell-startup
+++ b/shell-startup
@@ -115,27 +115,32 @@ unsetfuncs 'addpath'
 
 #-----------------------------------------------------------------------------
 # Source an optional hook file from $dfdir if it exists and is readable.
+#
+# COMMENTED OUT — preserved for possible future use. run_hook is called
+# nowhere today; uncomment the function and its unsetfuncs registration below
+# to reactivate it. Its behavior is covered by tests/shell/test_run_hook.bats,
+# which are skipped while this is commented out — remove that skip (and
+# uncomment below) to run them.
 
-run_hook() {
-  # Kept for possible future use — currently called nowhere (see TODO).
-  # Sources an optional hook named $1 from $dfdir, defaulting to the
-  # dotfiles hook directory when a caller has not set one.
-  local hook="${dfdir:-$DOTFILES/shell_startup.d}/$1"
-  debug "running hook: $hook"
-  [[ -r $hook ]] || {
-    debug "hook not readable: $hook"
-    return 1
-  }
-
-  # shellcheck disable=SC1090
-  source "$hook" || {
-    debug "hook failed: $hook"
-    return 1
-  }
-  return 0
-}
-
-unsetfuncs 'run_hook'
+# run_hook() {
+#   # Sources an optional hook named $1 from $dfdir, defaulting to the
+#   # dotfiles hook directory when a caller has not set one.
+#   local hook="${dfdir:-$DOTFILES/shell_startup.d}/$1"
+#   debug "running hook: $hook"
+#   [[ -r $hook ]] || {
+#     debug "hook not readable: $hook"
+#     return 1
+#   }
+#
+#   # shellcheck disable=SC1090
+#   source "$hook" || {
+#     debug "hook failed: $hook"
+#     return 1
+#   }
+#   return 0
+# }
+#
+# unsetfuncs 'run_hook'
 
 #-----------------------------------------------------------------------------
 # Add custom binary directories to the system's PATH variable, allowing users

--- a/tests/shell/test_run_hook.bats
+++ b/tests/shell/test_run_hook.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+# Tests for shell-startup's run_hook(). run_hook is preserved in the
+# orchestrator for possible future use but is currently COMMENTED OUT and
+# called nowhere, so these tests are skipped (see the skip in setup below).
+# To run them: uncomment run_hook in shell-startup and remove the skip.
+#
+# run_hook lives inside the shell-startup orchestrator (not independently
+# sourceable), so the tests extract just its definition from the file and
+# eval it in isolation rather than running the whole orchestrator.
+
+load ../helpers/common
+
+# Extract run_hook's definition from shell-startup so the real body can be
+# eval'd and exercised in isolation.
+extract_run_hook() {
+  awk '
+    /^run_hook\(\)[[:space:]]*\{/ { capture = 1 }
+    capture { print }
+    capture && /^\}/ { capture = 0 }
+  ' "$(dotfiles_root)/shell-startup"
+}
+
+setup() {
+  # Load libs first so teardown's cleanup_temp_dir is defined even when the
+  # skip below short-circuits the rest of setup.
+  load_bats_libs
+
+  skip "run_hook is commented out in shell-startup (preserved for future use)"
+
+  # run_hook calls debug(); stub it as a quiet no-op for these tests.
+  # shellcheck disable=SC2329  # invoked indirectly by the eval'd run_hook
+  debug() { :; }
+
+  eval "$(extract_run_hook)"
+
+  setup_temp_dir
+}
+
+teardown() {
+  cleanup_temp_dir
+}
+
+@test "run_hook runs a readable hook from a custom \$dfdir and returns 0" {
+  printf 'touch "%s/ran"\n' "$TEST_TEMP_DIR" > "$TEST_TEMP_DIR/myhook"
+
+  dfdir="$TEST_TEMP_DIR" run run_hook myhook
+
+  assert_success
+  assert_file_exist "$TEST_TEMP_DIR/ran"
+}
+
+@test "run_hook falls back to \$DOTFILES/shell_startup.d when \$dfdir unset" {
+  mkdir -p "$TEST_TEMP_DIR/shell_startup.d"
+  printf 'touch "%s/ran"\n' "$TEST_TEMP_DIR" \
+    > "$TEST_TEMP_DIR/shell_startup.d/deflt"
+
+  unset dfdir
+  DOTFILES="$TEST_TEMP_DIR" run run_hook deflt
+
+  assert_success
+  assert_file_exist "$TEST_TEMP_DIR/ran"
+}
+
+@test "run_hook returns non-zero for a missing hook" {
+  dfdir="$TEST_TEMP_DIR" run run_hook does-not-exist
+
+  assert_failure
+}
+
+@test "run_hook returns non-zero when the hook itself fails" {
+  printf 'return 1\n' > "$TEST_TEMP_DIR/bad"
+
+  dfdir="$TEST_TEMP_DIR" run run_hook bad
+
+  assert_failure
+}


### PR DESCRIPTION
## Summary
- Add `tests/shell/test_run_hook.bats` for `shell-startup`'s `run_hook`:
  custom `$dfdir`, `$DOTFILES/shell_startup.d` fallback, missing hook
  (non-zero), and failing hook (non-zero). The tests extract `run_hook`'s
  definition from `shell-startup` and eval it in isolation (it isn't
  independently sourceable). Verified passing with `run_hook` active.
- `run_hook` is called nowhere, so comment it out in `shell-startup`
  (preserved for future use) and set the tests to `skip` until it's
  reactivated. A header in `shell-startup` and the skip reason both explain
  how to bring it back.

## Test plan
- [x] `bats tests/shell/test_run_hook.bats` — 4 clean skips
- [x] verified 4/4 pass with `run_hook` active (before commenting)
- [x] full suite `bats tests/shell/test_*.bats` green (33 + 4 skipped)
- [x] shellcheck clean on the test
- [ ] CI green