### PR TITLE
shell-startup interactive-context guards + context-matrix tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -387,6 +387,21 @@ Review all files in `config/shell-startup/` for correctness and security:
   — standardize to `|| return 0` pattern per `000-loadtokens` fix
 - [ ] Any other shellcheck warnings not already suppressed with justification
 
+Beyond correctness/security, audit each module for **improve / add / remove**:
+
+- [ ] **Improve**: modernize patterns; fix the lint findings the
+  extensionless-files coverage gap currently hides (e.g. terraform's
+  `COMPREPLY=($(compgen …))` SC2207, perl's SC1003); cut per-startup cost
+  (subprocesses that run at every login).
+- [ ] **Add**: tools/integrations worth their own module that aren't covered.
+- [ ] **Remove / retire**: modules for tools no longer used; dead or
+  commented-out blocks (e.g. perl's `wtf_am_i_doing_here` early-`return`
+  function); stale host assumptions.
+- [ ] Finish the **interactive-context guards**: reorder the heavily-mixed
+  modules (`010-general`, `perl`) into env → `[[ $- == *i* ]] || return 0` →
+  interactive. (`python`, `ssh-config-completion`, `terraform`, `tmux`,
+  `bash_prompt`, `taskwarrior`, `git` are already guarded.)
+
 ## 🏠 $HOME Dotfile Audit (MEDIUM PRIORITY)
 
 Reduce $HOME clutter by moving dotfiles to XDG directories where supported
@@ -782,17 +797,22 @@ Problems to solve:
   `_DOTFILES_STARTUP_DONE` sentinel returns early on a second source in the
   same shell (`tests/shell/test_shell_startup_guard.bats`). The
   context-appropriate partial-run is the remaining context work below.
-- [ ] Detect shell context (`$-` contains `i` for interactive; login shells
-  set by checking `shopt login_shell` or `$0` prefix `-`)
-- [ ] Skip alias/function/prompt setup for non-interactive shells
+- [x] Detect shell context — modules use `[[ $- == *i* ]]` to gate
+  interactive-only content (convention; see the guarded modules below).
+- [ ] Skip alias/function/prompt setup for non-interactive shells — **in
+  progress**: guarded `bash_prompt`, `taskwarrior`, `git` (pre-existing) and
+  `python`, `ssh-config-completion`, `terraform`, `tmux`. Remaining: the
+  heavily-mixed `010-general` and `perl` need an env → guard → interactive
+  reorder (the user OK'd rearranging those files).
 - [ ] Handle incomplete terminal environments gracefully (e.g., vim shell,
   docker exec, ssh command) — these may lack `TERM`, `COLUMNS`, etc.
 - [ ] Audit `config/shell-startup/` modules: tag or split each module by
-  required context (env-only vs interactive-only)
+  required context (env-only vs interactive-only) — see the broader
+  config/shell-startup audit section above.
 - [ ] Write integration tests using Docker to cover each context:
-  - Use a minimal Docker image with bash and the dotfiles mounted/installed
-  - [ ] Interactive login: `docker run -it` with login shell (`bash -l`)
-    — verify aliases, functions, prompt, and full env are set
+  - [x] Harness + interactive/non-interactive login covered
+    (`tests/shell/test_integration_context.bats`: env in both, prompt +
+    aliases interactive-only).
   - [ ] Interactive non-login: `docker run -it` without `-l`
     — verify aliases/prompt present, env inherited correctly, no double-init
   - [ ] Non-interactive login: `docker run` with `bash -lc 'command'`

--- a/config/shell-startup/python
+++ b/config/shell-startup/python
@@ -10,6 +10,9 @@ export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/startup"
 
 export PATH="$PATH:$XDG_DATA_HOME/python/bin"
 
+# Interactive-only below (aliases, helper functions, completions).
+[[ $- == *i* ]] || return 0
+
 alias python='python3'
 alias wondertwins="source venv/bin/activate"
 

--- a/config/shell-startup/ssh-config-completion
+++ b/config/shell-startup/ssh-config-completion
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Completion setup — interactive shells only.
+[[ $- == *i* ]] || return 0
+
 _ssh() {
   readarray -t SSH_KNOWN_HOSTS < <(awk '{print $1}' ~/.ssh/known_hosts | cut -d ',' -f 1 | uniq | grep -v 'localhost')
   read -ra SSH_CONFIG_HOSTS < <(grep 'Host ' ~/.ssh/config | cut -d ' ' -f 2- | tr '\n' ' ' | uniq)

--- a/config/shell-startup/terraform
+++ b/config/shell-startup/terraform
@@ -2,6 +2,9 @@
 
 command -v terraform &> /dev/null || return 0
 
+# Aliases + completion — interactive shells only.
+[[ $- == *i* ]] || return 0
+
 #-----------------------------------------------------------------------------
 alias tf='terraform'
 

--- a/config/shell-startup/tmux
+++ b/config/shell-startup/tmux
@@ -2,6 +2,9 @@
 
 command -v tmux &> /dev/null || return 0
 
+# Aliases — interactive shells only.
+[[ $- == *i* ]] || return 0
+
 # swap this window to the left
 alias swapl='tmux swap-window -t -1 ; tmux select_window -t -'
 

--- a/config/shell-startup/tmux
+++ b/config/shell-startup/tmux
@@ -14,8 +14,9 @@ alias swapr='tmux swap-window -t +1 ; tmux select_window -t +'
 # swap this window with the one passed in
 alias swapw='tmux swap-window -t'
 
-# shellcheck disable=SC1003
+# shellcheck disable=SC1003  # literal \e in the printf format, not a quote
 set_title() { printf '\ek%s\e\\' "$1"; }
+# shellcheck disable=SC1003  # literal \e in the printf format, not a quote
 unset_title() { printf '\ek\e\\'; }
 export -f set_title unset_title
 

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -2,7 +2,9 @@
 
 # Default entrypoint for the dotfiles integration-test image. Deploys the
 # minimal dotfiles entry points (so a login shell loads shell-startup), then
-# runs a login shell with the arguments as its command.
+# execs bash with the passed arguments — so callers choose the shell mode:
+#   docker run IMAGE -lc  'cmd'   # non-interactive login
+#   docker run IMAGE -lic 'cmd'   # interactive login
 #
 # The repo under test is mounted read-only at /dotfiles. Tests that need a
 # pristine HOME (e.g. exercising check-dotfiles' own symlink creation)
@@ -13,4 +15,4 @@ set -euo pipefail
 ln -sf /dotfiles/shell-startup "$HOME/.bash_profile"
 ln -sf /dotfiles/shell-startup "$HOME/.bashrc"
 
-exec bash -lc "$*"
+exec bash "$@"

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -74,9 +74,15 @@ dotfiles_harness_image() {
 # Run a command in a throwaway container with the repo mounted read-only at
 # /dotfiles, inside a login shell that has the dotfiles deployed (the image's
 # default entrypoint). Sets $output/$status via bats `run`.
-#   dotfiles_login "$IMAGE" 'echo "$DOTFILES"'
+#   dotfiles_login "$IMAGE" 'echo "$DOTFILES"'              # non-interactive
+#   dotfiles_login_interactive "$IMAGE" 'echo "${PS1:+x}"' # interactive
 
 dotfiles_login() {
   local image=$1 cmd=$2
-  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" "$image" "$cmd"
+  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" "$image" -lc "$cmd"
+}
+
+dotfiles_login_interactive() {
+  local image=$1 cmd=$2
+  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" "$image" -lic "$cmd"
 }

--- a/tests/shell/test_integration_context.bats
+++ b/tests/shell/test_integration_context.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Context-matrix integration tests: a login shell must bring up the base
+# environment in every context, but interactive-only setup (the prompt) must
+# run only in interactive shells. Verifies the existing per-module guards
+# (e.g. bash_prompt) hold across contexts. Skips when docker is unavailable.
+
+# shellcheck disable=SC2016  # $VARs run in the container's shell, not here.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  IMAGE="$(dotfiles_harness_image)"
+}
+
+@test "non-interactive login: env comes up, but no prompt or aliases" {
+  dotfiles_login "$IMAGE" '
+    echo "DOTFILES=$DOTFILES"
+    echo "xdg=${XDG_CONFIG_HOME:+set}"
+    echo "pylint=${PYLINTRC:+set}"
+    echo "prompt=[${PS1:+set}]"
+    echo "pyalias=$(alias python > /dev/null 2>&1 && echo yes || echo no)"
+  '
+  assert_success
+  assert_output --partial 'DOTFILES=/dotfiles'
+  assert_output --partial 'xdg=set'
+  # Env-only module content still runs (the python module sets PYLINTRC)...
+  assert_output --partial 'pylint=set'
+  # ...but interactive-only content is guarded out (bash_prompt prompt, and
+  # the python module's `alias python`).
+  assert_output --partial 'prompt=[]'
+  assert_output --partial 'pyalias=no'
+}
+
+@test "interactive login: env comes up AND the prompt + aliases are set" {
+  dotfiles_login_interactive "$IMAGE" '
+    echo "DOTFILES=$DOTFILES"
+    echo "prompt=[${PS1:+set}]"
+    echo "pyalias=$(alias python > /dev/null 2>&1 && echo yes || echo no)"
+  '
+  assert_success
+  assert_output --partial 'DOTFILES=/dotfiles'
+  assert_output --partial 'prompt=[set]'
+  assert_output --partial 'pyalias=yes'
+}


### PR DESCRIPTION
## Summary
- **Interactive-context guards**: add `[[ $- == *i* ]] || return 0` to the
  cleanly-separable modules — `python` (after its env exports),
  `ssh-config-completion`, `terraform`, `tmux` — so non-interactive login
  shells skip aliases/completions they can't use. Joins the already-guarded
  `bash_prompt`/`taskwarrior`/`git`.
- **Harness interactive support**: entrypoint now `exec bash "$@"` (caller
  picks the mode); `common.bash` adds `dotfiles_login` (`-lc`) +
  `dotfiles_login_interactive` (`-lic`).
- **`test_integration_context.bats`**: verifies the matrix — env
  (`DOTFILES`/XDG/`PYLINTRC`) comes up in **both** contexts, while the prompt
  and `alias python` appear **only** in interactive shells.

## Scope
The heavily-mixed `010-general` and `perl` need a full env → guard →
interactive **reorder** (you OK'd rearranging) — deferred to a focused
follow-up so a ~150-line rewrite gets its own reviewable change. Tracked in
TODO, along with a new **config/shell-startup audit** task (improve / add /
remove).

## Test plan
- [x] `test_integration_context.bats` — interactive vs non-interactive verified
- [x] full suite green (72); shellcheck/shfmt clean on changed files
- [x] guards skip cleanly (no-op) where docker is absent
- [ ] CI green