### PR TITLE
pre-commit CI job + Phase 2 secret hooks

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -142,8 +142,8 @@ advisory — the remote enforces it:
 
 * **Direct pushes to `master` are rejected** — all changes land via PR.
 * **Squash is the only allowed merge method.**
-* **`bats` must be green** to merge (required status check). `perl` is
-  non-gating; add the pre-commit CI check to the required set when it lands.
+* **`bats` and `pre-commit` must be green** to merge (required status
+  checks). `perl` is non-gating.
 * Deletion and force-push of `master` are blocked; unresolved review threads
   block merge; stale reviews are dismissed on push.
 * No bypass actors — even the owner goes through a PR.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ name: tests
 #   - perl:   prove over tests/perl/ — non-gating for now (Perl::Tidy version
 #             drift; see TODO), promote once version-robust
 #   - python: pytest over tests/python/ (activates once tests exist)
+#   - pre-commit: the check config (lint/format/secret hooks) via
+#                 `pre-commit run --all-files`
 # The generated meta suite is not run here yet (it surfaces pre-existing
 # legacy lint/format + dependency debt — see TODO.md "Lint/format Debt in
 # Legacy Scripts").
@@ -81,3 +83,24 @@ jobs:
           else
             echo "no python tests yet — skipping"
           fi
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      # no-commit-to-branch is a local-only guard; skip it in CI (the run on
+      # master would otherwise fail merely for being on master). The gitleaks
+      # hook is a no-op here (it scans staged content); full secret scanning
+      # is the security-scan skill's job.
+      - name: Run pre-commit (check config)
+        run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,8 @@ repos:
       # check-json cannot parse; exclude them.
       - id: check-json
         exclude: '^\.vscode/'
+      # Secret detection (Phase 2): catch committed private keys.
+      - id: detect-private-key
 
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
@@ -59,3 +61,12 @@ repos:
     hooks:
       # Uses the repo-local .markdownlint.json (auto-discovered at the root).
       - id: markdownlint
+
+  # Secret detection (Phase 2). The gitleaks hook scans staged content at
+  # commit time — an effective local guard, but a no-op in CI's --all-files
+  # run (nothing is staged there). Full-repo/history secret scanning is the
+  # security-scan skill's job, not this hook.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/TODO.md
+++ b/TODO.md
@@ -611,10 +611,12 @@ Pre-commit can progress independently. CI/CD cannot lead pre-commit.
   - Fix ops: `pre-commit run --config .pre-commit-config-fix.yaml --files <file>`
   - Direct tool invocation becomes the fallback when pre-commit is not
     configured or the file is not covered by any hook
-- [ ] **Wire pre-commit into CI** (allowed now Phase 1 is done): a check-only
-  job running `pre-commit run --all-files` — but only after the legacy
-  lint/format debt is cleared, or scoped to changed files, so it doesn't fail
-  on pre-existing debt.
+- [x] **Wire pre-commit into CI** — `tests.yml` has a `pre-commit` job running
+  `pre-commit run --all-files` (the legacy debt is cleared, so it's clean).
+  `no-commit-to-branch` is skipped in CI (`SKIP=...`) since it would fail on
+  the master-push run.
+- [ ] Make the CI `pre-commit` check a **required status check** in the master
+  ruleset once it's confirmed green (add `{"context": "pre-commit"}`).
 
 ### Proposed: pre-commit skill, used by qa-check
 
@@ -628,13 +630,14 @@ Pre-commit can progress independently. CI/CD cannot lead pre-commit.
   config) instead of invoking shfmt/shellcheck/etc. directly; fall back to
   direct invocation when pre-commit is not configured.
 
-### Phase 2: Security Hooks
+### Phase 2: Security Hooks (DONE)
 
-- [ ] Add security checks to `.pre-commit-config.yaml`:
-  - [ ] gitleaks (secret detection)
-  - [ ] detect-private-key
-- [ ] Test security hooks on repository
-- [ ] Update documentation
+- [x] Add security checks to `.pre-commit-config.yaml`:
+  - [x] gitleaks (secret detection — scans staged content at commit time)
+  - [x] detect-private-key
+- [x] Test security hooks on repository (both pass `--all-files`)
+- Note: gitleaks here is a commit-time guard; full-repo/history secret
+  scanning remains the **security-scan** skill's job (separate from this hook).
 
 ### Phase 3: Language-Specific Hooks
 

