### PR TITLE
shell-startup: double-source guard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -115,13 +115,11 @@ findings. Research how to actually use each and whether to formalize it.
 
 ## 🔁 shell-startup: Double-load Guard + Interactive Guards (MEDIUM PRIORITY)
 
-- [ ] **Idempotency guard.** `.bash_profile` and `.bashrc` both symlink to
-  `shell-startup`, so a login that also starts an interactive shell (ssh
-  login, a new tmux window) runs `shell-startup` twice — re-prepending PATH
-  (duplicate entries), re-sourcing every module, etc. Add an "already loaded"
-  guard near the top that bails when a sentinel (e.g. `SHELL_STARTUP_LOADED`)
-  is set, and set it once loaded. Decide whether a re-source should ever be
-  forced (e.g. `SHELL_STARTUP_LOADED=` to reload).
+- [x] **Idempotency guard.** Added a non-exported `_DOTFILES_STARTUP_DONE`
+  sentinel near the top of `shell-startup` that `return`s early on a second
+  source in the same shell (child shells, not inheriting it, still run their
+  own startup). Covered by `tests/shell/test_shell_startup_guard.bats`.
+  (To force a reload: `unset _DOTFILES_STARTUP_DONE` then re-source.)
 - [ ] **Interactive vs non-interactive guards.** Modules in
   `config/shell-startup/` define things that only make sense in an interactive
   shell (aliases, prompt, completions) — and aliases aren't even expanded in
@@ -312,6 +310,23 @@ into CI as a gate (today CI gates only the hand-written `tests/shell/test_*`).
   cleanpath task.
 - [ ] Once a script is clean, confirm its `<dir>-<name>.meta.bats` passes;
   when all pass, add the meta suite to CI and run it in pre-commit.
+
+## 🧹 pre-commit doesn't lint extensionless shell files (MEDIUM PRIORITY)
+
+The shfmt and shellcheck pre-commit hooks (`types: [shell]`) **skip
+`shell-startup`** and likely the extensionless `config/shell-startup/*`
+modules — pre-commit's `identify` isn't tagging them as shell, so they get
+no lint/format gating (and the meta generator only scans `bin lib`).
+`shell-startup` in fact has pre-existing shfmt debt that nothing currently
+catches.
+
+- [ ] Make the shfmt + shellcheck hooks cover extensionless shell files —
+  add `files:` patterns (e.g. `^(shell-startup|config/shell-startup/)`) or
+  `types_or: [shell, file]`, and confirm via `pre-commit run --files
+  shell-startup`.
+- [ ] Then clean up the shfmt debt those files surface.
+- [ ] Consider adding `shell-startup` + `config/shell-startup` to the
+  meta-test generator roots too.
 
 ## 🐪 perl CI: make perltidyrc-clean tests version-robust (MEDIUM PRIORITY)
 
@@ -748,8 +763,10 @@ contexts that need different behavior:
 
 Problems to solve:
 
-- [ ] Guard against double-sourcing — detect if shell-startup has already
-  run and skip (or only run the parts appropriate to context)
+- [x] Guard against double-sourcing — done: non-exported
+  `_DOTFILES_STARTUP_DONE` sentinel returns early on a second source in the
+  same shell (`tests/shell/test_shell_startup_guard.bats`). The
+  context-appropriate partial-run is the remaining context work below.
 - [ ] Detect shell context (`$-` contains `i` for interactive; login shells
   set by checking `shopt login_shell` or `$0` prefix `-`)
 - [ ] Skip alias/function/prompt setup for non-interactive shells

--- a/shell-startup
+++ b/shell-startup
@@ -7,6 +7,16 @@
 # ssh localhost "PS4='[\$BASH_SOURCE[0]:\$LINENO]: ' bash -xl" |& tee login.log
 
 #-----------------------------------------------------------------------------
