### PR TITLE
Enforce + document master branch protection

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -147,6 +147,9 @@ advisory — the remote enforces it:
 * Deletion and force-push of `master` are blocked; unresolved review threads
   block merge; stale reviews are dismissed on push.
 * No bypass actors — even the owner goes through a PR.
+* A local `no-commit-to-branch` pre-commit hook also blocks a direct commit
+  to `master` at commit time (early guard; the server ruleset is what
+  actually enforces it). See `config/claude/rules/git.md`.
 
 To change the ruleset, edit the JSON and re-apply with the OAuth token (the
 narrow PAT lacks admin):

--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -134,6 +134,28 @@ in the pre-commit configuration.
 * Tests must pass
 * At least one review for significant changes
 
+**Enforced branch protection (`master`):**
+
+`master` is protected by a GitHub ruleset (`protect-master-solo.json` in
+`../private_dotfiles/github-rulesets/`, enforcement active). It is **not**
+advisory — the remote enforces it:
+
+* **Direct pushes to `master` are rejected** — all changes land via PR.
+* **Squash is the only allowed merge method.**
+* **`bats` must be green** to merge (required status check). `perl` is
+  non-gating; add the pre-commit CI check to the required set when it lands.
+* Deletion and force-push of `master` are blocked; unresolved review threads
+  block merge; stale reviews are dismissed on push.
+* No bypass actors — even the owner goes through a PR.
+
+To change the ruleset, edit the JSON and re-apply with the OAuth token (the
+narrow PAT lacks admin):
+
+```bash
+GH_TOKEN= GITHUB_TOKEN= gh api repos/harleypig/dotfiles/rulesets/17364459 \
+  --method PUT --input ../private_dotfiles/github-rulesets/protect-master-solo.json
+```
+
 ## Tool Setup Procedures
 
 ### Prerequisites

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,10 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      # Block direct commits to master locally — the server ruleset rejects
+      # the push, this catches it earlier, at commit time (see git.md).
+      - id: no-commit-to-branch
+        args: [--branch, master]
       - id: check-merge-conflict
       - id: check-added-large-files
       - id: check-yaml

