### PR TITLE
Guard interactive content in 010-general + perl

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -799,16 +799,18 @@ Problems to solve:
   context-appropriate partial-run is the remaining context work below.
 - [x] Detect shell context — modules use `[[ $- == *i* ]]` to gate
   interactive-only content (convention; see the guarded modules below).
-- [ ] Skip alias/function/prompt setup for non-interactive shells — **in
-  progress**: guarded `bash_prompt`, `taskwarrior`, `git` (pre-existing) and
-  `python`, `ssh-config-completion`, `terraform`, `tmux`. Remaining: the
-  heavily-mixed `010-general` and `perl` need an env → guard → interactive
-  reorder (the user OK'd rearranging those files).
+- [x] Skip alias/function/prompt setup for non-interactive shells — all
+  interactive-content modules now guarded with `[[ $- == *i* ]] || return 0`:
+  `bash_prompt`, `taskwarrior`, `git` (pre-existing), `python`,
+  `ssh-config-completion`, `terraform`, `tmux`, and the heavily-mixed
+  `010-general` + `perl` reordered into env → guard → interactive. Verified
+  in the harness (`test_integration_context.bats`).
 - [ ] Handle incomplete terminal environments gracefully (e.g., vim shell,
   docker exec, ssh command) — these may lack `TERM`, `COLUMNS`, etc.
-- [ ] Audit `config/shell-startup/` modules: tag or split each module by
-  required context (env-only vs interactive-only) — see the broader
-  config/shell-startup audit section above.
+- [x] Audit `config/shell-startup/` modules: tag/split by context — done as
+  the guarding above (env-only content kept unguarded; interactive-only
+  content moved below the guard). Broader improve/add/remove audit tracked in
+  the config/shell-startup audit section above.
 - [ ] Write integration tests using Docker to cover each context:
   - [x] Harness + interactive/non-interactive login covered
     (`tests/shell/test_integration_context.bats`: env in both, prompt +

--- a/config/shell-startup/010-general
+++ b/config/shell-startup/010-general
@@ -1,12 +1,76 @@
 # shellcheck shell=bash
 
-PROMPT_DIRTRIM=2
+##############################################################################
+# Always — environment / settings that also apply to non-interactive shells.
+# Interactive-only content (aliases, functions, prompt, completions, history)
+# is below the `[[ $- == *i* ]]` guard.
 
 #-----------------------------------------------------------------------------
 # Environment (moved from shell-startup — not needed before modules load)
 
 export EDITOR=vim
 export INPUTRC="$XDG_CONFIG_HOME/readline/inputrc"
+
+#-----------------------------------------------------------------------------
+# CVS settings
+export CVS_RSH='ssh'
+
+#-----------------------------------------------------------------------------
+# https://wiki.archlinux.org/index.php/Core_Utilities#grep
+export GREP_COLORS="mt=1;33"
+#export GREP_COLOR="$GREP_COLORS"
+
+#-----------------------------------------------------------------------------
+export DOCKER_CONFIG="${XDG_CONFIG_HOME}/docker"
+
+#-----------------------------------------------------------------------------
+command -v chromium-browser &> /dev/null && export BROWSER='chromium-browser'
+
+#-----------------------------------------------------------------------------
+umask 022
+
+#-----------------------------------------------------------------------------
+# Java
+#
+# jbang: run Java scripts/apps without a build system
+# https://www.jbang.dev
+addpath "$HOME/.jbang/bin"
+
+#-----------------------------------------------------------------------------
+# rust/rustup
+
+if [[ -d "$XDG_DATA_HOME" ]]; then
+  export CARGO_HOME="$XDG_DATA_HOME/cargo"
+  export RUSTUP_HOME="$XDG_CONFIG_HOME/rustup"
+  # The env file hard codes the location and is wrong
+  #source "$CARGO_HOME/env"
+  addpath "$CARGO_HOME/bin"
+fi
+
+#-----------------------------------------------------------------------------
+# cygwin specific stuff
+
+if [[ "$(uname -o)" == "Cygwin" ]]; then
+  # cygwin specific (not in bash manpage)
+  set -o igncr
+fi
+
+#-----------------------------------------------------------------------------
+# bats: expose this repo's first-class helper lib (lib/bats) ahead of the
+# system libs so any repo can `bats_load_library bats-toolbox`. Only when
+# bats is installed and the lib dir exists; honour an existing BATS_LIB_PATH.
+
+if command -v bats &> /dev/null && [[ -d "$DOTFILES/lib/bats" ]]; then
+  export BATS_LIB_PATH="$DOTFILES/lib/bats:${BATS_LIB_PATH:-/usr/lib/bats}"
+fi
+
+##############################################################################
+# Interactive-only below — aliases, functions, prompt, completions, history.
+
+[[ $- == *i* ]] || return 0
+
+#-----------------------------------------------------------------------------
+PROMPT_DIRTRIM=2
 
 #-----------------------------------------------------------------------------
 # shellcheck disable=SC2139,SC2086
@@ -32,8 +96,6 @@ proj() {
 shopt -s autocd cdspell direxpand dirspell globstar cdable_vars checkhash \
   checkwinsize dotglob extglob nocaseglob 2> /dev/null
 
-umask 022
-
 #-----------------------------------------------------------------------------
 # System
 
@@ -53,10 +115,6 @@ alias dumpldpath='echo -e ${LD_LIBRARY_PATH//:/\\n}'
 alias dotfiles='cd $DOTFILES'
 
 #-----------------------------------------------------------------------------
-# CVS settings
-export CVS_RSH='ssh'
-
-#-----------------------------------------------------------------------------
 # https://wiki.archlinux.org/index.php/Core_Utilities#ls
 # shellcheck disable=SC2046
 eval $(dircolors -b)
@@ -74,8 +132,6 @@ fi
 
 #-----------------------------------------------------------------------------
 # https://wiki.archlinux.org/index.php/Core_Utilities#grep
-export GREP_COLORS="mt=1;33"
-#export GREP_COLOR="$GREP_COLORS"
 alias grep='grep --color=auto'
 alias g='grep --color=auto'
 
@@ -121,18 +177,11 @@ shopt -s cmdhist histappend histreedit histverify
 alias h='history'
 
 #-----------------------------------------------------------------------------
-command -v chromium-browser &> /dev/null && export BROWSER='chromium-browser'
-
-#-----------------------------------------------------------------------------
-export DOCKER_CONFIG="${XDG_CONFIG_HOME}/docker"
-
-#-----------------------------------------------------------------------------
 # Mimic Zsh run-help ability
 # Press alt+h to get help for word on cursor
 # https://wiki.archlinux.org/title/Bash#Mimic_Zsh_run-help_ability
 # See inputrc for macros
 #run-help() { help "$READLINE_LINE" 2>/dev/null || man "$READLINE_LINE"; }
-
 
 #-----------------------------------------------------------------------------
 # Vault
@@ -150,29 +199,7 @@ fi
 #-----------------------------------------------------------------------------
 # Java
 
-# jbang: run Java scripts/apps without a build system
-# https://www.jbang.dev
-addpath "$HOME/.jbang/bin"
 alias j!=jbang
-
-#-----------------------------------------------------------------------------
-# rust/rustup
-
-if [[ -d "$XDG_DATA_HOME" ]]; then
-  export CARGO_HOME="$XDG_DATA_HOME/cargo"
-  export RUSTUP_HOME="$XDG_CONFIG_HOME/rustup"
-  # The env file hard codes the location and is wrong
-  #source "$CARGO_HOME/env"
-  addpath "$CARGO_HOME/bin"
-fi
-
-#-----------------------------------------------------------------------------
-# cygwin specific stuff
-
-if [[ "$(uname -o)" == "Cygwin" ]]; then
-  # cygwin specific (not in bash manpage)
-  set -o igncr
-fi
 
 #-----------------------------------------------------------------------------
 # gcloud stuff
@@ -217,13 +244,4 @@ findword() {
 
 if command -v gh &> /dev/null; then
   alias ghlastactionid="gh run list --limit 1 --json 'databaseId' --jq '.[0].databaseId'"
-fi
-
-#-----------------------------------------------------------------------------
-# bats: expose this repo's first-class helper lib (lib/bats) ahead of the
-# system libs so any repo can `bats_load_library bats-toolbox`. Only when
-# bats is installed and the lib dir exists; honour an existing BATS_LIB_PATH.
-
-if command -v bats &> /dev/null && [[ -d "$DOTFILES/lib/bats" ]]; then
-  export BATS_LIB_PATH="$DOTFILES/lib/bats:${BATS_LIB_PATH:-/usr/lib/bats}"
 fi

--- a/config/shell-startup/perl
+++ b/config/shell-startup/perl
@@ -103,6 +103,16 @@ wtf_am_i_doing_here() {
 }
 
 #-----------------------------------------------------------------------------
+# perlbrew sets PATH / PERL5LIB / PERLBREW_* — needed in any shell, so run it
+# before the interactive guard.
+setup_perlbrew
+
+##############################################################################
+# Interactive-only below — aliases and helpers.
+
+[[ $- == *i* ]] || return 0
+
+#-----------------------------------------------------------------------------
 # https://metacpan.org/module/Catalyst::Manual::Tutorial::07_Debugging#DEBUGGING-MODULES-FROM-CPAN
 # shellcheck disable=2154
 alias cmver="perl -e'for(@ARGV){\$v=eval\"require \$_\"?(\$_->VERSION||q(unknown)):q(not installed);print\"\$_ \$v\\n\"}'"
@@ -120,6 +130,5 @@ command -v cpanm &> /dev/null && {
   [[ $(which cpanm) != $HOME/* ]] && alias cpanm='cpanm -S'
 }
 
-setup_perlbrew
 setup_dzil
 setup_prove


### PR DESCRIPTION
## Summary
Reorder the two heavily-mixed `config/shell-startup` modules into
**env → guard → interactive** so non-interactive login shells skip
interactive-only setup (completing the per-module interactive guarding).

- **010-general**: env/PATH/settings (EDITOR, INPUTRC, CVS_RSH, GREP_COLORS,
  DOCKER_CONFIG, BROWSER, umask, jbang/cargo PATH, BATS_LIB_PATH) moved above
  `[[ $- == *i* ]] || return 0`; all aliases/functions/prompt/history/
  completions below it. **Content preserved** — verified by an inventory diff
  (identical set of export/alias/function/source lines).
- **perl**: `setup_perlbrew` (PATH/PERL5LIB) runs before the guard;
  `setup_dzil`/`setup_prove` calls + cmver/perldoc/cpanm aliases after.

## Test plan
- [x] 010-general: harness confirms non-interactive has EDITOR/CVS_RSH but not
      `alias ..`; interactive has both. `bash -n` + inventory-preserved.
- [x] perl: sourced in both modes here — `testtest` alias only in interactive;
      `bash -n` clean.
- [x] full bats suite green (72); all 8 integration tests pass.
- [ ] CI green

These modules are extensionless so pre-commit's shfmt/shellcheck skip them
(tracked coverage gap); behavior is covered by the docker harness instead.