### PR TITLE
feat(bin): add findword Wordle solver, converting the shell function

### DIFF
--- a/bin/findword
+++ b/bin/findword
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# findword - a Wordle solver/cheat over the system dictionary.
+#
+# Builds a per-position character-class regex from the supplied constraints,
+# greps the dictionary, then ranks the matches by distinct-vowel richness (a
+# decent opener heuristic) and shows the 100 richest, laid out in columns.
+#
+# Replaces the old `findword` shell function in config/shell-startup/010-general
+# (which only took a raw regex). Argument handling is driven by parse_params.
+#
+# Parameters (the per-position flags are length-dependent and generated from
+# -l, so a 5-letter word exposes --pos1..--pos5 and --not_pos1..--not_pos5):
+#
+#   -l, --length N       word length (default 5)
+#   -x, --exclude STR    letters that do not appear anywhere in the word
+#   -i, --include STR    letters that appear, position unknown
+#       --posN C         position N is exactly letter C (overrides --exclude
+#                        there; any --not_posN for that position is ignored)
+#       --not_posN STR   letters that are invalid at position N
+#
+# Deliberately no `set -euo pipefail` (bash.md's default): an over-constrained
+# query legitimately matches nothing, and pipefail/-e would turn that valid
+# empty result into a failure. Real error paths are guarded explicitly instead.
+
+dict=/usr/share/dict/words
+alphabet=abcdefghijklmnopqrstuvwxyz
+
+bindir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+parse_params=$bindir/parse_params
+
+##############################################################################
+# Pre-scan the length so we know how many --posN / --not_posN flags to define.
+# parse_params can't size its own definition, so length is read manually first;
+# the value is re-validated by parse_params below.
+##############################################################################
+
+length=5
+prev=
+
+for arg in "$@"; do
+  case $arg in
+    -l=* | --length=*) length=${arg#*=} ;;
+    *) [[ $prev == -l || $prev == --length ]] && length=$arg ;;
+  esac
+
+  prev=$arg
+done
+
+# A non-numeric or non-positive length can't size the flag set; fall back to 5
+# for building the definition and let parse_params reject the bad value.
+size=$length
+[[ $size =~ ^[0-9]+$ ]] && ((size > 0)) || size=5
+
+##############################################################################
+# Build the parse_params definition: the fixed flags plus one --posN /
+# --not_posN pair per letter position.
+##############################################################################
+
+def='
+l|length,integer,length,5
+x|exclude,string,exclude
+i|include,string,include
+'
+
+for ((n = 1; n <= size; n++)); do
+  def+="pos$n,char,p$n"$'\n'
+  def+="not_pos$n,string,np$n"$'\n'
+done
+
+# shellcheck disable=SC2154  # length/exclude/include/pN/npN are set by the eval
+eval "$("$parse_params" --auto --prog findword "$def" "$@")"
+
+((length > 0)) || {
+  printf 'findword: length must be greater than 0\n' >&2
+  exit 1
+}
+
+##############################################################################
+# Translate the constraints into a per-position character-class regex.
+##############################################################################
+
+exclude=${exclude,,}
+exclude=${exclude//[^a-z]/}
+include=${include,,}
+include=${include//[^a-z]/}
+
+regex=
+
+for ((n = 1; n <= length; n++)); do
+  pin_var=p$n
+  pin=${!pin_var-}
+  pin=${pin,,}
+  pin=${pin//[^a-z]/}
+
+  not_var=np$n
+  not=${!not_var-}
+  not=${not,,}
+  not=${not//[^a-z]/}
+
+  # A pinned position overrides --exclude and ignores --not_posN there.
+  if [[ -n $pin ]]; then
+    regex+="[$pin]"
+
+  else
+    allowed=$(tr -d "$exclude$not" <<< "$alphabet")
+    [[ -n $allowed ]] || exit 0 # nothing can fill this slot: no matches
+    regex+="[$allowed]"
+  fi
+done
+
+##############################################################################
+# Search, require the included letters, rank by vowel richness, show the top
+# 100 in columns.
+##############################################################################
+
+# The dictionary is only needed once a search is actually attempted; checking
+# it here (not at the top) lets --help, usage errors, and length validation
+# work without one.
+[[ -r $dict ]] || {
+  printf 'findword: cannot read dictionary %s\n' "$dict" >&2
+  exit 1
+}
+
+grep -iE "^$regex\$" "$dict" \
+  | tr '[:upper:]' '[:lower:]' \
+  | grep -xE '[a-z]+' \
+  | sort -u \
+  | awk -v inc="$include" '
+      {
+        for (k = 1; k <= length(inc); k++)
+          if (index($0, substr(inc, k, 1)) == 0) next
+
+        vowels = $0
+        gsub(/[^aeiouy]/, "", vowels)
+        seen = ""
+        count = 0
+        for (i = 1; i <= length(vowels); i++) {
+          c = substr(vowels, i, 1)
+          if (index(seen, c) == 0) { seen = seen c; count++ }
+        }
+        print count "\t" $0
+      }' \
+  | sort -k1,1n -k2 \
+  | cut -f2- \
+  | tail -n 100 \
+  | column

--- a/config/shell-startup/010-general
+++ b/config/shell-startup/010-general
@@ -215,31 +215,6 @@ if havecmd gcloud; then
 fi
 
 #-----------------------------------------------------------------------------
-# Cheaty
-
-findword() {
-  local default='[[:alpha:]]{5}'
-  local regex="^${1:-$default}$"
-  grep -iE "^${regex}$" /usr/share/dict/words \
-  | grep -E '^[[:alpha:]]+$' \
-  | awk '{
-      word = tolower($0)
-      gsub(/[^aeiouy]/, "", word)      # keep only vowels
-      split(word, chars, "")
-      seen = ""
-      count = 0
-      for (i=1; i<=length(word); i++) {
-        if (index(seen, chars[i]) == 0) {
-          seen = seen chars[i]
-          count++
-        }
-      }
-    print count "\t" $0}' \
-  | sort -k1,1n -k2 \
-  | cut -f2-
-}
-
-#-----------------------------------------------------------------------------
 # github cli
 
 if havecmd gh; then

--- a/docs/bin.md
+++ b/docs/bin.md
@@ -57,6 +57,12 @@ terminal color scripting.
 Human-readable date formatting utility. Converts or displays dates in friendly
 formats.
 
+**findword**
+Wordle solver/cheat. Builds a per-position character-class regex from
+constraints (`--length`, `--exclude`, `--include`, `--posN`, `--not_posN`),
+searches the system dictionary, and ranks matches by vowel richness. Run
+`findword --help` for the full flag list.
+
 **lwhich**
 Enhanced 'which' that follows symbolic links and shows the actual executable
 path.

--- a/tests/shell/test_findword.bats
+++ b/tests/shell/test_findword.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+# Tests for bin/findword — a Wordle solver/cheat that builds a per-position
+# character-class regex from its flags, greps the dictionary, and ranks the
+# matches by vowel richness.
+#
+# The script reads the real /usr/share/dict/words. Rather than assert exact
+# words (which depend on the installed wordlist), the result tests check
+# structural invariants — length, allowed letters, position constraints — over
+# whatever matched. They skip when no dictionary is installed.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  # findword calls `parse_params`; make both resolvable from the repo's bin/.
+  PATH="$(dotfiles_root)/bin:$PATH"
+}
+
+# Skip a result-producing test when the dictionary the script needs is absent.
+require_dict() {
+  [[ -r /usr/share/dict/words ]] || skip "no /usr/share/dict/words installed"
+}
+
+@test "every result is a 5-letter word by default" {
+  require_dict
+  run findword --pos1 z
+  assert_success
+  for w in $output; do
+    assert_equal "${#w}" 5
+  done
+}
+
+@test "--pos1 pins the first letter" {
+  require_dict
+  run findword --pos1 q
+  assert_success
+  [[ -n $output ]]
+  for w in $output; do
+    assert_equal "${w:0:1}" q
+  done
+}
+
+@test "--exclude removes words containing any excluded letter" {
+  require_dict
+  run findword --pos1 a --exclude eiou
+  assert_success
+  for w in $output; do
+    assert_equal "$w" "${w//[eiou]/}"
+  done
+}
+
+@test "--include requires every included letter to be present" {
+  require_dict
+  run findword --pos1 a --include z
+  assert_success
+  [[ -n $output ]]
+  for w in $output; do
+    assert_output --regexp "$w" # token is in output
+    [[ $w == *z* ]] || fail "word '$w' lacks required letter z"
+  done
+}
+
+@test "--not_posN forbids letters at that position only" {
+  require_dict
+  run findword --pos1 a --not_pos2 b
+  assert_success
+  for w in $output; do
+    assert [ "${w:1:1}" != b ]
+  done
+}
+
+@test "--posN overrides --exclude for that position" {
+  require_dict
+  # 'a' is globally excluded yet pinned at position 1: it must still appear
+  # there (and nowhere else, since it is excluded elsewhere).
+  run findword --pos1 a --exclude a
+  assert_success
+  [[ -n $output ]]
+  for w in $output; do
+    assert_equal "${w:0:1}" a
+    [[ ${w:1} != *a* ]] || fail "word '$w' has 'a' after the pinned position"
+  done
+}
+
+@test "a longer --length generates the matching --posN flags" {
+  require_dict
+  run findword --length 7 --pos1 a
+  assert_success
+  for w in $output; do
+    assert_equal "${#w}" 7
+  done
+}
+
+@test "an out-of-range --posN is an unknown option (parse_params, exit 2)" {
+  run findword --pos6 e
+  assert_failure 2
+  assert_output --partial 'Unknown option: pos6'
+}
+
+@test "a non-integer length is rejected (parse_params, exit 2)" {
+  run findword --length abc
+  assert_failure 2
+  assert_output --partial 'is not a integer'
+}
+
+@test "a non-positive length is rejected (exit 1)" {
+  run findword --length 0
+  assert_failure 1
+  assert_output --partial 'greater than 0'
+}
+
+@test "contradictory constraints yield no matches and exit 0" {
+  run findword --length 1 --exclude abcdefghijklmnopqrstuvwxyz
+  assert_success
+  assert_output ''
+}
+
+@test "--help prints usage and exits 0" {
+  run findword --help
+  assert_success
+  assert_output --partial 'Usage: findword'
+}


### PR DESCRIPTION
## Summary
- Convert the raw-regex `findword` shell function (in
  `config/shell-startup/010-general`) into `bin/findword`, a Wordle solver
  driven by `parse_params`.
- Accepts structured constraints — `--length`, `--exclude`, `--include`, and a
  length-generated `--posN` / `--not_posN` pair per position — and builds a
  per-position character-class regex. A pinned `--posN` overrides `--exclude`
  and ignores `--not_posN` there; an unconstrained position matches any letter.
- Keeps the original vowel-richness ranking and shows the top 100 via `column`.
- Removes the superseded function (and its now-empty section) from
  `010-general`; catalogs the script in `docs/bin.md`.

## Test plan
- [x] `tests/shell/test_findword.bats` — 12 cases: structural invariants
  (length, allowed letters, position constraints, pin-overrides-exclude,
  dynamic length) over the real dictionary, plus out-of-range/`--posN`,
  non-integer/non-positive length, contradictory-constraints, and `--help`.
- [x] Full hand-written suite green (158 passing); shfmt + shellcheck clean.
- [ ] CI green on the PR.