### PR TITLE
Rules: prefer pre-commit over direct tool invocation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -129,6 +129,33 @@ have one), so `markdownlint` is "command not found" locally. Add it to the
 - [ ] Note: independent of pre-commit — the remote-pinned markdownlint hook
   uses its own node install, not this wrapper (see Pre-commit Configuration).
 
+## 🐳 Research: run more linters/formatters via Docker (MEDIUM PRIORITY)
+
+Today only some tools have a `bin/` docker wrapper (shellcheck, shfmt,
+yamllint, prettier, hadolint, trivy, dive — via `bin/docker_wrapper`). Others
+(yapf, isort, flake8, perltidy, perlcritic, markdownlint) are "command not
+found" unless installed on the host, so a fresh machine is inconsistent and
+pre-commit's isolated envs are the only thing that runs them.
+
+- [ ] **Per-tool wrappers**: identify which remaining tools have a trustworthy
+  official/pinned image and add them to the `docker_wrapper` dispatcher (yapf,
+  isort, flake8, perltidy, perlcritic, …) — same pattern as the existing
+  wrappers, mounting `$PWD` + the relevant `config/` files. Ties into the
+  "bin/markdownlint docker wrapper" and docker_wrapper symlink-automation items.
+- [ ] **Evaluate Super-Linter** (`github/super-linter`) — one image bundling
+  many linters. The tension: it's built to scan a whole repo (CI), not to
+  expose each linter as an individual command, so it doesn't map cleanly onto
+  the per-tool `bin/<tool>` model or pre-commit's per-file hooks. Research
+  whether the bundled linters can be invoked individually
+  (`docker run … <linter> <args>`) and whether that's worth it vs. pinning each
+  tool's own image. Likely roles: a CI "lint everything" aggregate pass, or a
+  convenience wrapper — **not** a replacement for per-tool wrappers / pre-commit
+  hooks.
+- [ ] **Decide the boundary**: which tools are best as standalone pinned
+  images, which (if any) via Super-Linter, and how this interacts with
+  pre-commit (which already runs tools in isolated envs — a host wrapper is
+  mainly for ad-hoc CLI use outside a commit).
+
 ## 🪟 Break tmux config into its own repo (MEDIUM PRIORITY)
 
 Move the tmux configuration (or at least enough of it to support the
@@ -532,12 +559,13 @@ are in place, tested, documented (README + `.claude/rules/pre-commit.md`),
 wired into CI (`pre-commit run --all-files`), and the CI `pre-commit` check is
 required in the master ruleset alongside `bats`. One follow-up remains:
 
-- [ ] Update all `config/claude/rules/*.md` Agent Behavior sections to
-  prioritize pre-commit over direct tool invocation:
-  - Normal ops: `pre-commit run --files <file>` instead of `shfmt`/`shellcheck`/etc.
-  - Fix ops: `pre-commit run --config .pre-commit-config-fix.yaml --files <file>`
-  - Direct tool invocation becomes the fallback when pre-commit is not
-    configured or the file is not covered by any hook
+- [x] Update all `config/claude/rules/*.md` Agent Behavior sections to
+  prioritize pre-commit over direct tool invocation — added a canonical
+  *Prefer pre-commit Over Direct Tool Invocation* section to `pre-commit.md`
+  and pointed all 17 tool rules (bash, shellcheck, shfmt, yamllint,
+  markdownlint, yapf, isort, flake8, black, ruff, biome, perl, powershell,
+  docker, hadolint, vitest, TEMPLATE) at it; direct invocation is now the
+  documented fallback when pre-commit isn't configured / doesn't cover a file.
 
 ### Proposed: pre-commit skill, used by qa-check
 
@@ -904,12 +932,13 @@ in the future.
 
 1. **Testing Phase 3** — `lib/parse_params` (+ evaluate the perl rewrite) and
    `config/shell-startup/` module tests
-2. **Pre-commit Phase 3** — language hooks (Python, Perl, Rust)
+2. **Python lint/format debt in bin/ scripts** — clean `available-subnets`,
+   decide `poetry2setup`, then widen the Python pre-commit gate
 3. **perl CI** — make `perltidyrc-clean` tests version-robust, then promote to
-   a required check
-4. **Rules `*.md` Agent Behavior** — switch to preferring pre-commit invocation
-5. **Move gmailctl scripts** to private_dotfiles (retires the meta-suite
+   a required check (also unblocks the deferred Perl pre-commit hooks)
+4. **Move gmailctl scripts** to private_dotfiles (retires the meta-suite
    `XML::LibXML` debt)
+5. **Pre-commit Phase 4** (docs linting) and the phased CI/CD expansion
 
 ## Notes
 

--- a/config/claude/rules/TEMPLATE.md
+++ b/config/claude/rules/TEMPLATE.md
@@ -27,5 +27,8 @@ Where the config lives, how it is resolved, and any Docker wrapper notes.
 - After creating or modifying any file matched by the paths above:
   1. Step one.
   2. Step two.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/bash.md
+++ b/config/claude/rules/bash.md
@@ -137,5 +137,8 @@ value=$(
 - After creating or modifying any shell file matched by the paths above,
   follow the pipeline defined in `shfmt.md` (format) then `shellcheck.md`
   (lint).
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/biome.md
+++ b/config/claude/rules/biome.md
@@ -59,7 +59,10 @@ across machines and CI.
   and apply safe fixes, then resolve any remaining lint findings.
 - Run `tsc` (or `npm run typecheck`) separately — Biome does not type
   check.
-- In pre-commit context: `.pre-commit-config.yaml` runs `biome check`
-  (no writes); `.pre-commit-config-fix.yaml` runs `biome check --write`.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.
 - Do not reintroduce ESLint/Prettier alongside Biome in the same repo;
   pick one (see `typescript.md`).

--- a/config/claude/rules/black.md
+++ b/config/claude/rules/black.md
@@ -44,5 +44,8 @@ other is unused for that repo.
   2. Run `black <file>` to format. black must run *after* isort so it
      normalizes the result.
   3. Run `flake8 <file>` to catch any remaining issues.
-- In pre-commit context: `.pre-commit-config.yaml` uses `--check`;
-  `.pre-commit-config-fix.yaml` runs black without flags (fix in place).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/docker.md
+++ b/config/claude/rules/docker.md
@@ -95,7 +95,9 @@ This rule is the *policy*; three tools enforce and measure it — lint with
   - Flag inline secrets or credentials.
 - After authoring/changing a Dockerfile run `hadolint` (`hadolint.md`); after
   building/changing an image run `trivy image` + `trivy config` (`trivy.md`).
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes. hadolint is check-only (no
-  auto-fix equivalent); trivy/dive are not pre-commit hooks (they run in CI /
-  on demand).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file. hadolint is check-only; trivy/dive are not pre-commit
+  hooks (they run in CI / on demand).

--- a/config/claude/rules/flake8.md
+++ b/config/claude/rules/flake8.md
@@ -59,5 +59,8 @@ No errors permitted; fix all findings before committing.
 - After creating or modifying any Python file matched by the paths above: run
   `isort`, then `yapf`, then `flake8 --config config/flake8 <file>`, and fix
   all reported issues.
-- In pre-commit context: the check config runs flake8 (lint-only — there is no
-  fix variant); fixes come from `isort` / `yapf` in the fix config.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file. flake8 is lint-only; fixes come from `isort` / `yapf`.

--- a/config/claude/rules/hadolint.md
+++ b/config/claude/rules/hadolint.md
@@ -66,5 +66,8 @@ repo root or the directory holding the Dockerfile.
   at or above `warning` before continuing. Inline ignores require a reason.
 - Honour the best-practice policy in `docker.md` (pinning, layer hygiene,
   non-root, secrets) — hadolint catches most of it, but not all.
-- In pre-commit context: `.pre-commit-config.yaml` checks only; there is no
-  auto-fix variant for hadolint (it is check-only).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file. hadolint is check-only (no fix variant).

--- a/config/claude/rules/isort.md
+++ b/config/claude/rules/isort.md
@@ -45,5 +45,8 @@ re-ordered after formatting and create churn.
   1. Run `isort <file>` to sort imports.
   2. Run the repo's formatter (`black` or `yapf`).
   3. Run `flake8 <file>`.
-- In pre-commit context: `.pre-commit-config.yaml` uses `--check`;
-  `.pre-commit-config-fix.yaml` runs isort without flags (fix in place).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/markdownlint.md
+++ b/config/claude/rules/markdownlint.md
@@ -51,5 +51,8 @@ configs (see `TODO.md`). Active rule overrides:
   1. Run `markdownlint <file>` and fix all reported issues.
 - Wrap Markdown prose at 78 columns (per `CONVENTIONS.md`) unless a line
   contains a URL or code span that would break if wrapped.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/perl.md
+++ b/config/claude/rules/perl.md
@@ -17,5 +17,8 @@ paths:
   1. Run `perltidy -b <file>` to format in place (`-b` backs up the
      original as `<file>.bak`; delete the backup after confirming).
   2. Run `perlcritic --severity 4 <file>` and fix all reported violations.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/powershell.md
+++ b/config/claude/rules/powershell.md
@@ -29,5 +29,8 @@ Dev/Test research task in TODO.md.
 
 - After creating or modifying any PowerShell file matched by the paths above:
   1. Run `Invoke-ScriptAnalyzer -Path <file>` and fix all reported issues.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/pre-commit.md
+++ b/config/claude/rules/pre-commit.md
@@ -6,7 +6,7 @@ paths:
 
 # pre-commit Agent Contract
 
-**Version:** v1.4.0
+**Version:** v1.5.0
 
 This document defines **normative agent behavior** for interacting with
 **pre-commit** in this repository.
@@ -197,6 +197,29 @@ pre-commit cache. Reclaim that space periodically:
 ```bash
 pre-commit gc
 ```
+
+## Prefer pre-commit Over Direct Tool Invocation
+
+When a repo has `.pre-commit-config.yaml`, prefer driving formatters and
+linters **through pre-commit** rather than invoking the tools directly: the
+hook config is the single source of truth for *which* tool, *which* version,
+and *which* flags apply, so running it keeps what the agent runs in lock-step
+with what the gate enforces.
+
+- **Check (normal dev):** `pre-commit run --files <file>` (list several files,
+  or `--all-files` for the whole tree). Runs every hook matching those files.
+- **One tool only:** add the hook id — `pre-commit run shellcheck --files
+  <file>`.
+- **Fix:** `pre-commit run --config .pre-commit-config-fix.yaml --files
+  <file>` — only as the final pre-commit step, never mid-session for a single
+  failure (see *Pre-Commit Workflow When Ready to Commit*).
+- **Fall back to direct invocation** (`shellcheck <file>`, `yapf -i <file>`, …)
+  only when pre-commit is **not** configured, or the file is **not covered** by
+  any hook. The per-tool rules document those direct commands and flags.
+
+The per-tool rules (`shellcheck.md`, `shfmt.md`, `yamllint.md`,
+`markdownlint.md`, `yapf.md`, `isort.md`, `flake8.md`, `bash.md`, `perl.md`,
+…) point back here for this policy.
 
 ## Agent Rules
 

--- a/config/claude/rules/ruff.md
+++ b/config/claude/rules/ruff.md
@@ -61,7 +61,9 @@ Project-wide exceptions belong in `ignore` / per-file ignores in the config.
   1. `ruff format <path>`.
   2. `ruff check <path>` (or `--fix`) and resolve findings.
   3. `pyright`/`mypy` for types (ruff does not type-check).
-- In pre-commit context: `.pre-commit-config.yaml` runs `ruff check` +
-  `ruff format --check`; `.pre-commit-config-fix.yaml` runs
-  `ruff check --fix` + `ruff format`.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.
 - Do not run black/isort/flake8 alongside ruff in the same repo.

--- a/config/claude/rules/shellcheck.md
+++ b/config/claude/rules/shellcheck.md
@@ -72,5 +72,8 @@ always the final step:
 - Run `shellcheck <file>` after any shell file change.
 - Fix all reported issues before continuing. Inline disables require a
   reason comment.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/shfmt.md
+++ b/config/claude/rules/shfmt.md
@@ -88,5 +88,8 @@ the file being formatted).
      (`-s -w`) only for `.sh`/`.bash` files, explicit form
      (`-i 2 -s -bn -ci -sr -w`) for everything else.
   2. Run `shellcheck <file>` to catch any remaining issues.
-- In pre-commit context: `.pre-commit-config.yaml` uses `-d` (check
-  only, never `-w`); `.pre-commit-config-fix.yaml` uses `-w` (auto-fix).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/vitest.md
+++ b/config/claude/rules/vitest.md
@@ -62,8 +62,9 @@ Direct: `vitest run` (one-shot), `vitest` (watch), `vitest run <file>`
 - After creating or modifying tested logic, run `npm test` (or
   `vitest run <file>`) and make it green before moving on.
 - Run Biome and `tsc` separately (Vitest does not lint or type-check).
-- In pre-commit context: add a check-only `frontend-test` (or equivalent)
-  local hook running `vitest run` in `.pre-commit-config.yaml`; there is no
-  fix variant.
+- **Prefer pre-commit** when the repo wires it (see `pre-commit.md`): run
+  `pre-commit run frontend-test --files <file>`. Add a check-only
+  `frontend-test` local hook running `vitest run` in `.pre-commit-config.yaml`
+  (there is no fix variant). Fall back to direct `vitest run` otherwise.
 - When adding Vitest to a project that lacks a runner, surface the new dev
   deps (`vitest`, and the DOM env if used) per the rule-coverage policy.

--- a/config/claude/rules/yamllint.md
+++ b/config/claude/rules/yamllint.md
@@ -40,5 +40,8 @@ the current directory.
 
 - After creating or modifying any YAML file matched by the paths above:
   1. Run `yamllint <file>` and fix all reported issues.
-- In pre-commit context: `.pre-commit-config.yaml` checks only;
-  `.pre-commit-config-fix.yaml` applies fixes.
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.

--- a/config/claude/rules/yapf.md
+++ b/config/claude/rules/yapf.md
@@ -36,5 +36,8 @@ Style config lives at `config/yapf/style` in this repo, which resolves to
 - After creating or modifying any Python file matched by the paths above:
   1. Run `yapf --style="$XDG_CONFIG_HOME/yapf/style" -i <file>` to format.
   2. Run `flake8 <file>` to catch any remaining issues.
-- In pre-commit context: `.pre-commit-config.yaml` uses `-d` (check only);
-  `.pre-commit-config-fix.yaml` uses `-i` (fix in place).
+- **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
+  `pre-commit run --files <file>` to check, and `pre-commit run --config
+  .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct
+  invocation above only when pre-commit isn't configured or doesn't cover the
+  file.


### PR DESCRIPTION
## Summary
- Add a canonical **Prefer pre-commit Over Direct Tool Invocation** section to
  `pre-commit.md` (check → `pre-commit run --files`; fix → `--config` the fix
  config; single tool → add the hook id; **direct invocation is the fallback**
  when pre-commit isn't configured or doesn't cover the file).
- Point all **17** tool rules' Agent Behavior at it with one consistent
  bullet: bash, shellcheck, shfmt, yamllint, markdownlint, yapf, isort, flake8,
  black, ruff, biome, perl, powershell, docker, hadolint, vitest, TEMPLATE.
- Add a research TODO: run more linters/formatters via Docker (per-tool
  wrappers for yapf/isort/flake8/perltidy/perlcritic; evaluate
  `github/super-linter` and the "individual tools" tension).
- Mark the "prefer pre-commit" + related Phase-3 TODO items done.

## Test plan
- [x] markdownlint clean on all 18 changed Markdown files
- [ ] CI green