### PR TITLE
Test config/shell-startup/000-loadtokens; fix stale docker_helpers TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -526,12 +526,17 @@ working tree — evaluate carefully before implementing.
   - [ ] **Consider converting `bin/cleanpath` to perl** (same kind of text
         munging). Constraint: core perl modules only — no CPAN (keeps it
         runnable anywhere; avoids the Perl::Tidy/XML::LibXML install gap).
-  - [ ] docker_helpers — currently untested.
+  - [x] docker_helpers — `tests/shell/test_docker_helpers.bats` (20 cases).
   - (`is`, `Arrays`, `strings` archived to `archive/lib/`; `git-prompt`
     factored into `bin/git-status` — not tested.)
 - [ ] Add tests for config/shell-startup/ modules
-  - [ ] Test conditional loading
-  - [ ] Test error handling
+  - [x] `000-loadtokens` — `tests/shell/test_000-loadtokens.bats` (conditional
+    token loading, comment/missing-file skips, no-op when absent, temp-var
+    cleanup). The one module with real standalone logic worth isolating.
+  - The rest are guarded tool-setup (`command -v`/interactive) already
+    exercised in aggregate by the docker integration tests
+    (`test_integration_startup` + `test_integration_context`); add a focused
+    unit test only when a module grows real conditional logic.
 
 ### Phase 4: Extended Coverage
 
@@ -1022,9 +1027,9 @@ in the future.
 ## 📊 Progress Tracking
 
 - **Documentation:** ~85% complete (foundation laid, XXX cleanup remaining)
-- **Testing:** ~60% complete (docker harness + context matrix + several
-  scripts/libs covered, incl. the new perl `parse_params`; shell-startup
-  module tests + `docker_helpers` remain)
+- **Testing:** ~70% complete (docker harness + context matrix + parse_params,
+  docker_helpers, 000-loadtokens, hr, …; a broad per-script coverage audit and
+  Phase 4 remain)
 - **Pre-commit:** Phases 1–2 done (core + security, in CI + required); Phases
   3–4 (language, docs) remain
 - **CI/CD:** `tests.yml` (bats/perl/python) + `pre-commit` job live; phased
@@ -1034,13 +1039,15 @@ in the future.
 
 ## 🎯 Next Actions (Priority Order)
 
-1. **Testing Phase 3** — `config/shell-startup/` module tests and
-   `lib/docker_helpers` (parse_params is done — see bin/parse_params)
-2. **perl CI** — make `perltidyrc-clean` tests version-robust, then promote to
+1. **perl CI** — make `perltidyrc-clean` tests version-robust, then promote to
    a required check (also unblocks the deferred Perl pre-commit hooks)
-3. **Move gmailctl scripts** to private_dotfiles (retires the meta-suite
+2. **Move gmailctl scripts** to private_dotfiles (retires the meta-suite
    `XML::LibXML` debt)
-4. **Pre-commit Phase 4** (docs linting) and the phased CI/CD expansion
+3. **Perl quality tooling** — curated perlcritic + Test::Perl::Critic,
+   Devel::Cover, Pod::Coverage, … (see that section)
+4. **Comprehensive BATS coverage audit** — full pass over the remaining bin/
+   scripts (Phase 3 wrap-up)
+5. **Pre-commit Phase 4** (docs linting) and the phased CI/CD expansion
 
 ## Notes
 

--- a/tests/shell/test_000-loadtokens.bats
+++ b/tests/shell/test_000-loadtokens.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Tests for config/shell-startup/000-loadtokens — exports API tokens named in
+# $PROJECTS_DIR/dotfiles/api-keys.cfg from files under
+# $PROJECTS_DIR/private_dotfiles/api-key, but only when both are present. It
+# must be a no-op otherwise and must clean up its temporary variables.
+
+# shellcheck disable=SC1090  # $MODULE is resolved at runtime via dotfiles_root
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  MODULE="$(dotfiles_root)/config/shell-startup/000-loadtokens"
+  PROJECTS_DIR="$BATS_TEST_TMPDIR"
+  mkdir -p "$PROJECTS_DIR/private_dotfiles/api-key" "$PROJECTS_DIR/dotfiles"
+  export PROJECTS_DIR
+}
+
+@test "exports a token from a VAR=file mapping" {
+  printf 'ghtoken' > "$PROJECTS_DIR/private_dotfiles/api-key/github"
+  printf 'DEMO_TOKEN=github\n' > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  assert_equal "$DEMO_TOKEN" 'ghtoken'
+}
+
+@test "exports several tokens" {
+  printf 'a' > "$PROJECTS_DIR/private_dotfiles/api-key/one"
+  printf 'b' > "$PROJECTS_DIR/private_dotfiles/api-key/two"
+  printf 'ONE=one\nTWO=two\n' > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  assert_equal "$ONE" 'a'
+  assert_equal "$TWO" 'b'
+}
+
+@test "skips comment lines and lines without '='" {
+  printf 'tok' > "$PROJECTS_DIR/private_dotfiles/api-key/f"
+  printf '  # a comment\nnotamapping\nGOOD=f\n' \
+    > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  assert_equal "$GOOD" 'tok'
+}
+
+@test "skips a mapping whose token file is missing" {
+  printf 'MISSING=nofile\n' > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  assert_equal "${MISSING-UNSET}" 'UNSET'
+}
+
+@test "is a no-op when private_dotfiles is absent" {
+  rm -rf "$PROJECTS_DIR/private_dotfiles"
+  printf 'NOPE_TOKEN=github\n' > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  assert_equal "${NOPE_TOKEN-UNSET}" 'UNSET'
+}
+
+@test "is a no-op when the config file is absent" {
+  run source "$MODULE"
+  assert_success
+}
+
+@test "cleans up its temporary variables" {
+  printf 'tok' > "$PROJECTS_DIR/private_dotfiles/api-key/f"
+  printf 'GOOD=f\n' > "$PROJECTS_DIR/dotfiles/api-keys.cfg"
+  source "$MODULE"
+  for v in private_dotfiles config_file config_lines line filePath varName fileName; do
+    assert_equal "${!v-UNSET}" 'UNSET'
+  done
+}


### PR DESCRIPTION
## Summary
- **`tests/shell/test_000-loadtokens.bats`** (7 cases) — the one shell-startup
  module with real standalone logic: token loading from a `VAR=file` mapping,
  comment / no-`=` line skips, missing-token-file skip, no-op when
  `private_dotfiles` or the config is absent, and temp-var cleanup.
- **TODO fix:** `lib/docker_helpers` is *already* tested
  (`test_docker_helpers.bats`, 20 cases) — the cleanup note claiming it was
  untested was wrong. Corrected, and noted that the remaining shell-startup
  modules are guarded tool-setup already exercised by the docker integration
  tests (`test_integration_startup` + `test_integration_context`).

## Test plan
- [x] `bats tests/shell/test_000-loadtokens.bats` — 7 pass; shellcheck clean
- [x] full hand-written suite green (99)
- [ ] CI green