### PR TITLE
perf: prompt colors at load + fix/improve debug profiling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -396,58 +396,53 @@ shell-init path per manager — XDG-aware where possible, lazy-loaded in
   under one consistent pattern, documented in each
   `config/shell-startup/<lang>` module.
 
-## 🐢 Login shell slowdown — 3–5s (was <2s) (HIGH PRIORITY)
+## 🐢 Login shell slowdown — RESOLVED (~1.1s, was 5.8–7.25s)
 
-A new login shell now takes 3–5 seconds; it used to be under 2. Profiled with
-`PS4='+ ${EPOCHREALTIME} ...' bash -lixc exit` and attributed per-command.
+A login shell had regressed to 3–5s (peaks ~7s). Fixed by the cleanpath +
+`havecmd` work; now a stable **~1.05–1.15s**, under the original <2s baseline.
 
-- [x] **Profile it.** Done. Top costs (one login, WSL — times vary with /mnt/c
-  latency): `.grok/completions/bash/grok.bash` **1.54s**, `nvm.sh` (`manpath`)
-  **0.95s**, `bin/cleanpath PATH` **was ~1.5s, now 0.38s** (parallelized — see
-  below), then a long tail of `command -v` probes at **~0.25–0.32s each** (15+
-  of them). The probe tail is systemic: every `command -v` scans all of PATH,
-  and PATH carries ~53 slow-to-stat `/mnt/c` (Windows) entries.
-- [x] **cleanpath** — parallelized its per-entry `readlink` resolution with
-  `xargs -P "$(nproc)"` (sequential fallback where `xargs -P` is unavailable;
-  GNU `parallel` benchmarked **slower** here — 2.89s vs xargs 0.36s — so not
-  used). Output verified identical to the old sequential version; resolve +
-  prune-nonexistent + FIRST/LAST/STRIP/IGNORE semantics unchanged. ~1.1s saved.
-- [x] **`command -v` probe tail** — fixed. Added `havecmd` to `shell-startup`:
-  a `command -v` wrapper that drops the `/mnt/c` (Windows-interop) PATH entries
-  for the duration of one lookup, then restores PATH. Converted every
-  boolean-guard probe in `config/shell-startup/*` (and `tmux`'s `which ta`) to
-  `havecmd`; the two genuine path-captures (`vault`, `which cpanm`) were left on
-  `command -v`/`which`. The prompt probes on every render, after `havecmd` is
-  unset, so its logic moved to `lib/bash_prompt` and the
-  `config/shell-startup/bash_prompt` wrapper caches `pstree`/`pacman-status`
-  detection (`_HAS_PSTREE`/`_HAS_PACMAN_STATUS`) at load time; `loadavg`
-  (`bin/loadavg`) is called unconditionally. Tested in
-  `tests/shell/test_havecmd.bats`.
-- [ ] **nvm (0.95s)** — lazy-load (defer `nvm.sh` to first `nvm`/`node`/`npm`
-  use). Ties into the Tool/Version Manager Setup (lazy-load) item below.
-- [ ] **grok** — see the dedicated **grok** section below (1.54s completion +
-  installer-block relocation).
-- [x] **Re-measure** — login dropped from 5.8–7.25s to **2.2–2.4s** after
-  cleanpath + `havecmd`. The remaining ~2.2s is dominated by grok (1.54s) and
-  nvm (0.95s); finishing those two should bring it back under ~2s.
+**Profiling caveat (important).** Both `bash -lixc` (xtrace) **and** `DEBUG=1`
+*inflate* any module that runs many lines or calls `debug()` internally
+(`check-dotfiles`, `cleanpath`). Several early "findings" were measurement
+artifacts — grok 1.54s / nvm 0.95s / check-dotfiles 220ms / less-probe 67ms
+all evaporated when measured directly (real: ~0.01s / ~0s / ~25ms / ~0s).
+**Measure a suspect module directly (non-DEBUG) before optimizing it.**
+`lib/debug` now prints a `+Nms` delta for per-step timing, but only trust it
+for modules that don't themselves call `debug`.
 
-## 🤖 grok (MEDIUM PRIORITY)
+- [x] **cleanpath** — parallelized per-entry `readlink` with `xargs -P`
+  (sequential fallback; GNU `parallel` benchmarked *slower* for many tiny
+  jobs). Real cost ~145ms: the largest single login cost, already optimized —
+  only a rewrite (e.g. perl) would help further.
+- [x] **`command -v` probe tail** — added `havecmd` (a `command -v` wrapper
+  that drops `/mnt/c` for one lookup, then restores PATH) and converted every
+  boolean-guard probe in `config/shell-startup/*`. The biggest real win.
+- [x] **bash_prompt** — the prompt called `ansi` (a subprocess) on *every*
+  render for constant colors; moved all color computation to load time in the
+  `config/shell-startup/bash_prompt` wrapper so rendering spawns no `ansi`
+  (~16ms/render). `_HAS_PSTREE`/`_HAS_PACMAN_STATUS` cached at load; `loadavg`
+  (bin) called unconditionally. Tested via `tests/shell/test_havecmd.bats` +
+  manual render checks.
+- [x] **debug wiring** — `shell-startup` and `check-dotfiles` sourced the
+  nonexistent `bin/debug` (the lib moved to `lib/debug`), so `DEBUG=1` did
+  nothing; pointed both at `lib/debug`, guarded on `DEBUG`.
+- **Left alone (accepted costs):**
+  - **`git-status` ~99ms/render** — does necessary work for the git-aware
+    prompt; only async/caching would cut it, not worth the complexity.
+  - **grok / nvm** — not real costs (xtrace artifacts); no lazy-load needed.
 
-All grok-related startup work, collected here.
+## 🤖 grok (LOW PRIORITY)
 
-- [ ] **grok.bash completion is the #1 login cost (1.54s).** Profiled at
-  `~/.grok/completions/bash/grok.bash`. Check whether it shells out /
-  regenerates on every login; lazy-load it (defer until first `grok` use) or
-  cache the generated completion. Biggest remaining slowdown item (see the
-  Login shell slowdown section above).
+> **Not a performance item.** Sourcing `grok.bash` is ~0.01s; the "1.54s" in
+> the original profile was an xtrace artifact (tracing its 4,545-line
+> completion function). This is now purely a cleanliness item.
+
 - [ ] **Move the grok installer block out of `shell-startup`.** The
   `>>> grok installer >>>` block (PATH + completion) at the end of
   `shell-startup` runs *after* Cleanup and isn't a pre-load global — move it to
   a `config/shell-startup/grok` module (guarded like the others). First decide
   how to stop the grok installer re-appending it to `shell-startup` (retarget
-  it, or accept periodic cleanup). *[needs thought]* Doing this and the
-  lazy-load together is natural: the new module is where the deferred-load
-  guard would live.
+  it, or accept periodic cleanup). *[needs thought]*
 
 ## 🔍 config/shell-startup Audit (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -503,6 +503,7 @@ Known offenders to investigate (as of 2026-05-20):
 | `~/.docker` | Docker | `DOCKER_CONFIG` — already set in `010-general` but dir still in `$HOME` |
 | `~/.gradle` | Gradle | `GRADLE_USER_HOME` env var |
 | `~/.gradle-mcp` | gradle-mcp | likely follows `GRADLE_USER_HOME` or its own config |
