### PR TITLE
Convert bin/hr to parse_params; add slurp positional (#@)

### DIFF
--- a/bin/hr
+++ b/bin/hr
@@ -1,49 +1,41 @@
 #!/bin/bash
 
-declare -i len=0 default_len=40
-declare msg char='#'
+# hr - print a horizontal rule, optionally titled.
+#
+# Example of replacing a hand-written option loop with parse_params (see the
+# global bash.md "Argument Parsing"): a definition string + one `eval` do all
+# the parsing, validation, and --help. `--auto` makes parse_params report bad
+# input (and a usage block) itself.
 
-shopt -s extglob
+# shellcheck disable=SC2154  # $len/$char/$words are set by the parse_params eval
 
-warn() { printf '%s\n' "$*" >&2; }
-die() {
-  (($#)) && warn "$*"
-  exit 1
-}
+PARM_DEF='
+l|length,integer,len
+c|char,char,char,#
+#@,string,words
+'
 
-while (($#)); do
-  opt=$1
-  shift
+eval "$(parse_params --auto --prog "${0##*/}" "$PARM_DEF" "$@")"
 
-  case "$opt" in
-    -l)
-      len=$1
-      shift
-      ((len > 0)) || die 'length must be greater than 0'
-      ;;
-
-    -c)
-      char=$1
-      shift
-      [[ ${#char} -gt 1 ]] && die 'only a single character can be used for line character'
-      ;;
-
-    *) msg+="$opt " ;;
-  esac
-done
-
-if ((len == 0)); then
-  len=$default_len
+# Length: a supplied value must be positive (parse_params validates the integer
+# type but allows 0 / negatives). With none supplied, use the terminal width on
+# a tty, else 40.
+if [[ -z $len ]]; then
+  len=40
   [[ -t 1 ]] && len=$(tput cols)
+
+elif ((len <= 0)); then
+  printf 'hr: length must be greater than 0\n' >&2
+  exit 1
 fi
 
-[[ $msg =~ ^[[:space:]]*$ ]] && msg=
+# Optional title: "<char><char> <words> " prefixes the rule and shortens it.
+msg=
 
-if [[ -n $msg ]]; then
-  printf -v msg '%c%c %s' "$char" "$char" "$msg"
-  l="${#msg}"
-  len=$((len - l))
+if ((${#words[@]})); then
+  printf -v msg '%c%c %s ' "$char" "$char" "${words[*]}"
+  len=$((len - ${#msg}))
   ((len < 0)) && len=0
 fi
 
-printf '%s%s\n' "$msg" "$(head -c $len < /dev/zero | tr '\0' "$char")"
+printf '%s%s\n' "$msg" "$(head -c "$len" < /dev/zero | tr '\0' "$char")"

--- a/bin/parse_params
+++ b/bin/parse_params
@@ -128,18 +128,22 @@ sub parse_definition {
 
     def_err("missing OPTION in: $line") unless defined $opt && length $opt;
 
-    # Positional parameter.
-    if ( $opt eq '#' ) {
+    # Positional parameter. OPTION '#' is one fixed positional; '#@' is a
+    # slurp that collects ALL remaining args into a shell array. A slurp must
+    # be the last positional, and there can be only one.
+    if ( $opt eq '#' || $opt eq '#@' ) {
+      my $slurp = $opt eq '#@';
       def_err("positional needs a TYPE in: $line")
         unless defined $type && length $type;
-      ( my $ptype = $type ) =~ s/\@$//;
-      def_err("unknown type ($type) in: $line") unless $IS_TYPE{$ptype};
+      def_err("unknown type ($type) in: $line") unless $IS_TYPE{$type};
       def_err("positional needs a VARNAME in: $line")
         unless defined $var && length $var;
       def_err("invalid variable name ($var) in: $line")
         unless $var =~ /^[A-Za-z_]\w*$/;
+      def_err("a slurp positional (#\@) must be the last one in: $line")
+        if @positionals && $positionals[-1]{slurp};
 
-      push @positionals, { type => $ptype, var => $var };
+      push @positionals, { type => $type, var => $var, slurp => $slurp };
       next;
     }
 
@@ -223,8 +227,10 @@ sub parse_definition {
 sub build_usage {
   my ( $opts, $positionals ) = @_;
 
-  my $prog  = length $PROG_NAME ? "$PROG_NAME " : '';
-  my @lines = ( "Usage: ${prog}[options]" . ( @$positionals ? ' ' . join( ' ', map { $_->{var} } @$positionals ) : '' ) . "\n" );
+  my $prog = length $PROG_NAME ? "$PROG_NAME " : '';
+  my $args = join ' ',
+    map { $_->{slurp} ? "[$_->{var}...]" : $_->{var} } @$positionals;
+  my @lines = ( "Usage: ${prog}[options]" . ( length $args ? " $args" : '' ) . "\n" );
 
   if (@$opts) {
     push @lines, 'Options:';
@@ -247,7 +253,8 @@ sub build_usage {
 
   if (@$positionals) {
     push @lines, 'Positional:';
-    push @lines, "  $_->{var} <$_->{type}>" for @$positionals;
+    push @lines,
+      "  $_->{var} <$_->{type}>" . ( $_->{slurp} ? '...' : '' ) for @$positionals;
   }
 
   return join( "\n", @lines ) . "\n";
@@ -369,8 +376,22 @@ for my $o (@$OPTS) {
   push @out, "$var=" . shq($v);
 } ## end for my $o (@$OPTS)
 
-# Positionals: assign the leftover args in order.
+# Positionals: assign the leftover args in order. A slurp (#@) takes all that
+# remain, as a shell array.
 for my $p (@$POSITIONALS) {
+  if ( $p->{slurp} ) {
+    my @vals = @args;
+    @args = ();
+
+    for my $v (@vals) {
+      push @errors, "positional $p->{var} ($v) is not a $p->{type}"
+        unless valid_value( $p->{type}, $v );
+    }
+    @vals = map { File::Spec->rel2abs($_) } @vals if $p->{type} eq 'filename';
+    push @out, "$p->{var}=(" . join( ' ', map { shq($_) } @vals ) . ')';
+    next;
+  }
+
   my $v = shift @args;
   if ( defined $v && length $v && !valid_value( $p->{type}, $v ) ) {
     push @errors, "positional $p->{var} ($v) is not a $p->{type}";
@@ -378,7 +399,7 @@ for my $p (@$POSITIONALS) {
   $v = File::Spec->rel2abs($v)
     if $p->{type} eq 'filename' && defined $v && length $v;
   push @out, "$p->{var}=" . shq($v);
-}
+} ## end for my $p (@$POSITIONALS)
 
 bail_input(@errors) if @errors;
 
@@ -465,7 +486,9 @@ is trimmed):
 
 =item B<OPTION>
 
-Short (C<a>), long (C<app>), both (C<a|app>), or C<#> for a positional.
+Short (C<a>), long (C<app>), both (C<a|app>), C<#> for a fixed positional, or
+C<#@> for a slurp positional that collects all remaining args into a shell
+array. A slurp must be the last positional, and there can be only one.
 
 =item B<TYPE>
 

--- a/bin/parse_params
+++ b/bin/parse_params
@@ -511,6 +511,18 @@ optional).
 
 =back
 
+=head1 ARGUMENT ORDER
+
+Options and positionals may be interleaved on the command line: recognized
+options (with their values) are permuted out wherever they appear, and the
+remaining arguments, in order, are the positionals — each fixed C<#> takes
+one, then a C<#@> slurp takes the rest. So C<#@> must be the last positional in
+the *definition*, but on the command line the options can come before, after,
+or among the positional words.
+
+A positional that begins with C<-> must come after C<--> (which ends option
+parsing); otherwise it is taken as an unknown option and rejected.
+
 =head1 TYPES AND BEHAVIOR
 
 =over 4

--- a/config/claude/rules/bash.md
+++ b/config/claude/rules/bash.md
@@ -55,11 +55,12 @@ eval "$(parse_params --auto --prog "${0##*/}" "$PARM_DEF" "$@")"
 
 This replaces the boilerplate `while (($#)); do case $1 in …` loop and gives
 consistent type-checking, defaults, required-option enforcement, negatable
-booleans (`--no-x`), repeatable (`type@` → array) options, positionals, and an
-auto-generated `--help`. It also works **inside a function** — pass the
-function's `"$@"` (declare the target vars `local` first to scope them); a
-function with many parameters is usually better as its own script. Run
-`parse_params --help` for the full reference.
+booleans (`--no-x`), repeatable (`type@` → array) options, fixed and **slurp**
+(`#@` → array of the rest) positionals, and an auto-generated `--help`. It also
+works **inside a function** — pass the function's `"$@"` (declare the target
+vars `local` first to scope them); a function with many parameters is usually
+better as its own script. Run `parse_params --help` for the full reference, and
+see **`bin/hr`** for a worked example (options + `--auto` + a slurp positional).
 
 **Scope caveat:** `parse_params` ships in the dotfiles repo (`bin/parse_params`)
 and is only on `PATH` in that environment. Do **not** depend on it in a

--- a/tests/perl/parse_params-boolean.t
+++ b/tests/perl/parse_params-boolean.t
@@ -52,4 +52,21 @@ like($out, qr/^count='5'$/m,    'second positional assigned');
 ($out, $err, $rc) = run_pp("#,integer,count", 'notnum');
 is($rc, 1, 'positional type mismatch exits 1');
 
+# slurp positional (#@) collects ALL remaining args into a shell array
+($out, $err, $rc)
+  = run_pp("l|len,integer,len\n#\@,string,words", '--len', '3', 'a', 'b c', 'd');
+is($rc, 0, 'slurp exits 0');
+like($out, qr/^len='3'$/m, 'options still parsed alongside a slurp');
+like($out, qr/^words=\('a' 'b c' 'd'\)$/m,
+  'slurp collects the rest into an array (spaces preserved)');
+
+($out, $err, $rc) = run_pp("#\@,string,words");
+like($out, qr/^words=\(\)$/m, 'slurp with no args -> empty array');
+
+($out, $err, $rc) = run_pp("#\@,integer,nums", '1', 'x');
+is($rc, 1, 'slurp type-checks each element');
+
+($out, $err, $rc) = run_pp("#\@,string,a\n#,string,b");
+is($rc, 2, 'a slurp must be the last positional (definition error)');
+
 done_testing;

--- a/tests/shell/test_hr.bats
+++ b/tests/shell/test_hr.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Tests for bin/hr — a horizontal-rule printer, and the worked example of
+# driving bin/parse_params (options + a slurp positional) from a shell script.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  # hr calls `parse_params`; make both resolvable from the repo's bin/.
+  PATH="$(dotfiles_root)/bin:$PATH"
+}
+
+@test "hr defaults to a 40-char rule of '#' (non-tty)" {
+  run hr
+  assert_success
+  assert_equal "${#output}" 40
+  assert_output --regexp '^#+$'
+}
+
+@test "hr -l sets the length" {
+  run hr -l 10
+  assert_success
+  assert_output '##########'
+}
+
+@test "hr -c sets the rule character" {
+  run hr -c = -l 12
+  assert_success
+  assert_output '============'
+}
+
+@test "hr prints a title (slurp positional) then fills the rest" {
+  run hr -l 30 My title
+  assert_success
+  assert_equal "${#output}" 30
+  assert_output --regexp '^## My title #+$'
+}
+
+@test "hr combines -c and a title" {
+  run hr -c = -l 20 Section
+  assert_success
+  assert_output --regexp '^== Section =+$'
+}
+
+@test "hr rejects a non-integer length (parse_params, exit 2)" {
+  run hr -l abc
+  assert_failure 2
+  assert_output --partial 'is not a integer'
+}
+
+@test "hr rejects a non-positive length (exit 1)" {
+  run hr -l 0
+  assert_failure 1
+  assert_output --partial 'greater than 0'
+}
+
+@test "hr rejects a multi-char rule character (parse_params, exit 2)" {
+  run hr -c xx
+  assert_failure 2
+  assert_output --partial 'is not a char'
+}
+
+@test "hr --help prints usage and exits 0" {
+  run hr --help
+  assert_success
+  assert_output --partial 'Usage: hr'
+}


### PR DESCRIPTION
## Summary
- **parse_params: add a slurp positional** — OPTION `#@` collects all remaining
  args into a shell array (must be last; only one). Covers the common
  "options + free-form trailing args" pattern.
- **Convert `bin/hr`** as the worked example (replaces its `while`/`case`
  loop): a `PARM_DEF` + one `eval "$(parse_params --auto --prog "${0##*/}" …)"`
  handles `-l`/`-c` parsing, integer/char validation, `--help`, and the title
  via a `#@` slurp. Behavior preserved (default width, length > 0, single-char
  rule char, `<cc> <title> ` prefix).
- **bash.md** points at `bin/hr` as the example and documents `#@`.

## Test plan
- [x] `tests/shell/test_hr.bats` — 9 cases (default/len/char/title/combined +
  error + --help), shellcheck clean
- [x] slurp cases added to `parse_params-boolean.t`; parse_params suite 85
- [x] full bats suite (92) green; `bin/hr` shfmt + shellcheck clean
- [ ] CI green