### PR TITLE
Docker integration harness: startup + check-dotfiles

### DIFF
--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-**Version:** v2.2.0
+**Version:** v2.3.0
 
 ## Purpose
 
@@ -28,9 +28,10 @@ One `tests/` root with per-language subdirs (see
 
 ```text
 tests/
-  helpers/common.bash   # shared bash/bats support (load_bats_libs, dotfiles_root, make_stub)
+  helpers/common.bash   # shared bash/bats support (load_bats_libs, dotfiles_root, make_stub, docker harness)
   scaffold/             # meta-test generator + templates (build-meta-tests)
-  shell/                # bats: *.bats hand-written, *.meta.bats generated (gitignored)
+  docker/               # integration-test harness image (Dockerfile, entrypoint)
+  shell/                # bats: *.bats hand-written, *_integration_*.bats, *.meta.bats (generated, gitignored)
   python/               # pytest: test_*.py
   perl/                 # prove: *.t
   powershell/           # Pester: *.Tests.ps1
@@ -39,6 +40,27 @@ tests/
 bats helper libs come from the Debian packages (`bats bats-support
 bats-assert bats-file`); `tests/helpers/common.bash` adds this repo's
 `lib/bats` (`bats-toolbox`) to `BATS_LIB_PATH`.
+
+## Docker integration harness
+
+Tests that must exercise the *running* dotfiles (a real login shell, or a
+script with side effects like `check-dotfiles`'s `ln -fs` into `$HOME`) use a
+throwaway container as a sandbox — a mistake there can never touch the host.
+
+- `tests/docker/` — the harness image (Debian slim + bash/git/gettext/less +
+  the `en_US.UTF-8` locale). The repo under test is mounted **read-only** at
+  `/dotfiles` at run time, so tests exercise the current checkout. The default
+  entrypoint deploys `~/.bash_profile`/`~/.bashrc` → `shell-startup` and runs a
+  login shell; tests needing a pristine `HOME` override the entrypoint.
+- `tests/helpers/common.bash` provides `dotfiles_harness_image` (builds the
+  image, cached; **skips** the test when docker is unavailable or the build
+  fails) and `dotfiles_login`.
+- `tests/shell/test_integration_*.bats` — e.g. `test_integration_startup`
+  (login shell comes up with `DOTFILES`/XDG/PATH, double-source guard,
+  cleanpath dedup) and `test_integration_check_dotfiles`.
+
+These run wherever docker exists (CI, dev) and skip otherwise, so they sit in
+the same gating suite without breaking docker-less environments.
 
 ## What must be tested here
 

--- a/TODO.md
+++ b/TODO.md
@@ -159,15 +159,19 @@ verify a login shell comes up *working*, not merely that the scripts parse.
 This catches missing-tool guards, host assumptions, bashisms, and broken
 deploy/symlink (dotlinks) steps that never show on the dev machine.
 
-- [ ] bash: in a stock image (e.g. `bash:5` / `debian:stable`) with a fresh
-  `$HOME`, deploy the dotfiles (the symlink/dotlinks step) and start a login
-  shell through the real chain (`.bash_profile` / `.bashrc` / `.profile` →
-  `shell-startup`). Assert: no errors, expected env (`PATH`, `XDG_*`,
-  `BATS_LIB_PATH`), and that key aliases/functions are actually available
-  (i.e. startup *functions*, not just sources). Wire as a bats integration
-  test (`tests/suite/test_integration_*`) driving the container.
-- [ ] Run in a minimal image (most tools absent) to exercise the `command -v`
-  guards and confirm startup still yields a working shell.
+- [x] bash: harness built (`tests/docker/`) — a slim Debian image; the repo
+  is mounted read-only at `/dotfiles`; `~/.bash_profile`/`~/.bashrc` →
+  `shell-startup`; a login shell is started through the real chain.
+  `tests/shell/test_integration_startup.bats` asserts the env comes up
+  (`DOTFILES`, `XDG_CONFIG_HOME`, bin on PATH), the double-source guard
+  holds, and cleanpath dedups PATH. Harness skips when docker is absent.
+- [x] Minimal image (most dev tools absent) — that's exactly what the slim
+  harness exercises; startup still yields a working shell (only `command -v`
+  guards / probes for absent tools, no fatal errors).
+- [ ] **Extend the context matrix** — the harness covers interactive-login
+  (`bash -lc`). Add the other contexts (interactive non-login, non-interactive
+  login/non-login, incomplete terminal) once the per-module interactive
+  guards land (see "shell-startup: Shell Context Detection").
 - [ ] PowerShell: deploy + load `ps-startup.ps1` (+ `powershell/startup/*`)
   in a PowerShell image (`mcr.microsoft.com/powershell`) and verify the
   profile comes up functioning, no errors.
@@ -451,11 +455,12 @@ working tree — evaluate carefully before implementing.
   - [x] yesno (unit tests) — `tests/shell/test_yesno.bats`
   - [x] git-status (integration tests) — `tests/shell/test_git_status.bats`
         (skips the prompt assertion if system `git-prompt.sh` is absent)
-  - [ ] check-dotfiles (integration tests) — deferred: it has side effects
-        (`ln -fs` into `$HOME`) so it needs a sandboxed `HOME`/`DOTFILES`;
-        also has a latent bug (`check_dotfiles` links `$DOTFILES/shell_startup`
-        with an underscore, but the file is `shell-startup`) — fix while
-        adding the test.
+  - [x] check-dotfiles (integration tests) —
+        `tests/shell/test_integration_check_dotfiles.bats`, run in the docker
+        harness so its `ln -fs` into `$HOME` can't touch the host. Fixed the
+        latent bug along the way (`check_dotfiles` linked
+        `$DOTFILES/shell_startup` (underscore) instead of `shell-startup`, so
+        the `.bash_profile`/`.bashrc`/`.profile` linking silently no-op'd).
 - [ ] Add tests for lib/ libraries
   - [ ] debug — complex; its own task
   - [ ] parse_params — complex (657 L); its own task. Evaluate rewriting
@@ -796,13 +801,14 @@ Problems to solve:
     — verify minimal env only, no aliases, no prompt, no errors
   - [ ] Incomplete terminal (vim-style): simulate missing `TERM`/`COLUMNS`
     — verify shell-startup degrades gracefully without errors
-  - [ ] Double-source guard: source shell-startup twice in same session
-    — verify idempotent (no duplicate PATH entries, no re-run of setup)
-  - [ ] Research: can/should BATS drive Docker-based tests? Options include
-    running BATS inside the container, or using BATS on the host to `docker
-    run` and assert on exit codes and output. Determine which approach fits
-    the existing test framework and document the decision in TESTS.md
-  - [ ] Update TESTS.md to document Docker-based integration test approach
+  - [x] Double-source guard: covered hermetically
+    (`test_shell_startup_guard`) and in the harness
+    (`test_integration_startup`) — second source leaves PATH unchanged.
+  - [x] Research: can/should BATS drive Docker-based tests? Decided: **BATS on
+    the host `docker run`s** the harness image and asserts on output/exit
+    (the `dotfiles_harness_image`/`dotfiles_login` helpers), skipping when
+    docker is absent. Documented in TESTS.md.
+  - [x] Update TESTS.md to document Docker-based integration test approach.
 
 ### bin/cleanpath: Fix and Integrate (DONE 2026-06-07)
 

--- a/bin/check-dotfiles
+++ b/bin/check-dotfiles
@@ -56,7 +56,7 @@ check_dotfiles() {
 
   #---------------------------------------------------------------------------
   for dotfile in .bash_profile .bashrc .profile; do
-    check_link "$DOTFILES/shell_startup" "$dotfile"
+    check_link "$DOTFILES/shell-startup" "$dotfile"
   done
 
   #---------------------------------------------------------------------------

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,30 @@
+# Integration-test harness for dotfiles startup.
+#
+# This image is only the *runtime* — the repo under test is mounted read-only
+# at /dotfiles at run time (so the tests exercise the current checkout, not a
+# baked-in copy). The default entrypoint deploys the minimal dotfiles entry
+# points and runs a login shell; tests that need a clean environment (e.g.
+# check-dotfiles) override the entrypoint and invoke the script directly.
+
+FROM debian:bookworm-slim
+
+# bash + the few tools shell-startup needs to come up: gettext-base provides
+# envsubst (used by bin-dirs/dotlinks), git for the prompt, locales so the
+# en_US.UTF-8 LC_ALL shell-startup sets is actually available.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       bash ca-certificates gettext-base git less locales \
+  && sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+  && locale-gen \
+  && rm -rf /var/lib/apt/lists/*
+
+# A non-root user with a writable HOME — startup (XDG dirs) and check-dotfiles
+# (ln -fs) write there.
+RUN useradd --create-home --shell /bin/bash tester
+
+COPY entrypoint.sh /usr/local/bin/dotfiles-entrypoint
+RUN chmod +x /usr/local/bin/dotfiles-entrypoint
+
+USER tester
+WORKDIR /home/tester
+ENTRYPOINT ["/usr/local/bin/dotfiles-entrypoint"]

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Default entrypoint for the dotfiles integration-test image. Deploys the
+# minimal dotfiles entry points (so a login shell loads shell-startup), then
+# runs a login shell with the arguments as its command.
+#
+# The repo under test is mounted read-only at /dotfiles. Tests that need a
+# pristine HOME (e.g. exercising check-dotfiles' own symlink creation)
+# override this entrypoint (`--entrypoint bash`) and invoke scripts directly.
+
+set -euo pipefail
+
+ln -sf /dotfiles/shell-startup "$HOME/.bash_profile"
+ln -sf /dotfiles/shell-startup "$HOME/.bashrc"
+
+exec bash -lc "$*"

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -53,3 +53,30 @@ EOF
 
   chmod +x "$dir/$name"
 }
+
+#------------------------------------------------------------------------------
+# Docker integration harness. Build (cached) the dotfiles test image and echo
+# its tag; skip the calling test when docker is unavailable or the build
+# fails. The image is the runtime only — tests mount the repo read-only at
+# /dotfiles (see tests/docker/).
+
+dotfiles_harness_image() {
+  command -v docker > /dev/null 2>&1 || skip "docker not available"
+
+  local tag=dotfiles-test:latest
+  docker build -q -t "$tag" "$(dotfiles_root)/tests/docker" > /dev/null 2>&1 \
+    || skip "could not build the dotfiles test image"
+
+  printf '%s' "$tag"
+}
+
+#------------------------------------------------------------------------------
+# Run a command in a throwaway container with the repo mounted read-only at
+# /dotfiles, inside a login shell that has the dotfiles deployed (the image's
+# default entrypoint). Sets $output/$status via bats `run`.
+#   dotfiles_login "$IMAGE" 'echo "$DOTFILES"'
+
+dotfiles_login() {
+  local image=$1 cmd=$2
+  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" "$image" "$cmd"
+}

--- a/tests/shell/test_integration_check_dotfiles.bats
+++ b/tests/shell/test_integration_check_dotfiles.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+# Integration tests for bin/check-dotfiles, run in a throwaway container so its
+# `ln -fs` into $HOME can never touch the host — the container IS the sandbox.
+# Skips when docker is unavailable.
+
+# shellcheck disable=SC2016  # $VARs run in the container's shell, not here.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  IMAGE="$(dotfiles_harness_image)"
+}
+
+# Run a command directly (bypassing the login-shell entrypoint) so check-dotfiles
+# starts from a pristine HOME. Sets $output/$status via bats `run`.
+in_container() {
+  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" --entrypoint bash \
+    "$IMAGE" -c "$1"
+}
+
+@test "check-dotfiles links the shell entry points to shell-startup" {
+  in_container '
+    export DOTFILES=/dotfiles
+    rm -f "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile"
+    /dotfiles/bin/check-dotfiles
+    for f in .bash_profile .bashrc .profile; do
+      echo "$f -> $(readlink "$HOME/$f")"
+    done
+  '
+  assert_success
+  assert_output --partial '.bash_profile -> /dotfiles/shell-startup'
+  assert_output --partial '.bashrc -> /dotfiles/shell-startup'
+  assert_output --partial '.profile -> /dotfiles/shell-startup'
+}
+
+@test "check-dotfiles reports a mismatched link without clobbering it" {
+  in_container '
+    export DOTFILES=/dotfiles
+    ln -sf /etc/hostname "$HOME/.bash_profile"
+    /dotfiles/bin/check-dotfiles
+    echo "still -> $(readlink "$HOME/.bash_profile")"
+  '
+  assert_success
+  assert_output --partial ".bash_profile is not linked to /dotfiles/shell-startup"
+  assert_output --partial 'still -> /etc/hostname'
+}
+
+@test "check-dotfiles honours .nochecklinks" {
+  in_container '
+    export DOTFILES=/dotfiles
+    rm -f "$HOME/.bash_profile"
+    touch "$HOME/.nochecklinks"
+    /dotfiles/bin/check-dotfiles
+    [[ -e "$HOME/.bash_profile" ]] && echo created || echo skipped
+  '
+  assert_success
+  assert_output --partial 'skipped'
+}

--- a/tests/shell/test_integration_startup.bats
+++ b/tests/shell/test_integration_startup.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+# Integration tests for dotfiles startup, run in a throwaway container (the
+# repo mounted read-only at /dotfiles) so a real login shell is exercised
+# without touching the host. Skips when docker is unavailable.
+#
+# These confirm startup *functions* — a login shell comes up with the
+# expected environment — not merely that the scripts parse.
+
+# shellcheck disable=SC2016  # $VARs in the command strings are evaluated in
+# the container's shell, not here — deliberately single-quoted.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  IMAGE="$(dotfiles_harness_image)"
+}
+
+@test "a login shell comes up with DOTFILES, XDG, and bin on PATH" {
+  dotfiles_login "$IMAGE" '
+    echo "DOTFILES=$DOTFILES"
+    echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
+    case ":$PATH:" in
+      *:/dotfiles/bin:*) echo binpath=yes ;;
+      *) echo binpath=no ;;
+    esac
+  '
+  assert_success
+  assert_output --partial 'DOTFILES=/dotfiles'
+  assert_output --partial 'XDG_CONFIG_HOME=/dotfiles/config'
+  assert_output --partial 'binpath=yes'
+}
+
+@test "the double-source guard prevents a re-source from changing PATH" {
+  dotfiles_login "$IMAGE" '
+    before="$PATH"
+    source /dotfiles/shell-startup
+    [[ "$before" == "$PATH" ]] && echo guard=ok || echo guard=FAILED
+  '
+  assert_success
+  assert_output --partial 'guard=ok'
+}
+
+@test "PATH has no duplicate /dotfiles/bin entry (cleanpath integrated)" {
+  # Label the count so it is distinguishable from any startup stdout (e.g.
+  # check-dotfiles notices).
+  dotfiles_login "$IMAGE" \
+    'echo "dupcount=$(tr ":" "\n" <<< "$PATH" | grep -c "^/dotfiles/bin$")"'
+  assert_success
+  assert_output --partial 'dupcount=1'
+}


### PR DESCRIPTION
## Summary
Stand up a containerized integration harness so tests can exercise the
**running** dotfiles in a sandbox that can't touch the host — chosen
explicitly so check-dotfiles' `ln -fs` into `$HOME` is safe to test.

- **`tests/docker/`** — harness image (slim Debian + bash/git/gettext/less +
  `en_US.UTF-8`). Repo mounted **read-only** at `/dotfiles`; default
  entrypoint deploys `~/.bash_profile`/`~/.bashrc` → `shell-startup` and runs
  a login shell.
- **`tests/helpers/common.bash`** — `dotfiles_harness_image` (builds, cached;
  **skips** the test if docker is absent or the build fails) + `dotfiles_login`.
- **`test_integration_startup.bats`** — login shell comes up
  (`DOTFILES`/XDG/PATH), double-source guard holds, cleanpath dedups PATH.
- **`test_integration_check_dotfiles.bats`** — links the entry points,
  reports a mismatched link without clobbering, honours `.nochecklinks` — all
  in the container.
- **Fix `check-dotfiles`** — it linked `$DOTFILES/shell_startup` (underscore)
  instead of `shell-startup`, so `.bash_profile`/`.bashrc`/`.profile` linking
  silently no-op'd. The harness test now proves it works.
- Docs: `TESTS.md` (v2.3.0); TODO updated.

## Test plan
- [x] `bats tests/shell/test_integration_*.bats` — 6 pass locally (docker)
- [x] full suite green (70); shellcheck/shfmt clean on the new shell files
- [x] integration tests `skip` cleanly when docker is unavailable
- [ ] CI green — confirm the integration tests run in the CI bats job (docker
      present) or skip gracefully

This is item (c) — the Docker integration harness — unblocking the remaining
shell-startup/context tests.