### PR TITLE
pre-commit Phase 3: Python hooks (yapf + isort + flake8)

### DIFF
--- a/.pre-commit-config-fix.yaml
+++ b/.pre-commit-config-fix.yaml
@@ -39,6 +39,31 @@ repos:
       # Uses the repo-local .markdownlint.json (auto-discovered at the root).
       - id: markdownlint-fix
 
+  # Phase 3 (Language) — Python fixers (manual). Same scope-exclude as the
+  # check config; flake8 has no fix variant (lint-only). Run isort before yapf.
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        exclude: '^bin/(available-subnets|poetry2setup)$'
+
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      - id: yapf
+        args: [-i, --style, config/yapf/style]
+        exclude: '^bin/(available-subnets|poetry2setup)$'
+
+  # Perl fixer (perltidy) DEFERRED for the same reasons as the check config
+  # (perltidy version drift / perlbrew pinning — see TODO.md). When enabled:
+  # - repo: local
+  #   hooks:
+  #     - id: perltidy
+  #       name: perltidy -b
+  #       entry: perltidy -b -bext=/
+  #       language: system
+  #       types: [perl]
+
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,53 @@ repos:
       # Uses the repo-local .markdownlint.json (auto-discovered at the root).
       - id: markdownlint
 
+  # Phase 3 (Language) — Python: import order, format, lint. Scoped to skip the
+  # legacy bin/ Python scripts (pre-existing lint/format debt + a likely-
+  # vendored poetry2setup) until they're cleaned (see TODO.md). Tools match the
+  # repo's yapf + isort + flake8 choice (python.md), not black/ruff.
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: [--check, --diff]
+        exclude: '^bin/(available-subnets|poetry2setup)$'
+
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
+    hooks:
+      # 2-space style from config/yapf/style; -d = diff only (non-modifying).
+      - id: yapf
+        args: [-d, --style, config/yapf/style]
+        exclude: '^bin/(available-subnets|poetry2setup)$'
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      # config/flake8 reconciles flake8 with yapf's 2-space style (flake8.md).
+      - id: flake8
+        args: [--config, config/flake8]
+        exclude: '^bin/(available-subnets|poetry2setup)$'
+
+  # Phase 3 (Language) — Perl: DEFERRED (intentionally not enabled). Enabling
+  # either tool in this *gating* config would currently break the gate:
+  #   - perlcritic --severity 4 reports substantial debt on existing code, and
+  #     config/perl/perlcriticrc references policy bundles (OTRS, TryTiny) that
+  #     are not installed;
+  #   - perltidy has the version-drift problem that already makes the perl CI
+  #     job non-gating (see TODO.md "perl CI" + perlbrew pinning).
+  # Re-enable once the debt is cleared, the perlcriticrc is trimmed to
+  # installed policies, perltidy is pinned via perlbrew, and the perl tools are
+  # installed in the CI pre-commit job:
+  # - repo: local
+  #   hooks:
+  #     - id: perlcritic
+  #       name: perlcritic --severity 4
+  #       entry: perlcritic --severity 4 --profile config/perl/perlcriticrc
+  #       language: system
+  #       types: [perl]
+  #
+  # Phase 3 (Language) — Rust: N/A (no Rust in this repo).
+
   # Secret detection (Phase 2). The gitleaks hook scans staged content at
   # commit time — an effective local guard, but a no-op in CI's --all-files
   # run (nothing is staged there). Full-repo/history secret scanning is the

--- a/TODO.md
+++ b/TODO.md
@@ -215,6 +215,23 @@ to see status.
   when all pass, add the meta suite to CI and run it in pre-commit. (CI today
   gates only the hand-written `tests/shell/test_*`.)
 
