### PR TITLE
Fix git-all (3 set -e/-u bugs) + add tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -592,8 +592,12 @@ git-status, hr, mymcp, parse_params, perltidyrc-clean, yesno, **duration**
 - [x] `git-branch-clean` — `tests/shell/test_git-branch-clean.bats` (guards +
   gone-upstream dry-run/force/never-pushed, against a throwaway repo with a
   local bare remote).
-- [ ] `git-all` — runs git over every repo under `$REPOHOME` (needs a temp
-  `REPOHOME` with a couple of repos).
+- [x] `git-all` — `tests/shell/test_git-all.bats` (usage/REPOHOME/option
+  guards, run-across-repos summary, `-S` dirty-only). The test exposed that
+  git-all was **completely broken** under `set -euo pipefail` (three cascading
+  bugs, all masked by the first) — all fixed: the `read -d '' < <(find)` abort
+  (→ `mapfile -t`), the `grep && printf` abort on a clean repo (→ `if`), and
+  empty-array expansion under `set -u` (→ `declare -a fail=()` etc.).
 - [ ] `proj` — project switch (cd / filesystem).
 - [ ] `ansi` — tput wrapper (the TERM-unset path is already covered by
   `test_integration_context`); a focused unit test could assert sequence

--- a/bin/git-all
+++ b/bin/git-all
@@ -20,9 +20,11 @@ REPOHOME=${REPOHOME:-$HOME}
 VERBOSE=0
 
 count=0
-declare -a fail
-declare -a pass
-declare -A output
+# Initialize as empty (not just declared): under `set -u`, expanding a declared
+# but never-assigned array (`"${fail[@]}"`) is an "unbound variable" error.
+declare -a fail=()
+declare -a pass=()
+declare -A output=()
 
 print_error() {
   local msg=$1
@@ -69,7 +71,8 @@ breadlink() {
 
 do_all_action() {
   local repo resolved
-  IFS=$'\n' read -r -d $'\0' -a repos < <(find "$REPOHOME" -type d -name '.git' 2> /dev/null)
+  local -a repos
+  mapfile -t repos < <(find "$REPOHOME" -type d -name '.git' 2> /dev/null)
 
   for repo in "${repos[@]}"; do
     ((++count))
@@ -81,12 +84,17 @@ do_all_action() {
 
 stat_repos() {
   local repo resolved
-  IFS=$'\n' read -r -d $'\0' -a repos < <(find "$REPOHOME" -type d -name '.git' 2> /dev/null)
+  local -a repos
+  mapfile -t repos < <(find "$REPOHOME" -type d -name '.git' 2> /dev/null)
 
   for repo in "${repos[@]}"; do
     resolved=$(breadlink "${repo%.git}")
     cd "$resolved"
-    git status -s | grep -qv "^??" && printf "%s\n" "$resolved"
+    # A clean repo makes `grep -qv` exit 1; an `if` keeps that from tripping
+    # `set -e`. Lists repos with any tracked (non-`??`) change.
+    if git status -s | grep -qv "^??"; then
+      printf "%s\n" "$resolved"
+    fi
   done
 }
 

--- a/tests/shell/test_git-all.bats
+++ b/tests/shell/test_git-all.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+# Tests for bin/git-all — run a git command across every repo under $REPOHOME,
+# summarize pass/fail, and (-S) list repos with uncommitted changes. Exercised
+# against a throwaway $REPOHOME holding a couple of real repos.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  GA="$(dotfiles_root)/bin/git-all"
+  PATH="$(dotfiles_root)/bin:$PATH"   # git-all uses ansi
+  export TERM=dumb                    # keep ansi from emitting color
+  export REPOHOME="$BATS_TEST_TMPDIR/repos"
+  mkdir -p "$REPOHOME"
+}
+
+make_repo() {
+  local d="$REPOHOME/$1"
+  git init -q "$d"
+  git -C "$d" config user.email t@example.com
+  git -C "$d" config user.name test
+  git -C "$d" commit --allow-empty -q -m init
+}
+
+@test "no command prints usage and exits 1" {
+  run "$GA"
+  assert_failure
+  assert_output --partial 'Run git commands on all repositories'
+}
+
+@test "an invalid REPOHOME is rejected" {
+  REPOHOME=/no/such/dir run "$GA" status
+  assert_failure
+  assert_output --partial 'Invalid'
+}
+
+@test "an unknown option is rejected" {
+  run "$GA" -x
+  assert_failure
+  assert_output --partial 'invalid option'
+}
+
+@test "runs a git command across all repos and summarizes" {
+  make_repo one
+  make_repo two
+  run "$GA" rev-parse --abbrev-ref HEAD
+  assert_success
+  assert_output --partial 'Job Summary For 2 Repos'
+  assert_output --partial 'PASS'
+  assert_output --partial 'one'
+  assert_output --partial 'two'
+}
+
+@test "-S lists only repos with uncommitted changes" {
+  make_repo dirty
+  printf 'x\n' > "$REPOHOME/dirty/tracked"
+  git -C "$REPOHOME/dirty" add tracked
+  git -C "$REPOHOME/dirty" commit -q -m add
+  printf 'more\n' >> "$REPOHOME/dirty/tracked"   # uncommitted modification
+  make_repo clean
+  run "$GA" -S
+  assert_success
+  assert_output --partial 'dirty'
+  refute_output --partial '/clean'
+}


### PR DESCRIPTION
## Summary
Writing tests for `git-all` revealed it was **completely broken** under
`set -euo pipefail` — no output, exit 1 for any command. Three cascading bugs,
each masked by the previous, now fixed:

1. `read -d $'\0' -a repos < <(find …)` returns non-zero at EOF (find emits no
   NUL) → `set -e` aborted before the loop. Switched to `mapfile -t`.
2. `git status -s | grep -qv "^??" && printf` returns non-zero on a **clean**
   repo, aborting the `-S` loop. Wrapped in an `if`.
3. `declare -a fail` (declared but never assigned) is "unbound" for
   `"${fail[@]}"` under `set -u`. Initialized `fail=() pass=() output=()`.

`tests/shell/test_git-all.bats`: guards (usage / bad REPOHOME / bad option),
run-across-repos summary, and `-S` dirty-only listing.

## Test plan
- [x] 5 tests pass; `bin/git-all` shfmt + shellcheck clean
- [x] full hand-written bats suite green
- [ ] CI green