--- a/TODO.md
+++ b/TODO.md
@@ -615,8 +615,8 @@ Pre-commit can progress independently. CI/CD cannot lead pre-commit.
   `pre-commit run --all-files` (the legacy debt is cleared, so it's clean).
   `no-commit-to-branch` is skipped in CI (`SKIP=...`) since it would fail on
   the master-push run.
-- [ ] Make the CI `pre-commit` check a **required status check** in the master
-  ruleset once it's confirmed green (add `{"context": "pre-commit"}`).
+- [x] Made the CI `pre-commit` check a **required status check** in the master
+  ruleset (ruleset 17364459 now requires `bats` + `pre-commit`).
 
 ### Proposed: pre-commit skill, used by qa-check
 

--- a/config/claude/rules/pre-commit.md
+++ b/config/claude/rules/pre-commit.md
@@ -6,7 +6,7 @@ paths:
 
 # pre-commit Agent Contract
 
-**Version:** v1.3.0
+**Version:** v1.4.0
 
 This document defines **normative agent behavior** for interacting with
 **pre-commit** in this repository.
@@ -101,6 +101,49 @@ which <command>
 If the command is not installed, note the missing dependency in a
 comment on the hook or add `stages: [manual]` so a missing binary
 does not break `git commit` for other contributors.
+
+## Recommended Cross-Cutting Hooks
+
+Beyond the obvious language/file-type linters (shellcheck, shfmt, yamllint,
+markdownlint, a JS/TS linter, …), pre-commit offers **cross-cutting** hooks
+that are easy to forget but cheap to add and catch whole classes of mistakes
+independent of language. **Consider** these for any repo (don't add all of
+them — pick what fits; verify repo/rev/hook-id per *Hook and Repo
+Verification* first):
+
+### Secrets / safety
+
+- `gitleaks` (`gitleaks/gitleaks`) — scan **staged** content for secrets at
+  commit time. (Full repo/history scanning is the **security-scan** skill's
+  job, not this hook.)
+- `detect-private-key` — block committed private keys.
+- `detect-aws-credentials` — block AWS keys (when AWS is in play).
+
+### Git hygiene / safety (from `pre-commit/pre-commit-hooks`)
+
+- `no-commit-to-branch` — block direct commits to a protected branch (pair
+  with server-side branch protection; see `git.md`).
+- `check-added-large-files` — stop accidental large blobs entering history.
+- `check-merge-conflict` — catch leftover `<<<<<<<` conflict markers.
+- `check-case-conflict` — names that collide on case-insensitive filesystems
+  (macOS/Windows).
+- `check-symlinks` / `destroyed-symlinks` — broken symlinks, and symlinks
+  accidentally turned into regular files.
+- `mixed-line-ending` — CRLF/LF mixups.
+
+### Exec-bit / shebang consistency
+
+- `check-executables-have-shebangs` — executables must have a shebang.
+- `check-shebang-scripts-are-executable` — shebang'd scripts must be `+x`.
+
+### Whitespace / encoding (fixers — for the fix config)
+
+- `trailing-whitespace`, `end-of-file-fixer`, `fix-byte-order-marker`.
+
+The point is to *consider* the list, not adopt it wholesale: a repo that uses
+submodules wouldn't add `forbid-new-submodules`; a repo with no AWS skips
+`detect-aws-credentials`. The **qa-check** skill audits a repo's config
+against this list and flags applicable hooks that are missing.
 
 ## Setup and Maintenance Commands
 

--- a/config/claude/skills/qa-check/SKILL.md
+++ b/config/claude/skills/qa-check/SKILL.md
@@ -53,6 +53,11 @@ Only the qa-check-specific operational notes (the rest is in `qa.md`):
 
 - **Format** is the one auto-fix stage — run it once (the fix config), then
   the check-only pass; never fix-and-recommit per failure.
+- **Pre-commit hook coverage** — when the repo uses pre-commit, audit its
+  config against the *Recommended Cross-Cutting Hooks* in `pre-commit.md`
+  (secret detection, large-file / merge-conflict / case-conflict guards,
+  exec-bit ↔ shebang consistency, …) and flag any that are missing but would
+  fit the repo — the easy-to-forget, language-agnostic ones.
 - **Code style audit** — beyond what Format/Lint catch, audit the change
   against `code-style.md` (plus any repo override in `.claude/`) for the
   conventions no tool enforces: naming, paragraph spacing, section/function


### PR DESCRIPTION
## Summary
- **Pre-commit Phase 2 (security)**: add `gitleaks` (commit-time secret scan)
  and `detect-private-key` to `.pre-commit-config.yaml`; both pass
  `--all-files`.
- **pre-commit → CI**: new `pre-commit` job in `tests.yml` runs
  `pre-commit run --all-files` (the lint debt is cleared, so it's green).
  `no-commit-to-branch` is skipped in CI (`SKIP=...`) — it would otherwise
  fail on the master-push run merely for being on master.

gitleaks here is a local commit-time guard (scans staged content); full
repo/history secret scanning stays with the security-scan skill.

## Test plan
- [x] `pre-commit run gitleaks --all-files` / `detect-private-key` — pass
- [x] config validates; yamllint clean on `tests.yml`
- [ ] CI green incl. the new `pre-commit` job

Item 2 of 4. Follow-up: promote the `pre-commit` CI check to a required
status check in the master ruleset once it's confirmed green.