### PR TITLE
Testing Phase 3: yesno + git-status tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -447,17 +447,27 @@ working tree — evaluate carefully before implementing.
   - [ ] Test PATH building
   - [ ] Test module loading without errors
 - [ ] Add tests for critical bin/ scripts
-  - [ ] cleanpath (unit tests)
-  - [ ] yesno (unit tests)
-  - [ ] git-status (integration tests)
-  - [ ] check-dotfiles (integration tests)
+  - [x] cleanpath (unit tests) — `tests/shell/test_cleanpath.bats`
+  - [x] yesno (unit tests) — `tests/shell/test_yesno.bats`
+  - [x] git-status (integration tests) — `tests/shell/test_git_status.bats`
+        (skips the prompt assertion if system `git-prompt.sh` is absent)
+  - [ ] check-dotfiles (integration tests) — deferred: it has side effects
+        (`ln -fs` into `$HOME`) so it needs a sandboxed `HOME`/`DOTFILES`;
+        also has a latent bug (`check_dotfiles` links `$DOTFILES/shell_startup`
+        with an underscore, but the file is `shell-startup`) — fix while
+        adding the test.
 - [ ] Add tests for lib/ libraries
   - [ ] debug — complex; its own task
   - [ ] parse_params — complex (657 L); its own task. Evaluate rewriting
         in perl (much simpler than the bash version); note it's currently a
         sourced lib that sets caller variables, so a perl version would need
         to emit eval-able shell (getopt-style) for the caller to `eval`.
-        Write tests for whichever form it ends up as.
+        Write tests for whichever form it ends up as. **Also consider
+        converting `bin/cleanpath` to perl** (same kind of text munging).
+        Constraint: a perl rewrite of either must use **only core modules
+        shipped with perl** — no CPAN dependencies (keeps them runnable
+        anywhere perl is, and avoids the Perl::Tidy/XML::LibXML kind of
+        install gap; see perl CI notes).
   - (`is`, `Arrays`, `strings` archived to `archive/lib/` — legacy/unused,
     not tested; `git-prompt` factored into `bin/git-status`)
 - [ ] Add tests for config/shell-startup/ modules

--- a/tests/shell/test_git_status.bats
+++ b/tests/shell/test_git_status.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Tests for bin/git-status — renders a colored git prompt fragment
+# ("(repo: branch …)") via __git_ps1. It needs the system git-prompt.sh
+# (which provides __git_ps1); when that isn't installed it prints nothing, so
+# those assertions skip rather than fail.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  setup_temp_dir
+
+  repo="$TEST_TEMP_DIR/myrepo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" -c user.email=t@example.com -c user.name=t \
+    commit -q --allow-empty -m init
+}
+
+teardown() {
+  cleanup_temp_dir
+}
+
+# Run git-status inside the temp repo with the repo's bin/ on PATH (so it
+# finds `ansi` and git-status itself).
+run_git_status() {
+  run bash -c 'cd "$1" && PATH="$2/bin:$PATH" git-status' _ \
+    "$repo" "$(dotfiles_root)"
+}
+
+@test "git-status outside a git repo prints nothing and succeeds" {
+  run bash -c 'cd "$1" && PATH="$2/bin:$PATH" git-status' _ \
+    "$TEST_TEMP_DIR" "$(dotfiles_root)"
+  assert_success
+  assert_output ''
+}
+
+@test "git-status names the repository inside a git repo" {
+  run_git_status
+  assert_success
+  [[ -z $output ]] && skip "git-prompt.sh (__git_ps1) not available"
+  assert_output --partial 'myrepo'
+}
+
+@test "git-status marks a bare repository" {
+  local bare="$TEST_TEMP_DIR/bare.git"
+  git init -q --bare "$bare"
+  run bash -c 'cd "$1" && PATH="$2/bin:$PATH" git-status' _ \
+    "$bare" "$(dotfiles_root)"
+  assert_success
+  assert_output --partial 'BARE'
+}

--- a/tests/shell/test_yesno.bats
+++ b/tests/shell/test_yesno.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Tests for bin/yesno — prompt for a Y/N answer, reprompting on invalid input.
+# The chosen letter is printed (uppercased) to stdout; the prompt and the
+# invalid-input warning go to stderr. Input is fed on stdin.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  cd "$(dotfiles_root)" || return 1
+}
+
+@test "yesno returns Y for 'y'" {
+  run bash -c 'printf y | bin/yesno 2> /dev/null'
+  assert_success
+  assert_output Y
+}
+
+@test "yesno returns N for 'n'" {
+  run bash -c 'printf n | bin/yesno 2> /dev/null'
+  assert_success
+  assert_output N
+}
+
+@test "yesno reprompts past invalid input" {
+  run bash -c 'printf xY | bin/yesno -q 2> /dev/null'
+  assert_success
+  assert_output Y
+}
+
+@test "yesno -h prints usage and exits 0" {
+  run bin/yesno -h
+  assert_success
+  assert_output --partial 'Usage:'
+}
+
+@test "yesno rejects an unknown option (exit 2)" {
+  run bin/yesno --bogus
+  assert_failure 2
+  assert_output --partial 'Unknown option'
+}


### PR DESCRIPTION
## Summary
Testing Phase 3 — unit/integration tests for critical `bin/` scripts:
- `tests/shell/test_yesno.bats` — Y/N return (uppercased), reprompt past
  invalid input, `-h` usage, unknown-option exit 2. Stderr is discarded in
  the subshell so there's no `run`-flag / bats-version dependency.
- `tests/shell/test_git_status.bats` — empty + success outside a repo; names
  the repo inside one (**skips** the prompt assertion when the system
  `git-prompt.sh`/`__git_ps1` is absent); marks a bare repo.

TODO: cleanpath/yesno/git-status checked off under Phase 3. `check-dotfiles`
deferred (it `ln -fs`es into `$HOME`, so it needs a sandboxed
`HOME`/`DOTFILES`, and it has a latent `shell_startup` vs `shell-startup`
bug to fix alongside its test). The parse_params task now also notes
considering a perl rewrite of `cleanpath`, with both constrained to
**core-only perl modules** (no CPAN).

## Test plan
- [x] `bats tests/shell/test_yesno.bats` (5) + `test_git_status.bats` (3)
- [x] full suite green; shellcheck clean on both
- [ ] CI green (bats + pre-commit required)