+| `~/.grok` | grok (xAI CLI) | check XDG / config-dir support; also relocate the installer block out of `shell-startup` (see the **grok** section) |
 | `~/.java` | Java/JVM | `java.util.prefs.userRoot` system property |
 | `~/.jbang` | jbang | `JBANG_DIR` env var |
 | `~/.kivy` | Kivy | `KIVY_HOME` env var |

--- a/bin/check-dotfiles
+++ b/bin/check-dotfiles
@@ -9,7 +9,12 @@
 [[ -z $DOTFILES ]] && exit 0
 cd "$HOME" || return 0
 
-source "$DOTFILES/lib/debug"
+# Only pay for lib/debug (sourcing it + its per-call stack walk) when DEBUG is
+# set; otherwise debug() is a cheap no-op. Mirrors shell-startup's wiring.
+debug() { true; }
+[[ -n ${DEBUG:-} ]] \
+  && [[ -f "$DOTFILES/lib/debug" ]] \
+  && source "$DOTFILES/lib/debug"
 
 #-----------------------------------------------------------------------------
 check_link() {

--- a/config/shell-startup/bash_prompt
+++ b/config/shell-startup/bash_prompt
@@ -1,14 +1,34 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2034  # the flag/color vars below are read by lib/bash_prompt
 
-# Wrapper for the prompt library (lib/bash_prompt). The prompt functions run
-# on every render — after startup has unset havecmd — so probe for the optional
-# tools once here (while havecmd is still defined) and cache the result. The
-# library reads these flags instead of probing.
+# Wrapper for the prompt library (lib/bash_prompt). The prompt is
+# interactive-only and its functions run on every render, so all one-time work
+# happens here at load time and the library only references the results:
+#   - havecmd is unset before the prompt renders, so cache pstree/pacman-status
+#     detection now (_HAS_*).
+#   - compute every (constant) prompt color once here instead of calling ansi
+#     inside _exit_status/_venv on every render — a faster prompt.
 
-# shellcheck disable=SC2034  # read by lib/bash_prompt at prompt-render time
+[[ $- == *i* ]] || return 0
+
 havecmd pstree && _HAS_PSTREE=1
-# shellcheck disable=SC2034  # read by lib/bash_prompt at prompt-render time
 havecmd pacman-status && _HAS_PACMAN_STATUS=1
+
+# Base prompt colors.
+export atsign_color color_off hostname_color nonroot_color prompt_color root_color
+atsign_color="$(ansi -n fg bright_black)"
+color_off="$(ansi -n off)"
+hostname_color="$(ansi -n fg yellow)"
+nonroot_color="$(ansi -n fg bright_cyan)"
+prompt_color="$(ansi -n fg cyan)"
+root_color="$(ansi -n fg bright_red)"
+
+# Colors that _exit_status / _venv used to recompute on every render.
+exit_good_color="$(ansi -n bg blue fg yellow)"
+exit_bad_color="$(ansi -n bg red fg white)"
+venv_poetry_color="$(ansi -n fg bright_purple)"
+venv_ok_color="$(ansi -n fg bright_green)"
+venv_bad_color="$(ansi -n fg red)"
 
 # shellcheck disable=SC1091  # sourced library, resolved at runtime
 source "$DOTFILES/lib/bash_prompt"

--- a/lib/bash_prompt
+++ b/lib/bash_prompt
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2154  # prompt color vars are assigned by the config/shell-startup/bash_prompt wrapper that sources this file
 
 # Ideas ripped off and made to fit from:
 #   http://wiki.archlinux.org/index.php/Color_Bash_Prompt
@@ -15,15 +16,10 @@
 }
 
 #----------------------------------------------------------------------------