--- a/TODO.md
+++ b/TODO.md
@@ -52,33 +52,40 @@ Pinned `dulwich >= 1.2.5` (PR #10); both high-severity advisories
 the triage habit: `gh api repos/harleypig/dotfiles/dependabot/alerts -f
 state=open` (see `gh.md` *Issues & triage*).
 
-## 🛡️ Protect the master Branch (HIGH PRIORITY)
+## 🛡️ Protect the master Branch (DONE 2026-06-07)
 
-We've started behaving as if `master` is protected (changes land via PR with
-green checks — e.g. PRs #9–#11); now enforce it on GitHub using the prepared
-**rulesets** in `../private_dotfiles/github-rulesets/` (sibling repo), per its
-README.
+Enforced on GitHub via the `protect-master-solo.json` ruleset (id 17364459,
+enforcement active): PR required, squash-only merge, stale-review dismissal,
+required thread resolution, deletion + force-push blocked, `bats` required
+green; `current_user_can_bypass: never`.
 
-- [ ] Use `protect-master-solo.json` (this is a solo repo: 0 required reviews,
-  squash-only merges, stale-review dismissal, required thread resolution,
-  deletion + force-push blocked, PR required, status checks required).
-  `protect-master-team.json` is the variant if this ever becomes a team repo.
-- [ ] Fix the required-check contexts before importing — the file ships
-  placeholders (`Build`, `Pre-commit checks`) that don't match this repo. Set
-  them to our real checks: `bats` at minimum, optionally `CodeFactor` and
-  `security/snyk`.
-- [ ] Import via the rulesets API with an admin/OAuth token (the narrow PAT
-  can't — `Resource not accessible by personal access token`):
+- [x] Applied `protect-master-solo.json` (solo: 0 reviews, squash-only,
+  stale-review dismissal, thread resolution, deletion + force-push blocked).
+  `protect-master-team.json` remains the variant if this becomes a team repo.
+- [x] Fixed the required-check context to the repo's real check (`bats`);
+  removed the `Build` / `Pre-commit checks` placeholders. Add the pre-commit
+  CI check to the required set once it lands (see Pre-commit → CI).
+- [x] Imported via the rulesets API with the OAuth token (the narrow PAT
+  can't).
+- [x] Verified: ruleset active on `master`; direct pushes are rejected and a
+  PR needs `bats` green to merge.
+- [x] Documented the enforced workflow in `WORKFLOW.md`.
+- [ ] Confirm Dependabot / auto-merge interplay once a Dependabot PR appears
+  (squash-only + required `bats` — ensure auto-merge still completes).
 
-  ```bash
-  GH_TOKEN= GITHUB_TOKEN= gh api repos/harleypig/dotfiles/rulesets \
-    --method POST --input protect-master-solo.json
-  ```
+## 🧭 Explore other GitHub rulesets (LOW PRIORITY)
 
-- [ ] Verify: a direct push to `master` is rejected, and a PR needs green
-  checks to merge.
-- [ ] Confirm Dependabot / auto-merge interplay once the ruleset is active.
-- [ ] Document the enforced workflow in `WORKFLOW.md`.
+We use a single branch ruleset (protect master). Survey what else rulesets
+offer and whether any help this repo:
+
+- [ ] Review the available rule types — **tag** rulesets (protect release
+  tags from deletion/force-push), **push** rulesets (block large files or
+  secrets at push time), required linear history, required deployments /
+  code-scanning results, commit-metadata patterns (e.g. enforce Conventional
+  Commits subjects), restricted file-path changes, required workflows.
+- [ ] Decide which add value here (likely candidates: a tag ruleset for
+  release tags; a commit-message pattern enforcing Conventional Commits) and
+  capture their configs in `../private_dotfiles/github-rulesets/`.
 
 ## ✅ Evaluate / Clean Up Stale Branches (DONE 2026-06-07)
 

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.2.0
+**Version:** v1.3.0
 
 ## Commit Messages
 
@@ -54,6 +54,29 @@ git symbolic-ref "refs/remotes/origin/HEAD" | sed 's@^refs/remotes/origin/@@'
 
 If unset, query via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
 and then `git remote set-head origin <branch>` to cache it.
+
+## Protecting the Default Branch
+
+When a repo's default branch should be PR-only, protect it in **two layers**
+— the server enforces it, the local hook catches mistakes earlier:
+
+1. **Server-side ruleset / branch protection** (authoritative): require PRs,
+   required status checks, and block deletion + force-push. This is what
+   actually rejects a direct push. Apply it via the host's API (GitHub
+   rulesets need an admin/OAuth token, not a narrow PAT).
+2. **Local `no-commit-to-branch` pre-commit hook** (early guard): add the
+   `no-commit-to-branch` hook (from `pre-commit/pre-commit-hooks`) to the
+   check config so a direct commit on the protected branch fails *before* the
+   push is even attempted:
+
+   ```yaml
+   - id: no-commit-to-branch
+     args: [--branch, <default-branch>]
+   ```
+
+The local hook is a convenience, not a substitute — without the server-side
+ruleset, anyone (or any tool) without the hook installed can still push. The
+repo's concrete ruleset/config lives in its `.claude/` docs.
 
 ## Worktrees
 


### PR DESCRIPTION
## Summary
- Applied the `protect-master-solo.json` ruleset (id **17364459**, enforcement
  active) to `master`: PR-only, squash-only merge, **`bats` required green**,
  deletion/force-push blocked, stale-review dismissal, thread resolution, no
  bypass actors (`current_user_can_bypass: never`).
- Fixed the ruleset's required-check context (placeholders `Build` /
  `Pre-commit checks` → real `bats`) in `private_dotfiles` and imported via the
  OAuth token.
- Documented the enforced workflow in `.claude/WORKFLOW.md`; marked the TODO
  done; added a low-priority task to survey other GitHub ruleset types.

## Test plan
- [x] `gh api .../rulesets` shows the ruleset active on `master`
- [x] `gh api .../rules/branches/master` lists deletion, non_fast_forward,
      pull_request, required_status_checks
- [x] markdownlint clean on the doc changes
- [ ] CI green (this PR exercises the new PR-required + bats-required flow)

## Note
This is item 1 of 4 (each on its own branch). Dependabot/auto-merge interplay
is left as an open follow-up to confirm when a Dependabot PR next appears.