### PR TITLE
Treat generated changelog regen as a pre-PR QA prep step

### DIFF
--- a/config/claude/rules/qa.md
+++ b/config/claude/rules/qa.md
@@ -1,6 +1,6 @@
 # Quality Assurance Rules
 
-**Version:** v2.5.0
+**Version:** v2.6.0
 
 QA is the full pipeline that takes a change from "written" to
 "release-ready." This rule is **language- and tool-agnostic**: it defines the
@@ -65,11 +65,16 @@ skip silently.
 12. **Build** — the artifact actually compiles/bundles, and images build
     (the **containerize** skill) when containers change. Note size deltas.
 13. **Documentation** — the change's docs are **current** and **accurate**:
-    user-facing docs (README/usage/API), in-repo planning (a `TODO` /
-    roadmap), and the governing rules/skills it affects (global *and* local)
-    are updated; prose is linted (e.g. a Markdown linter) with no stale or
-    broken references. A change that alters behaviour but not its docs is
-    incomplete.
+    user-facing docs (README/usage/API, **changelog**), in-repo planning (a
+    `TODO` / roadmap), and the governing rules/skills it affects (global
+    *and* local) are updated; prose is linted (e.g. a Markdown linter) with
+    no stale or broken references. A change that alters behaviour but not its
+    docs is incomplete. When a repo's **changelog is generated** (from git
+    history or commit metadata), regenerating it **mutates the tree**, so it
+    is a **prep step in the same class as Format** (dimension 1) — run it
+    once just before opening the PR and **commit the result**; never in CI,
+    which gates and must not commit. The concrete command lives in the
+    repo's QA doc.
 14. **Code review** — human peer review of the change. A gate, not a tool;
     state whether/how it is required (e.g. PR approvals) or, for a solo repo,
     that it is informal.

--- a/config/claude/skills/qa-check/SKILL.md
+++ b/config/claude/skills/qa-check/SKILL.md
@@ -5,7 +5,7 @@ description: Run the full quality-assurance pipeline on a change (format, lint, 
 
 # QA Check
 
-**Version:** v2.2.0
+**Version:** v2.3.0
 
 Run the quality-assurance pipeline for **this** repo and route every stage
 through its rule. QA spans many tools that are individually easy to forget;
@@ -53,6 +53,10 @@ Only the qa-check-specific operational notes (the rest is in `qa.md`):
 
 - **Format** is the one auto-fix stage — run it once (the fix config), then
   the check-only pass; never fix-and-recommit per failure.
+- **Documentation prep (generated changelog)** — if the repo's QA doc lists a
+  changelog-regeneration command (a generate-then-commit prep action, same
+  mutating class as Format), run it once when preparing the PR and commit the
+  result; never in CI. Get the concrete command from the repo's QA doc.
 - **Pre-commit hook coverage** — when the repo uses pre-commit, audit its
   config against the *Recommended Cross-Cutting Hooks* in `pre-commit.md`
   (secret detection, large-file / merge-conflict / case-conflict guards,


### PR DESCRIPTION
## Summary
- `qa.md` (Documentation dimension): name **changelog** as user-facing doc, and state that when a changelog is *generated*, regenerating it **mutates the tree** — so it's a **prep step in the same class as Format**: run once before opening the PR and commit the result, **never in CI**. Concrete command stays in each repo's QA doc.
- `qa-check` skill: parallel operational note so the skill runs the changelog regen as the Documentation prep action at PR time.
- Version bumps: `qa.md` v2.5.0 → v2.6.0; qa-check v2.2.0 → v2.3.0.

Motivated by pigify, whose `npm run generate:changelog` had drifted because there was no documented home for "regenerate before the PR." The generic discipline lives here; the pigify-specific command lives in pigify's `.claude/` docs.

## Test plan
- [ ] markdownlint passes (pre-commit)
- [ ] Prose wraps at 78 cols