+## 🐍 Python lint/format debt in bin/ scripts (MEDIUM PRIORITY)
+
+The Phase-3 Python pre-commit hooks (yapf/isort/flake8) currently **exclude**
+two bin/ scripts that carry pre-existing debt (`exclude:
+'^bin/(available-subnets|poetry2setup)$'` in both configs):
+
+- [ ] `bin/available-subnets` (ours) — yapf/flake8 findings (long lines, E251,
+  and E265 on the repo's `#----` separator comments). Reformat with yapf,
+  hand-fix the rest, and decide the **separator-comment policy for Python**
+  (keep `#####`/`#----` and add `E265,E266` to `config/flake8`, or switch to
+  plain comments — `#` followed by a space). See `flake8.md`.
+- [ ] `bin/poetry2setup` — appears to be the upstream `poetry2setup` tool.
+  Decide: vendor it properly (add a `SOURCE.md`, leave it unformatted) or
+  adopt it as ours (then format it).
+- [ ] Once both are resolved, drop the `exclude` from the Python hooks in both
+  pre-commit configs so the whole repo's Python is gated.
+
 ## 🧹 pre-commit doesn't lint extensionless shell files (MEDIUM PRIORITY)
 
 The shfmt and shellcheck pre-commit hooks (`types: [shell]`) **skip
@@ -542,20 +559,26 @@ scanning remains the **security-scan** skill's job (separate from this hook).
 
 ### Phase 3: Language-Specific Hooks
 
-- [ ] Add Python hooks (commented/conditional):
-  - [ ] black (formatting check)
-  - [ ] isort (import sorting check)
-  - [ ] flake8 (linting)
-  - [ ] mypy (type checking)
-- [ ] Add Perl hooks:
-  - [ ] perlcritic (linting)
-  - [ ] perltidy (formatting check)
-- [ ] Add Rust hooks (if applicable):
-  - [ ] cargo fmt (check mode)
-  - [ ] clippy (linting)
-- [ ] Update fix configuration with language-specific auto-fixes
-- [ ] Test with actual project files
-- [ ] Update documentation
+- [x] **Python** — wired the repo's actual toolchain (`yapf` + `isort` +
+  `flake8`, **not** black/mypy): `isort --check` + `yapf -d` + `flake8` in the
+  check config, `isort` + `yapf -i` in the fix config. Added `config/flake8`
+  (reconciles flake8 with yapf's 2-space style) and
+  `config/claude/rules/flake8.md`. `config/claude/hooks/rule-coverage.py` was
+  reformatted to pass; the legacy bin/ Python scripts are excluded pending the
+  debt cleanup below.
+  - [ ] mypy/pyright stay CI/on-demand (per `python.md`), not in pre-commit.
+- [ ] **Perl** — DEFERRED; staged commented in both configs. Blocked on:
+  existing `perlcritic --severity 4` debt; `config/perl/perlcriticrc`
+  referencing uninstalled policy bundles (OTRS, TryTiny); perltidy version
+  drift (the perl CI job is already non-gating for this — see "perl CI"); and
+  needing perl tools installed in the CI pre-commit job. Enable after perlbrew
+  pinning + perlcriticrc trim + debt cleanup.
+- [x] **Rust** — N/A (no Rust in this repo); noted in the config.
+- [x] Update fix configuration with language-specific auto-fixes (isort, yapf).
+- [x] Test with actual project files (rule-coverage.py passes; full check run
+  green).
+- [x] Update documentation (`flake8.md` added; `python.md`/`yapf.md`/`isort.md`
+  already cover the tools).
 
 ### Phase 4: Documentation Linting
 

--- a/config/claude/hooks/rule-coverage.py
+++ b/config/claude/hooks/rule-coverage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 """PostToolUse hook: flag tools/libraries/languages used without a rule.
 
 Reminds (non-blocking) when:
@@ -26,35 +27,35 @@ from pathlib import Path
 MANIFESTS = {"package.json", "pyproject.toml"}
 
 LANG_BY_EXT = {
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".mts": "typescript",
-    ".cts": "typescript",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".mjs": "javascript",
-    ".cjs": "javascript",
-    ".py": "python",
-    ".pyi": "python",
-    ".css": "css",
-    ".scss": "scss",
-    ".sass": "scss",
-    ".go": "go",
-    ".rs": "rust",
-    ".java": "java",
-    ".rb": "ruby",
-    ".sh": "bash",
-    ".bash": "bash",
-    ".html": "html",
-    ".htm": "html",
-    ".sql": "sql",
-    ".lua": "lua",
-    ".php": "php",
-    ".kt": "kotlin",
-    ".kts": "kotlin",
-    ".swift": "swift",
-    ".tf": "terraform",
-    ".vue": "vue",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".mts": "typescript",
+  ".cts": "typescript",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".py": "python",
+  ".pyi": "python",
+  ".css": "css",
+  ".scss": "scss",
+  ".sass": "scss",
+  ".go": "go",
+  ".rs": "rust",
+  ".java": "java",
+  ".rb": "ruby",
+  ".sh": "bash",
+  ".bash": "bash",
+  ".html": "html",
+  ".htm": "html",
+  ".sql": "sql",
+  ".lua": "lua",
+  ".php": "php",
+  ".kt": "kotlin",
+  ".kts": "kotlin",
+  ".swift": "swift",
+  ".tf": "terraform",
+  ".vue": "vue",
 }
 
 # Dependencies that never warrant their own rule (type stubs, etc.).
@@ -62,231 +63,230 @@ IGNORE_DEP = re.compile(r"^@types/")
 
 
 def _rules_dir() -> Path:
-    base = os.environ.get("CLAUDE_CONFIG_DIR") or str(Path.home() / ".claude")
-    return Path(base).expanduser() / "rules"
+  base = os.environ.get("CLAUDE_CONFIG_DIR") or str(Path.home() / ".claude")
+  return Path(base).expanduser() / "rules"
 
 
 def _rule_exists(rules_dir: Path, name: str) -> bool:
-    return (rules_dir / f"{name}.md").exists()
+  return (rules_dir / f"{name}.md").exists()
 
 
 def _dep_candidates(dep: str) -> list[str]:
-    dep = dep.strip().lower()
-    cands: list[str] = []
+  dep = dep.strip().lower()
+  cands: list[str] = []
 
-    if dep.startswith("@") and "/" in dep:
-        scope, pkg = dep[1:].split("/", 1)
-        cands += [scope, pkg, f"{scope}-{pkg}"]
+  if dep.startswith("@") and "/" in dep:
+    scope, pkg = dep[1:].split("/", 1)
+    cands += [scope, pkg, f"{scope}-{pkg}"]
 
-    cands.append(dep)
-    cands.append(re.sub(r"[^a-z0-9]+", "-", dep).strip("-"))
+  cands.append(dep)
+  cands.append(re.sub(r"[^a-z0-9]+", "-", dep).strip("-"))
 
-    seen: set[str] = set()
-    out: list[str] = []
-    for cand in cands:
-        if cand and cand not in seen:
-            seen.add(cand)
-            out.append(cand)
+  seen: set[str] = set()
+  out: list[str] = []
+  for cand in cands:
+    if cand and cand not in seen:
+      seen.add(cand)
+      out.append(cand)
 
-    return out
+  return out
 
 
 def _has_rule_for_dep(rules_dir: Path, dep: str) -> bool:
-    return any(_rule_exists(rules_dir, c) for c in _dep_candidates(dep))
+  return any(_rule_exists(rules_dir, c) for c in _dep_candidates(dep))
 
 
 def _pep508_name(spec: str) -> str:
-    return re.split(r"[\s<>=!~\[;()]", spec.strip(), maxsplit=1)[0]
+  return re.split(r"[\s<>=!~\[;()]", spec.strip(), maxsplit=1)[0]
 
 
 def _current_deps(manifest: Path) -> set[str]:
-    try:
-        if manifest.name == "package.json":
-            data = json.loads(manifest.read_text(encoding="utf-8"))
-            deps: set[str] = set()
-            for key in (
-                "dependencies",
-                "devDependencies",
-                "peerDependencies",
-                "optionalDependencies",
-            ):
-                deps.update((data.get(key) or {}).keys())
-            return deps
+  try:
+    if manifest.name == "package.json":
+      data = json.loads(manifest.read_text(encoding="utf-8"))
+      deps: set[str] = set()
+      for key in (
+          "dependencies",
+          "devDependencies",
+          "peerDependencies",
+          "optionalDependencies",
+      ):
+        deps.update((data.get(key) or {}).keys())
+      return deps
 
-        if manifest.name == "pyproject.toml":
-            try:
-                import tomllib
-            except ModuleNotFoundError:
-                return set()
-
-            data = tomllib.loads(manifest.read_text(encoding="utf-8"))
-            deps = set()
-
-            project = data.get("project", {})
-            for spec in project.get("dependencies", []) or []:
-                deps.add(_pep508_name(spec))
-            for group in (project.get("optional-dependencies", {}) or {}).values():
-                for spec in group or []:
-                    deps.add(_pep508_name(spec))
-
-            poetry = data.get("tool", {}).get("poetry", {})
-            for name in poetry.get("dependencies", {}) or {}:
-                if name.lower() != "python":
-                    deps.add(name)
-            for grp in (poetry.get("group", {}) or {}).values():
-                for name in grp.get("dependencies", {}) or {}:
-                    if name.lower() != "python":
-                        deps.add(name)
-
-            return {d for d in deps if d}
-    except Exception:
+    if manifest.name == "pyproject.toml":
+      try:
+        import tomllib
+      except ModuleNotFoundError:
         return set()
 
+      data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+      deps = set()
+
+      project = data.get("project", {})
+      for spec in project.get("dependencies", []) or []:
+        deps.add(_pep508_name(spec))
+      for group in (project.get("optional-dependencies", {}) or {}).values():
+        for spec in group or []:
+          deps.add(_pep508_name(spec))
+
+      poetry = data.get("tool", {}).get("poetry", {})
+      for name in poetry.get("dependencies", {}) or {}:
+        if name.lower() != "python":
+          deps.add(name)
+      for grp in (poetry.get("group", {}) or {}).values():
+        for name in grp.get("dependencies", {}) or {}:
+          if name.lower() != "python":
+            deps.add(name)
+
+      return {d for d in deps if d}
+  except Exception:
     return set()
+
+  return set()
 
 
 def _added_tokens(project_dir: str, manifest: str) -> set[str] | None:
-    """Tokens on added (+) diff lines for the manifest; None if no git."""
+  """Tokens on added (+) diff lines for the manifest; None if no git."""
 
-    def diff(*extra: str) -> str:
-        result = subprocess.run(
-            ["git", "-C", project_dir, "diff", "--unified=0", *extra, "--", manifest],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout if result.returncode == 0 else ""
+  def diff(*extra: str) -> str:
+    result = subprocess.run(
+      [
+        "git", "-C", project_dir, "diff", "--unified=0", *extra, "--", manifest
+      ],
+      capture_output=True,
+      text=True,
+      timeout=5,
+    )
+    return result.stdout if result.returncode == 0 else ""
 
-    try:
-        text = diff() or diff("--cached")
-    except Exception:
-        return None
+  try:
+    text = diff() or diff("--cached")
+  except Exception:
+    return None
 
-    tokens: set[str] = set()
-    for line in text.splitlines():
-        if line.startswith("+") and not line.startswith("+++"):
-            tokens.update(re.findall(r"[A-Za-z0-9_.@/-]+", line))
+  tokens: set[str] = set()
+  for line in text.splitlines():
+    if line.startswith("+") and not line.startswith("+++"):
+      tokens.update(re.findall(r"[A-Za-z0-9_.@/-]+", line))
 
-    return tokens
+  return tokens
 
 
 def _newly_added_deps(project_dir: str, manifest: Path) -> set[str]:
-    current = _current_deps(manifest)
-    if not current:
-        return set()
+  current = _current_deps(manifest)
+  if not current:
+    return set()
 
-    tokens = _added_tokens(project_dir, str(manifest))
-    if tokens is None:
-        # No git diff available — fall back to all current deps; the
-        # per-project dedup keeps this from repeating.
-        return current
+  tokens = _added_tokens(project_dir, str(manifest))
+  if tokens is None:
+    # No git diff available — fall back to all current deps; the
+    # per-project dedup keeps this from repeating.
+    return current
 
-    return {dep for dep in current if dep in tokens}
+  return {dep for dep in current if dep in tokens}
 
 
 def _state_file(project_dir: str) -> Path:
-    git = Path(project_dir) / ".git"
-    if git.is_dir():
-        return git / "claude-rule-reminders"
+  git = Path(project_dir) / ".git"
+  if git.is_dir():
+    return git / "claude-rule-reminders"
 
-    import hashlib
-    import tempfile
+  import hashlib
+  import tempfile
 
-    digest = hashlib.sha1(project_dir.encode()).hexdigest()[:12]
-    return Path(tempfile.gettempdir()) / f"claude-rule-reminders-{digest}"
+  digest = hashlib.sha1(project_dir.encode()).hexdigest()[:12]
+  return Path(tempfile.gettempdir()) / f"claude-rule-reminders-{digest}"
 
 
 def _filter_new(project_dir: str, items: list[str]) -> list[str]:
-    state = _state_file(project_dir)
+  state = _state_file(project_dir)
 
-    seen: set[str] = set()
+  seen: set[str] = set()
+  try:
+    if state.exists():
+      seen = set(state.read_text(encoding="utf-8").split())
+  except Exception:
+    seen = set()
+
+  new = [item for item in items if item not in seen]
+
+  if new:
     try:
-        if state.exists():
-            seen = set(state.read_text(encoding="utf-8").split())
+      with state.open("a", encoding="utf-8") as handle:
+        for item in new:
+          handle.write(item + "\n")
     except Exception:
-        seen = set()
+      pass
 
-    new = [item for item in items if item not in seen]
-
-    if new:
-        try:
-            with state.open("a", encoding="utf-8") as handle:
-                for item in new:
-                    handle.write(item + "\n")
-        except Exception:
-            pass
-
-    return new
+  return new
 
 
 def main() -> int:
-    try:
-        event = json.load(sys.stdin)
-    except Exception:
-        return 0
-
-    file_path = (event.get("tool_input") or {}).get("file_path")
-    if not file_path:
-        return 0
-
-    project_dir = (
-        os.environ.get("CLAUDE_PROJECT_DIR") or event.get("cwd") or os.getcwd()
-    )
-    rules_dir = _rules_dir()
-    path = Path(file_path)
-
-    items: list[str] = []
-
-    if path.name in MANIFESTS and path.exists():
-        for dep in sorted(_newly_added_deps(project_dir, path)):
-            if IGNORE_DEP.match(dep):
-                continue
-            if not _has_rule_for_dep(rules_dir, dep):
-                items.append(f"dep:{dep}")
-    else:
-        lang = LANG_BY_EXT.get(path.suffix.lower())
-        if lang and not _rule_exists(rules_dir, lang):
-            items.append(f"lang:{lang}")
-
-    if not items:
-        return 0
-
-    new = _filter_new(project_dir, items)
-    if not new:
-        return 0
-
-    deps = [i.split(":", 1)[1] for i in new if i.startswith("dep:")]
-    langs = [i.split(":", 1)[1] for i in new if i.startswith("lang:")]
-
-    lines: list[str] = []
-    if deps:
-        lines.append("dependencies with no rule: " + ", ".join(deps))
-    if langs:
-        lines.append("languages with no rule: " + ", ".join(langs))
-
-    message = (
-        "Rule coverage: these are now in use here but have no "
-        f"{rules_dir}/<name>.md —\n - "
-        + "\n - ".join(lines)
-        + '\n\nPer the global CLAUDE.md "Missing or Conflicting Tool Rules" '
-        "policy, surface this to the user and propose creating the rule(s) "
-        "(decide scope via the three-tier model). Skip genuinely trivial "
-        "utilities. This reminder will not repeat for the same items in "
-        "this project."
-    )
-
-    print(
-        json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PostToolUse",
-                    "additionalContext": message,
-                }
-            }
-        )
-    )
+  try:
+    event = json.load(sys.stdin)
+  except Exception:
     return 0
+
+  file_path = (event.get("tool_input") or {}).get("file_path")
+  if not file_path:
+    return 0
+
+  project_dir = (
+    os.environ.get("CLAUDE_PROJECT_DIR") or event.get("cwd") or os.getcwd()
+  )
+  rules_dir = _rules_dir()
+  path = Path(file_path)
+
+  items: list[str] = []
+
+  if path.name in MANIFESTS and path.exists():
+    for dep in sorted(_newly_added_deps(project_dir, path)):
+      if IGNORE_DEP.match(dep):
+        continue
+      if not _has_rule_for_dep(rules_dir, dep):
+        items.append(f"dep:{dep}")
+  else:
+    lang = LANG_BY_EXT.get(path.suffix.lower())
+    if lang and not _rule_exists(rules_dir, lang):
+      items.append(f"lang:{lang}")
+
+  if not items:
+    return 0
+
+  new = _filter_new(project_dir, items)
+  if not new:
+    return 0
+
+  deps = [i.split(":", 1)[1] for i in new if i.startswith("dep:")]
+  langs = [i.split(":", 1)[1] for i in new if i.startswith("lang:")]
+
+  lines: list[str] = []
+  if deps:
+    lines.append("dependencies with no rule: " + ", ".join(deps))
+  if langs:
+    lines.append("languages with no rule: " + ", ".join(langs))
+
+  message = (
+    "Rule coverage: these are now in use here but have no "
+    f"{rules_dir}/<name>.md —\n - " + "\n - ".join(lines)
+    + '\n\nPer the global CLAUDE.md "Missing or Conflicting Tool Rules" '
+    "policy, surface this to the user and propose creating the rule(s) "
+    "(decide scope via the three-tier model). Skip genuinely trivial "
+    "utilities. This reminder will not repeat for the same items in "
+    "this project."
+  )
+
+  print(
+    json.dumps({
+      "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": message,
+      }
+    })
+  )
+  return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+  sys.exit(main())

--- a/config/claude/rules/flake8.md
+++ b/config/claude/rules/flake8.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+
+# flake8 Rules
+
+**Version:** v1.0.0
+
+Linter for Python. Pairs with `yapf` (format) and `isort` (imports); see
+`python.md` for the toolchain and `yapf.md` / `isort.md` for the formatters.
+flake8 is the linter half of this repo's `yapf + isort + flake8` choice — do
+**not** also wire `ruff` (they are mutually exclusive, see `python.md`).
+
+## Configuration File
+
+flake8 config lives at `config/flake8` in this repo, which resolves to
+`$XDG_CONFIG_HOME/flake8` (flake8's XDG user-config path) — the same pattern
+as `config/yapf/style` and `config/yamllint/config`. flake8's *project*
+discovery (`setup.cfg` / `tox.ini` / `.flake8`) does **not** look at the XDG
+path, so the pre-commit hook points at it explicitly: `--config config/flake8`.
+
+### Reconciled with yapf
+
+The repo's yapf style (`config/yapf/style`) is **2-space** indent with
+`column_limit = 79`. flake8's defaults assume 4-space, so `config/flake8` must
+ignore the indent and the continuation/line-break checks yapf owns, and match
+the line length:
+
+```ini
+[flake8]
+max-line-length = 79
+extend-ignore = E111,E114,E121,E123,E126,E133,E226,E24,E704,W503,W504
+```
+
+Run the tools formatters-first: `isort` → `yapf` → `flake8` (see `isort.md`).
+
+### Separator comments
+
+`code-style.md`'s `#####` / `#----` section and function separators trip
+flake8's E265/E266. A Python file that uses them needs `E265,E266` added to
+the ignore list (or must use plain comments — `#` followed by a space). The
+currently-gated Python
+(`config/claude/hooks/rule-coverage.py`) uses plain comments, so E265/E266 are
+**not** ignored yet — revisit when the legacy bin/ Python scripts (which do use
+the separators) are cleaned and brought under the gate (see `TODO.md`).
+
+## Invocation
+
+```bash
+flake8 --config config/flake8 <file>
+```
+
+No errors permitted; fix all findings before committing.
+
+## Agent Behavior
+
+- After creating or modifying any Python file matched by the paths above: run
+  `isort`, then `yapf`, then `flake8 --config config/flake8 <file>`, and fix
+  all reported issues.
+- In pre-commit context: the check config runs flake8 (lint-only — there is no
+  fix variant); fixes come from `isort` / `yapf` in the fix config.

--- a/config/flake8
+++ b/config/flake8
@@ -1,0 +1,14 @@
+# flake8 configuration.
+#
+# Resolves to $XDG_CONFIG_HOME/flake8 (config/ is $XDG_CONFIG_HOME in this
+# repo), the same XDG pattern as config/yapf/style and config/yamllint/config.
+# In pre-commit the flake8 hook points at it explicitly (--config config/flake8)
+# since the repo isn't deployed to ~/.config there.
+#
+# Reconciled with the repo's yapf style (config/yapf/style: 2-space indent,
+# column_limit = 79): ignore the 4-space-indent assumptions (E111/E114) and the
+# continuation-line / line-break checks yapf owns, and match the line length to
+# yapf's column_limit.
+[flake8]
+max-line-length = 79
+extend-ignore = E111,E114,E121,E123,E126,E133,E226,E24,E704,W503,W504


### PR DESCRIPTION
## Summary
- Wire **Phase 3 Python** hooks into pre-commit using the repo's *actual*
  toolchain — **yapf + isort + flake8** (per `python.md`/`yapf.md`/`isort.md`),
  not black/mypy.
  - Check config: `isort --check`, `yapf -d` (`config/yapf/style`), `flake8`.
  - Fix config: `isort`, `yapf -i`. flake8 is lint-only (no fix variant).
- Add **`config/flake8`** — reconciles flake8 with yapf's 2-space style
  (ignore E111/E114 + continuation checks; `max-line-length 79`) at the XDG
  path, matching `config/yapf/style` / `config/yamllint/config`.
- Add **`config/claude/rules/flake8.md`** (sibling to yapf.md/isort.md).
- Reformat `config/claude/hooks/rule-coverage.py` so it passes the gate.
- **Scope/defer:** the two legacy bin/ Python scripts (`available-subnets`,
  `poetry2setup`) are excluded and tracked as debt (TODO). **Perl** is staged
  commented + DEFERRED (existing perlcritic debt, `perlcriticrc` references
  uninstalled policy bundles, perltidy version-drift, CI tool install). **Rust**
  is N/A.

## Test plan
- [x] `pre-commit validate-config` on both configs
- [x] `pre-commit run --all-files` (check config) green — isort/yapf/flake8 pass
- [x] fix-config isort/yapf are no-ops on the reformatted file
- [ ] CI green