-export atsign_color color_off hostname_color nonroot_color prompt_color
-export root_color
-
-atsign_color="$(ansi -n fg bright_black)"
-color_off="$(ansi -n off)"
-hostname_color="$(ansi -n fg yellow)"
-nonroot_color="$(ansi -n fg bright_cyan)"
-prompt_color="$(ansi -n fg cyan)"
-root_color="$(ansi -n fg bright_red)"
+# All prompt colors are computed once by the config/shell-startup/bash_prompt
+# wrapper (atsign_color, color_off, hostname_color, nonroot_color,
+# prompt_color, root_color, plus the exit_*/venv_* colors used below), so the
+# per-render functions never spawn ansi.
 
 # Array of Unicode characters to rotate through for non-root prompt
 # Use show-unicode to see what symbols are available on your current terminal.
@@ -90,11 +86,6 @@ parent=$(_parent)
 function _exit_status() {
   local -a status
 
-  local color_bad color_good
-
-  color_bad="$(ansi -n bg red fg white)"
-  color_good="$(ansi -n bg blue fg yellow)"
-
   for s in "$@"; do
 
     # Wrap the exit symbols in appropriate ansi codes.
@@ -107,8 +98,8 @@ function _exit_status() {
     # doesn't throw an appropriate exit status.
 
     case "$s" in
-      0 | 141) status+="$color_good $s $color_off" ;;
-      *) status+="$color_bad $s $color_off" ;;
+      0 | 141) status+="$exit_good_color $s $color_off" ;;
+      *) status+="$exit_bad_color $s $color_off" ;;
     esac
   done
 
