### PR TITLE
Add pre-commit Phase 1 (check + fix configs)

### DIFF
--- a/.pre-commit-config-fix.yaml
+++ b/.pre-commit-config-fix.yaml
@@ -1,0 +1,35 @@
+---
+# Auto-fix pre-commit hooks (MODIFYING) — run MANUALLY, never on commit:
+#   pre-commit run --config .pre-commit-config-fix.yaml --all-files
+# The check-only gate is .pre-commit-config.yaml. Per
+# .claude/rules/pre-commit.md, run this once as a final prep step before
+# committing, not mid-session in response to individual failures.
+#
+# Phase 1 (Core).
+#
+# Refresh revs with:
+#   pre-commit autoupdate --config .pre-commit-config-fix.yaml
+
+exclude: '^archive/'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      # -w = write in place; flags match shfmt.md / .editorconfig.
+      - id: shfmt
+        args: [-w, -i, '2', -s, -bn, -ci, -sr]
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
+    hooks:
+      # Markdown and YAML are owned by markdownlint / yamllint; exclude them
+      # so prettier does not fight those tools' formatting.
+      - id: prettier
+        exclude: '\.(md|markdown|ya?ml)$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+---
+# Check-only pre-commit hooks (NON-MODIFYING) — run on `git commit` and gate
+# the commit. Auto-fixers live in .pre-commit-config-fix.yaml and are run
+# manually (see README + .claude/rules/pre-commit.md).
+#
+# Phase 1 (Core). Security / language / docs hooks are tracked in TODO.md and
+# must land here before CI is allowed to gate them.
+#
+# trailing-whitespace / end-of-file-fixer are intentionally NOT here: those
+# hooks can only fix (they modify files), which would violate "check-only".
+# They live in the fix config instead.
+#
+# Revs are pinned. Refresh with `pre-commit autoupdate` when drift is
+# suspected (see .claude/rules/pre-commit.md).
+
+exclude: '^archive/'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-json
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
+    hooks:
+      - id: shellcheck
+        args: [--external-sources]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      # -d = diff only (non-modifying); flags match shfmt.md / .editorconfig.
+      - id: shfmt
+        args: [-d, -i, '2', -s, -bn, -ci, -sr]
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: [-c, config/yamllint/config]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint
+        args: [--config, dot-general/.markdownlintrc]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,30 @@ echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
 complete -p | grep git
 ```
 
+### 5. (Optional) Enable pre-commit hooks
+
+The repo ships two [pre-commit] configs: `.pre-commit-config.yaml`
+(check-only, gates `git commit`) and `.pre-commit-config-fix.yaml`
+(auto-fixers, run manually).
+
+```bash
+# Install the git hook so the check config runs on every commit
+pre-commit install
+
+# Apply auto-fixes (formatting, trailing whitespace) before committing
+pre-commit run --config .pre-commit-config-fix.yaml --all-files
+
+# Ad-hoc check without committing
+pre-commit run --all-files
+```
+
+`--all-files` surfaces pre-existing lint/format debt in legacy scripts
+(tracked in `TODO.md`); a normal commit only checks the files it touches.
+See `.claude/rules/pre-commit.md` for the full command reference
+(`install` variants, `autoupdate`, `validate-config`, `gc`).
+
+[pre-commit]: https://pre-commit.com/
+
 ## Architecture Overview
 
 ### Shell Startup System

--- a/TODO.md
+++ b/TODO.md
@@ -207,6 +207,23 @@ tool — or a fresh checkout — can silently lack its symlink.
   symlink mode is 120000 and unaffected by `core.filemode=false` (see Git
   File-Mode Normalization above).
 
+## 📝 bin/markdownlint docker wrapper (MEDIUM PRIORITY)
+
+markdownlint is the only linter in the toolset without a `bin/` docker
+wrapper (shellcheck, shfmt, yamllint, prettier, hadolint, trivy, dive all
+have one), so `markdownlint` is "command not found" locally. Add it to the
+`docker_wrapper` dispatcher using the official image
+`ghcr.io/igorshubovych/markdownlint-cli` (versioned tags, e.g. `:v0.48.0`).
+
+- [ ] Add `IMG_MARKDOWNLINT`, a `markdownlint()` function (mount `$PWD` and
+  the repo's `dot-general/.markdownlintrc` like the other wrappers) and
+  `known_tool[markdownlint]=1`, plus the `bin/markdownlint` symlink (the
+  symlink-automation `--fix` above can create it once registered).
+- [ ] Pin the image tag and refresh it alongside the markdownlint-cli
+  pre-commit hook rev so the CLI and the hook stay in lock-step.
+- [ ] Note: independent of pre-commit — the remote-pinned markdownlint hook
+  uses its own node install, not this wrapper (see Pre-commit Configuration).
+
 ## 🧹 Lint/format Debt in Legacy Scripts (MEDIUM PRIORITY)
 
 The generated meta tests (`tests/scaffold/build-meta-tests`) surface

--- a/TODO.md
+++ b/TODO.md
@@ -501,31 +501,46 @@ after every `Edit` or `Write` on a shell file.
 **Key Rule:** CI/CD Phase N requires Pre-commit Phase N completed first.
 Pre-commit can progress independently. CI/CD cannot lead pre-commit.
 
-### Phase 1: Core Hooks (NEXT PRIORITY)
-- [ ] Create `.pre-commit-config.yaml` with core hooks:
-  - [ ] shellcheck (bash script linting)
-  - [ ] shfmt (shell formatting check, not fix)
-  - [ ] yamllint (YAML syntax)
-  - [ ] markdownlint (Markdown formatting)
-  - [ ] trailing-whitespace
-  - [ ] end-of-file-fixer (check mode)
-  - [ ] check-yaml
-  - [ ] check-json
-  - [ ] check-merge-conflict
-  - [ ] check-added-large-files
-- [ ] Create `.pre-commit-config-fix.yaml` with auto-fix hooks:
-  - [ ] shfmt -w (write mode)
-  - [ ] prettier (formatting)
-  - [ ] end-of-file-fixer (fix mode)
-  - [ ] trailing-whitespace (fix mode)
-- [ ] Test pre-commit configuration with sample files
-- [ ] Document pre-commit usage in README.md
+### Phase 1: Core Hooks (DONE — except the rule Agent-Behavior pass below)
+- [x] Create `.pre-commit-config.yaml` with core hooks (all remote, pinned):
+  - [x] shellcheck (`--external-sources`)
+  - [x] shfmt (`-d`, check-only; flags per shfmt.md/.editorconfig)
+  - [x] yamllint (`-c config/yamllint/config`)
+  - [x] markdownlint (`--config dot-general/.markdownlintrc`)
+  - [x] check-yaml, check-json, check-merge-conflict, check-added-large-files
+  - trailing-whitespace / end-of-file-fixer: **moved to the fix config** —
+    those hooks can only modify, which violates the check config's
+    non-modifying contract (`.claude/rules/pre-commit.md`).
+- [x] Create `.pre-commit-config-fix.yaml` with auto-fix hooks:
+  - [x] trailing-whitespace, end-of-file-fixer
+  - [x] shfmt `-w` (write mode)
+  - [x] prettier (excludes md/yaml — owned by markdownlint/yamllint)
+- [x] Test pre-commit configuration with sample files (check + fix; clean
+  files pass and are left unmodified; revs confirmed current via autoupdate)
+- [x] Document pre-commit usage in README.md (+ full command reference —
+  `install` variants, `autoupdate`, `validate-config`, `gc` — in
+  `.claude/rules/pre-commit.md`)
 - [ ] Update all `config/claude/rules/*.md` Agent Behavior sections to
   prioritize pre-commit over direct tool invocation:
   - Normal ops: `pre-commit run --files <file>` instead of `shfmt`/`shellcheck`/etc.
   - Fix ops: `pre-commit run --config .pre-commit-config-fix.yaml --files <file>`
   - Direct tool invocation becomes the fallback when pre-commit is not
     configured or the file is not covered by any hook
+- [ ] **Wire pre-commit into CI** (allowed now Phase 1 is done): a check-only
+  job running `pre-commit run --all-files` — but only after the legacy
+  lint/format debt is cleared, or scoped to changed files, so it doesn't fail
+  on pre-existing debt.
+
+### Proposed: pre-commit skill, used by qa-check
+- [ ] Evaluate a `pre-commit` **skill** packaging the operational workflow
+  (fix → check → commit prep; `install` variants; `autoupdate` on suspected
+  drift; `validate-config`; `gc`) now documented in
+  `.claude/rules/pre-commit.md`. The rule is policy/reference; a skill is the
+  forcing function that runs it (cf. qa-check).
+- [ ] Have **qa-check** delegate its Format + Lint stages to pre-commit when
+  `.pre-commit-config.yaml` is present (run the fix config, then the check
+  config) instead of invoking shfmt/shellcheck/etc. directly; fall back to
+  direct invocation when pre-commit is not configured.
 
 ### Phase 2: Security Hooks
 - [ ] Add security checks to `.pre-commit-config.yaml`:

--- a/config/claude/rules/pre-commit.md
+++ b/config/claude/rules/pre-commit.md
@@ -6,7 +6,7 @@ paths:
 
 # pre-commit Agent Contract
 
-**Version:** v1.2.0
+**Version:** v1.3.0
 
 This document defines **normative agent behavior** for interacting with
 **pre-commit** in this repository.
@@ -101,6 +101,59 @@ which <command>
 If the command is not installed, note the missing dependency in a
 comment on the hook or add `stages: [manual]` so a missing binary
 does not break `git commit` for other contributors.
+
+## Setup and Maintenance Commands
+
+A config file does nothing on its own. Until the git hook is installed,
+hooks run only when invoked manually (`pre-commit run`). Pick the right
+setup command:
+
+| Command | What it does | When to use |
+|---------|--------------|-------------|
+| `pre-commit install` | Installs the `.git/hooks/pre-commit` git hook so the check config runs on every `git commit`. Hook environments build lazily on first run. | The normal one-time setup per clone. **Without this (or a manual `pre-commit run`) the config is inert.** |
+| `pre-commit install --install-hooks` | The above **plus** eagerly builds all hook environments now rather than on the first commit. | When the first commit should be fast, or to surface install/build errors immediately — e.g. in an onboarding/setup script. |
+| `pre-commit install-hooks` | Builds the hook environments **without** installing the git hook. | Pre-warming environments (CI caches, before going offline) when commits should **not** be gated, or the git hook is installed separately. |
+
+Notes:
+
+- The git hook from `pre-commit install` uses **`.pre-commit-config.yaml`**
+  only. A repo's fix config (e.g. `.pre-commit-config-fix.yaml`) is never a
+  git hook — run it manually with `--config` (see the fix workflow below).
+- `pre-commit run --all-files` / `--files <f>` work without `install`; use
+  them for ad-hoc checks and in CI.
+
+### autoupdate — keep revs current
+
+Hook `rev:`s are pinned. When drift is suspected (a hook is stale, or a newer
+tool release is needed), bump with autoupdate — **once per config file**,
+since a repo may have more than one:
+
+```bash
+pre-commit autoupdate                                       # .pre-commit-config.yaml
+pre-commit autoupdate --config .pre-commit-config-fix.yaml  # fix config
+```
+
+Review the rev changes, then re-run the hooks to confirm nothing broke. Per
+*Hook and Repo Verification*, never hand-edit a rev to a guessed value — let
+autoupdate resolve it, or verify via `gh`.
+
+### validate-config — after editing a config
+
+After creating or editing a config, validate its schema before relying on it:
+
+```bash
+pre-commit validate-config .pre-commit-config.yaml
+pre-commit validate-config .pre-commit-config-fix.yaml
+```
+
+### gc — reclaim cached environments
+
+autoupdate and rev changes leave old, unused hook environments in the
+pre-commit cache. Reclaim that space periodically:
+
+```bash
+pre-commit gc
+```
 
 ## Agent Rules
 


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` (check-only gate) and
  `.pre-commit-config-fix.yaml` (manual auto-fixers) — no pre-commit config
  existed before. **All hooks remote + pinned**, verified current via
  `pre-commit autoupdate`; pointed at the repo's existing configs
  (`config/yamllint/config`, `dot-general/.markdownlintrc`, `.editorconfig`).
- Check: check-merge-conflict, check-added-large-files, check-yaml,
  check-json, shellcheck, shfmt `-d`, yamllint, markdownlint.
  Fix: trailing-whitespace, end-of-file-fixer, shfmt `-w`, prettier
  (md/yaml excluded). `archive/` excluded.
- `trailing-whitespace`/`end-of-file-fixer` are in the **fix** config only —
  they can only modify, which would violate the check config's non-modifying
  contract (`.claude/rules/pre-commit.md`).
- Docs: `.claude/rules/pre-commit.md` (v1.3.0) gains a Setup & Maintenance
  Commands section (`install` variants, `autoupdate`, `validate-config`,
  `gc`); README gets a usage section; TODO Phase 1 marked done and a
  pre-commit-skill + qa-check integration proposal queued.

## Test plan
- [x] `pre-commit validate-config` on both
- [x] `pre-commit autoupdate` on both — all revs already current
- [x] check config runs clean on sample files (shellcheck/shfmt/yamllint/
      markdownlint/builtins)
- [x] fix config runs clean and leaves clean files unmodified
- [ ] CI green

## Notes
- `pre-commit install` is a per-clone local action (not committed); run it to
  activate the git hook. Documented in README + the rule.
- `pre-commit run --all-files` surfaces **pre-existing** markdownlint debt in
  `TODO.md` (deferred/research sections, lines ~837–922: bare URLs, blank-line
  spacing) and the tracked shell lint/format debt — left as-is here (out of
  scope); happy to clean the TODO.md markdownlint debt in a follow-up.