+# Guard against double-sourcing within a single shell. Both ~/.bash_profile
+# and ~/.bashrc are symlinked to this file, so a shell that reads both would
+# otherwise run startup twice (re-prepending PATH, re-sourcing modules). The
+# flag is deliberately NOT exported, so child shells still run their own
+# startup.
+
+[[ -n ${_DOTFILES_STARTUP_DONE-} ]] && return 0
+_DOTFILES_STARTUP_DONE=1
+
+#-----------------------------------------------------------------------------
 # Use these functions to clean up the environment at end of startup.
 #
 # Add any various variables or functions that you want to unset to the

--- a/tests/shell/test_shell_startup_guard.bats
+++ b/tests/shell/test_shell_startup_guard.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# Tests shell-startup's double-source guard. Both ~/.bash_profile and
+# ~/.bashrc are symlinked to shell-startup, so a shell that reads both would
+# run startup twice. A non-exported _DOTFILES_STARTUP_DONE flag makes a second
+# source in the same shell a no-op (child shells, not inheriting the flag,
+# still run their own startup).
+#
+# Tested hermetically: extract just the guard lines and source those (no full
+# orchestrator run), so the test is fast and CI-portable.
+
+load ../helpers/common
+
+# The guard lines from shell-startup (both mention _DOTFILES_STARTUP_DONE).
+extract_guard() {
+  awk '/_DOTFILES_STARTUP_DONE/ { print }' "$(dotfiles_root)/shell-startup"
+}
+
+setup() {
+  load_bats_libs
+  setup_temp_dir
+  unset _DOTFILES_STARTUP_DONE
+}
+
+teardown() {
+  cleanup_temp_dir
+}
+
+@test "shell-startup defines the double-source guard" {
+  run extract_guard
+  assert_success
+  assert_output --partial '_DOTFILES_STARTUP_DONE'
+  assert_line --index 0 --partial 'return 0'
+}
+
+@test "a second source is a no-op in the same shell (guard short-circuits)" {
+  local probe="$TEST_TEMP_DIR/probe"
+  {
+    extract_guard
+    printf 'echo ran >> %q\n' "$TEST_TEMP_DIR/marker"
+  } > "$probe"
+
+  # shellcheck disable=SC1090  # probe path is built at runtime
+  source "$probe"
+  # shellcheck disable=SC1090
+  source "$probe"
+
+  assert_equal "$(wc -l < "$TEST_TEMP_DIR/marker")" 1
+}
+
+@test "the guard flag is not exported (child shells run their own startup)" {
+  _DOTFILES_STARTUP_DONE=1
+  run bash -c 'echo "${_DOTFILES_STARTUP_DONE-unset}"'
+  assert_output 'unset'
+}


### PR DESCRIPTION
## Summary
- Add a **double-source guard** to `shell-startup`: a non-exported
  `_DOTFILES_STARTUP_DONE` sentinel returns early on a second source in the
  same shell. Both `~/.bash_profile` and `~/.bashrc` symlink to shell-startup,
  so a shell reading both was running startup twice (re-prepending PATH,
  re-sourcing modules). Child shells don't inherit the flag, so they still run
  their own startup.
- `tests/shell/test_shell_startup_guard.bats` covers it hermetically
  (extracts just the guard lines; no full-orchestrator run, so CI-portable).
- Verified manually: sourcing shell-startup twice leaves PATH unchanged on the
  2nd source.

## Scope (item 3 of 4)
This is the safe, high-value **core** of "shell-startup context detection".
The broader pieces — interactive vs non-interactive guards, per-module
context tagging, and the 5-context **Docker integration-test matrix** — are
larger and riskier (they touch the login path) and remain tracked in TODO.

## Also flagged (new TODO)
pre-commit's shfmt/shellcheck hooks **skip extensionless shell files**
(`shell-startup`, `config/shell-startup/*`) — `identify` doesn't tag them as
shell, so they're not lint-gated (shell-startup has pre-existing shfmt debt
nothing catches). Tracked separately.

## Test plan
- [x] `bats tests/shell/test_shell_startup_guard.bats` — 3 pass
- [x] full `bats tests/shell/test_*.bats` green (49)
- [x] shellcheck clean on the test; guard verified manually
- [ ] CI green (bats + pre-commit required)