### PR TITLE
Fix creds-helper PAT fallback + add tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -205,18 +205,18 @@ creating the symlinks.
 - [ ] Decide dotvim's expected location (sibling clone under `$PROJECTS_DIR`
   per the repo conventions) and reference it consistently.
 
-## 🐛 bin/creds-helper PAT fallback bug (MEDIUM PRIORITY)
+## ✅ bin/creds-helper PAT fallback bug (DONE 2026-06-07)
 
-Found during the lint cleanup (not a lint error, so left unfixed there).
-When the credential isn't found in `~/.netrc`, `bin/creds-helper` checks
-`$PROJECTS_DIR/private_dotfiles/api-key/github` for existence but then reads
-a **different** variable, `$PAT_FILE` (unset) — so it tries `< ""` and errors
-(`No such file or directory`) instead of using the PAT.
+When the credential wasn't found in `~/.netrc`, `creds-helper` checked
+`$PROJECTS_DIR/private_dotfiles/api-key/github` but then read a **different**,
+unset `$PAT_FILE` (`< ""` → error) instead of the PAT.
 
-- [ ] Reconcile the check and the read: either read the file it checked
-  (`$PROJECTS_DIR/private_dotfiles/api-key/github`) or define/point `$PAT_FILE`
-  at it, and guard against an empty/unset path.
-- [ ] Add a bats test covering the .netrc-miss → PAT-fallback path.
+- [x] Read the file it checked (via a single `pat_file` variable).
+- [x] Also made it exit 0 when it has no credential (a helper shouldn't fail
+  just because it has no answer).
+- [x] `tests/shell/test_creds-helper.bats` — netrc hit, netrc-miss → PAT
+  fallback (the regression), netrc-wins precedence, and the no-credential
+  no-op.
 
 ## 📐 Retire global ~/.markdownlintrc — per-repo configs (MEDIUM PRIORITY)
 
@@ -580,8 +580,8 @@ git-status, hr, mymcp, parse_params, perltidyrc-clean, yesno, **duration**
   on success.
 - [ ] (reclassified to integration) `showvars` — needs `shfmt` (docker
   wrapper) + `jq`; covered under the integration group, not pure-unit.
-- [ ] `creds-helper` — credential lookup; pair with the known PAT-fallback bug
-  fix (its own section) so the fix lands with a regression test.
+- [x] `creds-helper` — `tests/shell/test_creds-helper.bats`; landed with the
+  PAT-fallback bug fix (see its section above).
 - [x] `available-subnets` — **removed** (obsolete: old GCP-subnet tooling no
   longer used); archived to `archive/bin/`. No test needed.
 - [ ] (marginal) `loadavg` (output depends on real load), `dateh` (date-format

--- a/bin/creds-helper
+++ b/bin/creds-helper
@@ -31,10 +31,15 @@ done
   found && $1 == "password" {print $2; exit}
 ' ~/.netrc)"
 
-# If not found in .netrc, check the PAT file
+# If not found in .netrc, fall back to the PAT file.
+pat_file="$PROJECTS_DIR/private_dotfiles/api-key/github"
 [[ -z $GIT_CREDENTIALS ]] \
-  && [[ -r $PROJECTS_DIR/private_dotfiles/api-key/github ]] \
-  && GIT_CREDENTIALS=$(< "$PAT_FILE")
+  && [[ -r $pat_file ]] \
+  && GIT_CREDENTIALS=$(< "$pat_file")
 
-# Output the password if found, otherwise let Git prompt for credentials
-[[ -n $GIT_CREDENTIALS ]] && echo "password=$GIT_CREDENTIALS"
+# Output the password if found; otherwise emit nothing and still exit cleanly
+# so Git moves on to prompt (a credential helper shouldn't fail just because it
+# has no answer).
+if [[ -n $GIT_CREDENTIALS ]]; then
+  echo "password=$GIT_CREDENTIALS"
+fi

--- a/tests/shell/test_creds-helper.bats
+++ b/tests/shell/test_creds-helper.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+# Tests for bin/creds-helper — a git credential helper: emit "password=..."
+# from ~/.netrc for the requested host, falling back to the
+# $PROJECTS_DIR/private_dotfiles/api-key/github PAT file.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  CREDS="$(dotfiles_root)/bin/creds-helper"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export PROJECTS_DIR="$BATS_TEST_TMPDIR/projects"
+  mkdir -p "$HOME" "$PROJECTS_DIR/private_dotfiles/api-key"
+}
+
+@test "emits the .netrc password for the host" {
+  printf 'machine github.com\n  login me\n  password netrcsecret\n' \
+    > "$HOME/.netrc"
+  run "$CREDS" <<< "host=github.com"
+  assert_success
+  assert_output 'password=netrcsecret'
+}
+
+@test "falls back to the PAT file when .netrc has no match" {
+  # No ~/.netrc; the PAT file should be used (regression: it used to read an
+  # unset $PAT_FILE and error instead of this file).
+  printf 'pattoken' > "$PROJECTS_DIR/private_dotfiles/api-key/github"
+  run "$CREDS" <<< "host=github.com"
+  assert_success
+  assert_output 'password=pattoken'
+}
+
+@test ".netrc wins over the PAT file" {
+  printf 'machine github.com\n  password netrcsecret\n' > "$HOME/.netrc"
+  printf 'pattoken' > "$PROJECTS_DIR/private_dotfiles/api-key/github"
+  run "$CREDS" <<< "host=github.com"
+  assert_output 'password=netrcsecret'
+}
+
+@test "emits nothing when neither source has the credential" {
+  run "$CREDS" <<< "host=github.com"
+  assert_success
+  assert_output ''
+}


### PR DESCRIPTION
## Summary
- **Bug fix:** on a `~/.netrc` miss, `creds-helper` checked
  `$PROJECTS_DIR/private_dotfiles/api-key/github` for readability but then read
  an **unset `$PAT_FILE`** (`< ""` → error) instead of that file. Now reads the
  file it checked (single `pat_file` var).
- Also **exit 0 when no credential is found** — a git credential helper
  shouldn't fail just because it has no answer (the trailing `&&` left a
  non-zero exit).
- **`tests/shell/test_creds-helper.bats`** — netrc hit, netrc-miss → PAT
  fallback (the regression), netrc-wins precedence, no-credential no-op.

## Test plan
- [x] 4 tests pass; `bin/creds-helper` shfmt + shellcheck clean
- [x] full hand-written bats suite green
- [ ] CI green