@@ -130,16 +121,16 @@ _venv() {
   if [[ -n $POETRY_ACTIVE ]]; then
     # XXX: Figure out a way to detect true hostname directory
     #      Look into setting virtualenvs.in-project with poetry config
-    color="$(ansi -n fg bright_purple)"
+    color=$venv_poetry_color
     dir="poetry venv"
 
   else
     # XXX: If manually starting a poetry venv, this will be permanently red
-    color="$(ansi -n fg bright_green)"
+    color=$venv_ok_color
     dir="venv"
 
     if [[ ! $curpwd =~ ^${VIRTUAL_ENV%/*} ]]; then
-      color="$(ansi -n fg red)"
+      color=$venv_bad_color
       dir="venv: ${VIRTUAL_ENV%/*}"
     fi
   fi

--- a/lib/debug
+++ b/lib/debug
@@ -46,6 +46,14 @@ POD
 debug() {
   ((DEBUG)) || return 0
 
+  # Milliseconds elapsed since the previous debug call — cheap profiling with
+  # no subprocess (integer math on EPOCHREALTIME's microseconds). The first
+  # call shows +0ms and seeds the baseline.
+  local now_us=${EPOCHREALTIME/./}
+  local -i delta_ms=0
+  [[ -n ${_DBG_LAST_US:-} ]] && delta_ms=$(((now_us - _DBG_LAST_US) / 1000))
+  _DBG_LAST_US=$now_us
+
   local -a msg
 
   # Read either debug "message" or "command | debug"
@@ -99,7 +107,7 @@ debug() {
     trace+="${el[ix]}"
   done
 
-  printf -v pfx '[%s%s]%s ' "$interactive" "$loginshell" "$trace"
+  printf -v pfx '[%s%s+%dms]%s ' "$interactive" "$loginshell" "$delta_ms" "$trace"
   printf "$pfx%s\n" "${msg[@]}" >&2
 }
 

--- a/shell-startup
+++ b/shell-startup
@@ -79,10 +79,12 @@ export LC_ALL=en_US.UTF-8
 
 debug() { true; }
 [[ -n "${DEBUG:-}" ]] \
-  && [[ -f "$DOTFILES/bin/debug" ]] \
-  && source "$DOTFILES/bin/debug"
+  && [[ -f "$DOTFILES/lib/debug" ]] \
+  && source "$DOTFILES/lib/debug"
 
 unsetfuncs 'debug'
+
+debug "startup begin" # PROFILE
 
 #-----------------------------------------------------------------------------
 # Add a path to the PATH variable.
@@ -223,6 +225,7 @@ load_files() {
     for f in "${load_files[@]}"; do
       # shellcheck disable=SC1090
       [[ -r $f ]] && source "$f"
+      debug "loaded ${f##*/}" # PROFILE
     done
   done
 }
@@ -235,7 +238,9 @@ unsetvars 'load_files'
 
 #-----------------------------------------------------------------------------
 set_bin_dirs
+debug "after set_bin_dirs" # PROFILE
 load_files
+debug "after load_files" # PROFILE
 
 #-----------------------------------------------------------------------------
 # De-duplicate PATH and drop nonexistent entries. Guarded: only replace PATH
@@ -246,6 +251,7 @@ if _cleaned_path=$("$DOTFILES/bin/cleanpath" PATH 2> /dev/null) \
   export PATH="$_cleaned_path"
 fi
 unset _cleaned_path
+debug "after cleanpath" # PROFILE
 
 ##############################################################################
 # Cleanup


### PR DESCRIPTION
## Summary
- **bash_prompt:** `_exit_status`/`_venv` called `ansi` (a subprocess) on *every* prompt render for constant colors. All colors are now computed once at load time in the `config/shell-startup/bash_prompt` wrapper; rendering spawns no `ansi` (~16ms/render saved, no login regression).
- **debug wiring fix:** `shell-startup` and `check-dotfiles` sourced `$DOTFILES/bin/debug`, which no longer exists (lib moved to `lib/debug`) — so `DEBUG=1` did nothing and `debug()` stayed a no-op. Both now point at `lib/debug`; `check-dotfiles` guards it on `DEBUG` instead of sourcing unconditionally.
- **debug profiling:** added a `+Nms` per-call delta (integer math on `EPOCHREALTIME`, no subprocess) + per-module `debug` calls in `load_files`, for honest subprocess-free timing.
- **TODO:** recorded the corrected login picture (~1.1s, down from 5.8–7.25s) and the key caveat — *both* xtrace and `DEBUG=1` inflate modules that call `debug()` internally, so several earlier "costs" (grok/nvm/check-dotfiles/less-probe) were measurement artifacts. `git-status` (~99ms/render) and `cleanpath` (~145ms) are the real remaining costs, both left as-is by decision.

## Test plan
- [x] Full gate suite `bats tests/shell/test_*.bats` — 146/146 pass
- [x] Prompt renders correctly (colors present, no `ansi`/not-found errors); no `ansi` calls remain in the per-render functions
- [x] `DEBUG=1 bash -lic exit` emits timestamped per-module output (debug wiring works)
- [x] check-dotfiles real cost unchanged (~0.02s); no longer loads lib/debug unless `DEBUG` set
- [x] Login time unchanged (~1.15s with and without these changes)
- [x] pre-commit clean (shellcheck, shfmt, markdownlint, secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)