### PR TITLE
Add PowerShell startup integration test; fix pwsh parser bugs

### DIFF
--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-**Version:** v2.3.0
+**Version:** v2.4.0
 
 ## Purpose
 
@@ -58,6 +58,11 @@ throwaway container as a sandbox — a mistake there can never touch the host.
 - `tests/shell/test_integration_*.bats` — e.g. `test_integration_startup`
   (login shell comes up with `DOTFILES`/XDG/PATH, double-source guard,
   cleanpath dedup) and `test_integration_check_dotfiles`.
+- `tests/shell/test_integration_powershell.bats` — drives the **stock**
+  `mcr.microsoft.com/powershell` image directly (no custom Dockerfile):
+  deploys `ps-startup.ps1` as the pwsh profile, runs `pwsh -File`, and asserts
+  the profile comes up (`DOTFILES` set, `powershell/startup/*` modules loaded)
+  with no parser errors. Same skip-if-no-docker guard.
 
 These run wherever docker exists (CI, dev) and skip otherwise, so they sit in
 the same gating suite without breaking docker-less environments.

--- a/TODO.md
+++ b/TODO.md
@@ -172,12 +172,16 @@ deploy/symlink (dotlinks) steps that never show on the dev machine.
   (`bash -lc`). Add the other contexts (interactive non-login, non-interactive
   login/non-login, incomplete terminal) once the per-module interactive
   guards land (see "shell-startup: Shell Context Detection").
-- [ ] PowerShell: deploy + load `ps-startup.ps1` (+ `powershell/startup/*`)
+- [x] PowerShell: deploy + load `ps-startup.ps1` (+ `powershell/startup/*`)
   in a PowerShell image (`mcr.microsoft.com/powershell`) and verify the
-  profile comes up functioning, no errors.
-- [ ] Decide the runner (reuse the `docker_wrapper` pattern?) and whether
-  these gate in CI — they need docker available (bats-action + docker, or a
-  dind/services setup).
+  profile comes up functioning, no errors —
+  `tests/shell/test_integration_powershell.bats`. Surfaced + fixed two real
+  parser bugs (`$env:$var` is invalid PowerShell) in `000-loadtokens.ps1` and
+  `aider.ps1`, plus the `Test-Path … -and Test-Path …` paren bug.
+- [x] Decide the runner — driven from bats (like the bash harness): runs the
+  stock `mcr.microsoft.com/powershell` image directly (no custom Dockerfile),
+  deploys `ps-startup.ps1` as the pwsh profile, runs `pwsh -File`. Sits in the
+  gating suite and **skips** when docker is unavailable.
 
 ## 🧭 Audit Project .claude/ Dirs for Promotable Rules/Skills (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -876,6 +876,38 @@ arrays — `syntax error: operand expected` on every entry).
 - [ ] (Optional) Extend to other path vars (`LD_LIBRARY_PATH`, `MANPATH`) if
   duplicates show up there too.
 
