### PR TITLE
Test lib/debug; queue gmailctl scripts move to private_dotfiles

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -252,6 +252,21 @@ main dotfiles checkout.
   execution trace to stderr on every tmux status render (almost certainly a
   debugging leftover). Can be fixed independently of the extraction.
 
+## 📧 Move gmailctl scripts to private_dotfiles (MEDIUM PRIORITY)
+
+`bin/gmailfilter_toyaml` (and likely `bin/filter_gmail`) support **gmailctl**,
+which holds/accesses sensitive Gmail filter config — that work only happens
+out of `private_dotfiles`, so the scripts don't belong in the public dotfiles
+repo. The scripts themselves aren't insecure; this is about keeping
+gmail-related tooling alongside the private config it serves.
+
+- [ ] Move `bin/gmailfilter_toyaml` to `private_dotfiles` (decide the layout —
+  a `bin/` there, or alongside the gmailctl config). Evaluate moving
+  `bin/filter_gmail` too.
+- [ ] Update any references (PATH expectations, docs) after the move.
+- [ ] This also retires the public meta-suite `perl -c` debt for
+  `gmailfilter_toyaml` (it needs `XML::LibXML`) — it leaves the public repo.
+
 ## 🧩 dotvim check + clone/link automation (LOW PRIORITY)
 
 dotfiles has no check or setup automation for the companion **dotvim** repo
@@ -308,8 +323,9 @@ into CI as a gate (today CI gates only the hand-written `tests/shell/test_*`).
   `shfmt -w`.
 - [x] **lib/** (shellcheck/shfmt): cleared — debug, parse_params.
       (`is`, `Arrays`, `strings` archived; `git-prompt` folded into git-status.)
-- [ ] **bin/** (perl -c): gmailfilter_toyaml — needs `XML::LibXML`; install
-  `libxml-libxml-perl` or accept the meta test failing where it is absent.
+- [ ] **bin/** (perl -c): gmailfilter_toyaml — needs `XML::LibXML`. Resolves
+  itself once the script moves to private_dotfiles (see "Move gmailctl
+  scripts to private_dotfiles" below); it leaves the public meta suite.
 - [x] `bin/CleanPath.tmp`: archived to `archive/bin/` as part of the cleanpath
   fix (see "bin/cleanpath: Fix and Integrate").
 - [ ] Once a script is clean, confirm its `<dir>-<name>.meta.bats` passes;
@@ -477,7 +493,8 @@ working tree — evaluate carefully before implementing.
         `$DOTFILES/shell_startup` (underscore) instead of `shell-startup`, so
         the `.bash_profile`/`.bashrc`/`.profile` linking silently no-op'd).
 - [ ] Add tests for lib/ libraries
-  - [ ] debug — complex; its own task
+  - [x] debug — `tests/shell/test_debug.bats` (refuses execution; debug()
+        silent unless $DEBUG; prefixes + prints args and stdin to stderr).
   - [ ] parse_params — complex (657 L); its own task. Evaluate rewriting
         in perl (much simpler than the bash version); note it's currently a
         sourced lib that sets caller variables, so a perl version would need

--- a/tests/shell/test_debug.bats
+++ b/tests/shell/test_debug.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Tests for lib/debug — a sourced library providing sourced() and debug().
+# It refuses to be executed; debug() is a no-op unless $DEBUG is truthy,
+# otherwise it writes each message to stderr prefixed with an
+# interactive/login + call-stack tag.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  # shellcheck disable=SC1090  # path resolved at runtime via dotfiles_root
+  source "$(dotfiles_root)/lib/debug"
+}
+
+@test "lib/debug refuses to be executed" {
+  run bash "$(dotfiles_root)/lib/debug"
+  assert_failure
+  assert_output --partial 'must only be sourced'
+}
+
+@test "sourcing lib/debug defines sourced() and debug()" {
+  assert_equal "$(type -t sourced)" function
+  assert_equal "$(type -t debug)" function
+}
+
+@test "debug is silent unless DEBUG is set" {
+  DEBUG='' run debug "should not appear"
+  assert_success
+  assert_output ''
+}
+
+@test "debug prints the message (after a [...] prefix) when DEBUG is set" {
+  DEBUG=1 run debug "hello world"
+  assert_success
+  assert_output --partial '] hello world'
+}
+
+@test "debug prints one prefixed line per argument" {
+  DEBUG=1 run debug "first" "second"
+  assert_success
+  assert_equal "${#lines[@]}" 2
+  assert_line --partial 'first'
+  assert_line --partial 'second'
+}
+
+@test "debug reads the message from stdin" {
+  # shellcheck disable=SC2016  # $1 is for the inner bash -c, not this shell
+  run bash -c 'source "$1/lib/debug"; echo piped | DEBUG=1 debug' _ \
+    "$(dotfiles_root)"
+  assert_success
+  assert_output --partial 'piped'
+}


### PR DESCRIPTION
## Summary
- **`tests/shell/test_debug.bats`** — covers `lib/debug`: refuses to be
  executed (sourced-only guard via `sourced()`); `debug()` is silent unless
  `$DEBUG` is truthy; otherwise prefixes each message with an
  interactive/login + call-stack tag and prints args **and** stdin to stderr.
- **TODO**: move `bin/gmailfilter_toyaml` (and likely `bin/filter_gmail`) to
  `private_dotfiles` — they support **gmailctl** (sensitive Gmail config) and
  only run from there. This also retires the public meta-suite `XML::LibXML`
  `perl -c` debt (the script leaves the repo).

## Test plan
- [x] `bats tests/shell/test_debug.bats` — 6 pass
- [x] full suite green (81); shellcheck clean
- [ ] CI green