### PR TITLE
Cover bin/where (+ fix 2 bugs); login-slowdown TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -402,6 +402,25 @@ shell-init path per manager — XDG-aware where possible, lazy-loaded in
   under one consistent pattern, documented in each
   `config/shell-startup/<lang>` module.
 
+## 🐢 Login shell slowdown — 3–5s (was <2s) (HIGH PRIORITY)
+
+A new login shell now takes 3–5 seconds; it used to be under 2. Something added
+to startup regressed it — most likely a `config/shell-startup/` module shelling
+out (a version-manager/tool init, completion generation, a `command -v` probe
+that execs, or token loading) at every login.
+
+- [ ] **Profile it.** Time a clean login (`time bash -lic exit`), then find the
+  cost: bisect by disabling modules in `load_files`, or trace with
+  `PS4='+ $EPOCHREALTIME '; bash -lixc exit` (or wrap each module load in
+  `date +%s.%N` timing). Look for network/subprocess calls.
+- [ ] **Likely suspects:** recently-added modules (binenv, nodejs/go/ruby/rust
+  env init, cuda, claude, aider), per-prompt `bin/git-status`, or a slow
+  `000-loadtokens` path.
+- [ ] **Fix:** lazy-load the offender (defer to first use), cache its output, or
+  guard it; re-measure to confirm back under ~2s. Ties into the
+  config/shell-startup audit ("cut per-startup cost") and the Tool/Version
+  Manager Setup (lazy-load) items below.
+
 ## 🔍 config/shell-startup Audit (MEDIUM PRIORITY)
 
 Review all files in `config/shell-startup/` for correctness and security:
@@ -555,8 +574,12 @@ git-status, hr, mymcp, parse_params, perltidyrc-clean, yesno, **duration**
 
 **Unit-testable (pure logic) — to do:**
 
-- [ ] `where` — locate/classify commands.
-- [ ] `showvars` — print selected shell variables.
+- [x] `where` — `tests/shell/test_where.bats` (keyword/builtin/file/not-found).
+  Surfaced + fixed two bugs: a missing command hit the "Unexpected type"
+  branch (modern `type -t` prints nothing for unknowns), and it exited 1 even
+  on success.
+- [ ] (reclassified to integration) `showvars` — needs `shfmt` (docker
+  wrapper) + `jq`; covered under the integration group, not pure-unit.
 - [ ] `creds-helper` — credential lookup; pair with the known PAT-fallback bug
   fix (its own section) so the fix lands with a regression test.
 - [ ] `available-subnets` — Python subnet math; belongs in `tests/python/`

--- a/bin/where
+++ b/bin/where
@@ -20,10 +20,11 @@ function where() {
     cmd="$1"
     shift
 
-    cmd_type=$(type -t "$cmd" 2>&1)
+    cmd_type=$(type -t "$cmd" 2> /dev/null)
 
-    [[ $cmd_type == *not\ found* ]] && {
-      printf '%s is not found' "$cmd"
+    # `type -t` prints nothing (and exits non-zero) for an unknown command.
+    [[ -z $cmd_type ]] && {
+      printf '%s is not found\n' "$cmd"
       continue
     }
 
@@ -84,6 +85,8 @@ function where() {
     shopt -u extglob
     TOGGLE_extglob=
   }
+
+  return 0
 }
 
 where "$@"

--- a/tests/shell/test_where.bats
+++ b/tests/shell/test_where.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Tests for bin/where — classify how each command name resolves
+# (keyword / builtin / file+path / not found). The function and alias paths
+# need a live shell environment and aren't exercised here.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  WHERE="$(dotfiles_root)/bin/where"
+}
+
+@test "where reports a shell keyword" {
+  run "$WHERE" if
+  assert_success
+  assert_output --partial 'if:keyword'
+}
+
+@test "where reports a builtin" {
+  run "$WHERE" cd
+  assert_output --partial 'cd:builtin'
+}
+
+@test "where reports a file command with its path" {
+  run "$WHERE" ls
+  assert_output --regexp '^ls:file:/'
+}
+
+@test "where reports a missing command" {
+  run "$WHERE" __no_such_cmd_xyz__
+  assert_output --partial 'is not found'
+}
+
+@test "where handles several commands at once" {
+  run "$WHERE" if cd
+  assert_output --partial 'if:keyword'
+  assert_output --partial 'cd:builtin'
+}


### PR DESCRIPTION
## Summary
- **`tests/shell/test_where.bats`** — keyword / builtin / file+path / not-found
  classification.
- **Fixed two bugs in `bin/where`** the test surfaced:
  - a missing command fell through to the "Unexpected command type" branch
    because modern `type -t` prints *nothing* (not "not found") for unknowns —
    now detects empty output;
  - the function exited `1` even on success (trailing `&&`) — added `return 0`.
- **TODO:** HIGH-priority item to investigate the new **login-shell slowdown**
  (3–5s, was <2s) — profile startup, find the offending module, lazy-load/cache.
  Marked `where` done in the coverage audit; reclassified `showvars` as
  integration (needs shfmt + jq).

## Test plan
- [x] `where` tests pass; `bin/where` shfmt + shellcheck clean
- [x] full hand-written bats suite green
- [ ] CI green