+### PowerShell ↔ Bash Feature Parity (MEDIUM PRIORITY)
+
+The PowerShell startup (`ps-startup.ps1` + `powershell/startup/*`) lags the
+bash side (`shell-startup` + `config/shell-startup/*` + `lib/*` + `bin/*`).
+Bring it to parity **where it makes sense for PowerShell** — port the
+cross-shell concepts, skip the bash-only or Windows-irrelevant bits. Now that
+`tests/shell/test_integration_powershell.bats` exists, each ported feature
+should get an assertion there (or a Pester test under `tests/powershell/`).
+
+- [ ] Audit bash `config/shell-startup/*` against `powershell/startup/*` and
+  decide, per feature, port / adapt / skip. Candidates that map cleanly:
+  - [ ] **History** — `010-general.ps1` already flags this (PSReadLine: history
+    file location/size, dedupe, search); mirror the bash `HIST*` intent.
+  - [ ] **Completions** — bash completions → PSReadLine / argument completers.
+  - [ ] **Prompt** — a pwsh `prompt` function mirroring the bash prompt (git
+    status, last exit code, cwd) — reuse the `bin/git-status` concept.
+  - [ ] **Aliases/functions** — port still-relevant bash aliases/functions not
+    already in `010-general.ps1`; grep colors → PSReadLine colors.
+  - [ ] **PATH dedup** — a `cleanpath` equivalent for `$env:PATH` so
+    ps-startup's PATH prepend can't accumulate duplicates. (Also fixes the
+    Windows-style `\`/`;` PATH line in `ps-startup.ps1` when run under Linux
+    `pwsh`.)
+  - [ ] **Interactive vs always split** — the bash side guards interactive-only
+    setup with `[[ $- == *i* ]]`; decide the pwsh analog (a non-interactive
+    `pwsh -File`/`-Command` still loads the profile — keep env setup cheap and
+    side-effect-free, gate interactive-only bits on
+    `[Environment]::UserInteractive`/`$Host` if needed).
+  - [ ] **debug helper** — a `$env:DEBUG`-gated trace mirroring `lib/debug`.
+- [ ] `powershell/bin/*` vs `bin/*` — note which bash utilities have a
+  Windows-relevant analog worth providing (and which stay bash-only).
+- [ ] Fold the XXX items below into this audit as they're addressed.
+
 ### PowerShell Improvements
 
 - [ ] ps-startup.ps1:49 - Move Python path to dedicated setup file (XXX)
@@ -893,15 +925,16 @@ PowerShell 5.1.
   - Determine if `ps-startup.ps1` and `config/powershell/` scripts use any
     Windows-only features that would break under `pwsh` on Linux
   - Check if Pester (PowerShell test framework) runs identically on both
-- [ ] Research using Docker for PowerShell testing:
-  - Microsoft publishes official `mcr.microsoft.com/powershell` images
-    (Linux-based `pwsh`) — suitable for CI and local testing
-  - Investigate whether a Windows container (`mcr.microsoft.com/windows/...`)
-    would be needed to test true Windows PowerShell 5.1 behavior, and
-    whether that's practical (requires Windows host for Windows containers)
-  - Document the recommended approach and its limitations in TESTS.md
-- [ ] If Linux `pwsh` + Docker is viable: set up a test harness (likely
-  Pester inside the container) before tackling the improvement tasks above
+- [x] Research using Docker for PowerShell testing — **viable and done**: the
+  stock `mcr.microsoft.com/powershell` image (Linux `pwsh`) runs the profile
+  cleanly. `tests/shell/test_integration_powershell.bats` drives it from bats
+  (skip-if-no-docker), documented in TESTS.md.
+  - [ ] (Still open) Whether a Windows container is needed to test true
+    Windows PowerShell 5.1 behavior, and whether that's practical (requires a
+    Windows host for Windows containers).
+- [x] Test harness set up — the bats-driven container harness above. (Pester
+  unit tests under `tests/powershell/` can layer on later for pure-logic
+  functions; the integration smoke test exists now.)
 
 ### Bin Scripts
 
@@ -912,7 +945,7 @@ PowerShell 5.1.
 
 ### Library Documentation and Testing
 
-- [ ] lib/debug:3,4 - Test (documented)
+- [x] lib/debug:3,4 - Test (documented) — `tests/shell/test_debug.bats`
 - [ ] lib/strings:7,8,9 - Document, test, enforce sourcing only (XXX)
 - [ ] lib/Arrays:7,8,9,38 - Document, test, enforce sourcing, consider moving to
   tools/bin (XXX)

--- a/powershell/startup/000-loadtokens.ps1
+++ b/powershell/startup/000-loadtokens.ps1
@@ -1,7 +1,7 @@
 $private_dotfiles = "$PROJECTS_DIR/private_dotfiles/api-key"
 $config_file = "$DOTFILES/api-keys.cfg"
 
-if (Test-Path $private_dotfiles -and Test-Path $config_file) {
+if ((Test-Path $private_dotfiles) -and (Test-Path $config_file)) {
   $config_lines = Get-Content -Path $config_file
 
   foreach ($line in $config_lines) {
@@ -15,7 +15,7 @@ if (Test-Path $private_dotfiles -and Test-Path $config_file) {
 
       if (Test-Path $filePath) {
         $value = (Get-Content -Path $filePath -Raw).Trim()
-        $env:$varName = $value
+        Set-Item -Path "Env:$varName" -Value $value
       }
     }
   }

--- a/powershell/startup/aider.ps1
+++ b/powershell/startup/aider.ps1
@@ -6,7 +6,7 @@ if (Get-Command aider -ErrorAction SilentlyContinue) {
             if ($_ -match "^(.*?)=(.*)$") {
                 $envName = $matches[1]
                 $envValue = $matches[2]
-                $env:$envName = $envValue
+                Set-Item -Path "Env:$envName" -Value $envValue
             }
         }
     }

--- a/tests/shell/test_integration_powershell.bats
+++ b/tests/shell/test_integration_powershell.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Integration test for the PowerShell startup (ps-startup.ps1 + the
+# powershell/startup/*.ps1 modules), run in a pwsh container. Deploys
+# ps-startup.ps1 as the profile and asserts it comes up with DOTFILES set,
+# the startup modules loaded, and no parser errors. Skips when docker is
+# unavailable.
+
+# shellcheck disable=SC2016  # PowerShell $env: refs are evaluated by pwsh.
+
+load ../helpers/common
+
+PS_IMAGE='mcr.microsoft.com/powershell'
+
+setup() {
+  load_bats_libs
+  command -v docker > /dev/null 2>&1 || skip "docker not available"
+}
+
+# Deploy ps-startup.ps1 as the pwsh profile and run a pwsh script (passed via
+# an env var, written to a file so the container's bash never expands its
+# $env: references). pwsh -File loads the profile, then runs the script.
+# The repo is mounted read-only at /dotfiles. Sets $output/$status.
+ps_startup() {
+  run docker run --rm -v "$(dotfiles_root):/dotfiles:ro" -e PSCMD="$1" \
+    "$PS_IMAGE" bash -c '
+      mkdir -p ~/.config/powershell
+      printf "%s\n" ". /dotfiles/ps-startup.ps1" \
+        > ~/.config/powershell/Microsoft.PowerShell_profile.ps1
+      printf "%s" "$PSCMD" > /tmp/cmd.ps1
+      pwsh -File /tmp/cmd.ps1
+    '
+}
+
+@test "pwsh profile comes up with DOTFILES and startup modules loaded" {
+  ps_startup '
+    Write-Output "DOTFILES=$env:DOTFILES"
+    Write-Output "hasAlias=$([bool](Get-Alias c -ErrorAction SilentlyContinue))"
+    Write-Output "hasFunc=$([bool](Get-Command Set-ParentDirectory -ErrorAction SilentlyContinue))"
+  '
+  assert_success
+  assert_output --partial 'DOTFILES=/dotfiles'
+  assert_output --partial 'hasAlias=True'
+  assert_output --partial 'hasFunc=True'
+}
+
+@test "pwsh startup loads the modules without parser errors" {
+  ps_startup 'Write-Output started-ok'
+  assert_success
+  assert_output --partial 'started-ok'
+  refute_output --partial 'ParserError'
+  refute_output --partial 'is not valid'
+}


### PR DESCRIPTION
## Summary
- **`tests/shell/test_integration_powershell.bats`** — drives the stock
  `mcr.microsoft.com/powershell` image from bats: deploys `ps-startup.ps1` as
  the pwsh profile, runs `pwsh -File`, and asserts the profile comes up
  (`DOTFILES` set, `powershell/startup/*` modules loaded) with no parser
  errors. Skip-if-no-docker, same as the bash harness.
- **Bug fixes the test surfaced** (modules silently failed to load):
  - `$env:$var = …` is invalid PowerShell (a parse error fails the whole
    file). Switched to `Set-Item -Path "Env:$var"` in `000-loadtokens.ps1`
    and `aider.ps1`.
  - `000-loadtokens.ps1`: `if (Test-Path $a -and Test-Path $b)` binds `-and`
    as a `Test-Path` parameter — parenthesised each `Test-Path`.
- **Docs**: TESTS.md harness section (+ v2.4.0); TODO PowerShell items marked
  done (runner decision recorded).

## Test plan
- [x] `bats tests/shell/test_integration_powershell.bats` — 2 pass (locally,
  pulled the pwsh image; before the fix the parser-error assertion failed)
- [x] full suite green (83); shellcheck clean
- [ ] CI green