### PR TITLE
fix(tokens): rework GitHub credentials around one wide-open GH_TOKEN

### DIFF
--- a/api-keys.cfg
+++ b/api-keys.cfg
@@ -5,8 +5,9 @@ LINODE_TOKEN=linode
 OPENAI_API_KEY=openai
 OPENROUTER_API_KEY=openrouter
 XAI_API_KEY=grok
-GITHUB_TOKEN=github
-GITHUB_PERSONAL_ACCESS_TOKEN=github
+# GH_TOKEN is the single wide-open PAT for the gh CLI. GITHUB_TOKEN is
+# deliberately left unset; gh falls through to GH_TOKEN, and MCP servers
+# read their own scoped tokens directly (see bin/mymcp).
 GH_TOKEN=gh
 CONTEXT7_API_KEY=context7
 

--- a/bin/mymcp
+++ b/bin/mymcp
@@ -17,6 +17,11 @@ echo "0: $0 ::: $PWD ::: $* <<<" >&2
 : "${DOTFILES:?DOTFILES environment variable is not set}"
 log_dir="$DOTFILES/.mymcp"
 
+# Per-server API tokens live in the private api-key store, alongside the
+# dotfiles checkout. Each server reads the file it needs directly (see
+# read_api_key); servers that share permission needs read the same file.
+api_key_dir="${PROJECTS_DIR:-$(dirname "$DOTFILES")}/private_dotfiles/api-key"
+
 # Create log directory if it doesn't exist
 mkdir -p "$log_dir"
 
@@ -38,6 +43,19 @@ declare -A known_cmd
 # Utility Functions
 
 #------------------------------------------------------------------------------
+# Read a token from the private api-key store. Give a server its own file
+# only when its access needs differ; servers with the same needs pass the
+# same name and share one token.
+read_api_key() {
+  local name="$1"
+  local file="$api_key_dir/$name"
+
+  [[ -r $file ]] || dw_die 1 "api-key file not found or unreadable: $file"
+
+  printf '%s' "$(< "$file")"
+}
+
+#------------------------------------------------------------------------------
 docker_run() {
   local opts=('run' '--rm' '-i' "$@")
   dw_warn "docker ${opts[*]}"
@@ -56,8 +74,8 @@ npx_run() {
 
 # https://github.com/github/github-mcp-server/blob/main/docs/server-configuration.md
 github() {
-  : "${GITHUB_TOKEN:?GITHUB_TOKEN not set}"
-  export GITHUB_PERSONAL_ACCESS_TOKEN="$GITHUB_TOKEN"
+  export GITHUB_PERSONAL_ACCESS_TOKEN
+  GITHUB_PERSONAL_ACCESS_TOKEN="$(read_api_key mcp-github)"
   docker_run \
     '-e' 'GITHUB_PERSONAL_ACCESS_TOKEN' \
     'ghcr.io/github/github-mcp-server' \

--- a/config/claude/rules/gh.md
+++ b/config/claude/rules/gh.md
@@ -4,7 +4,7 @@
 
 # gh (GitHub CLI) Rules
 
-**Version:** v1.1.0
+**Version:** v1.2.0
 
 ## Pull Requests
 
@@ -71,20 +71,23 @@ as `fixup commit 1, fixup commit 2, ...` noise.
 
 This user maintains **two** credentials for `gh`, deliberately:
 
-- **`GH_TOKEN` / `GITHUB_TOKEN` env vars** — a narrowly-scoped
-  fine-grained PAT exported from the user's shell environment. This is
-  the default credential and serves nearly every gh operation in the
-  user's normal workflow. Many of the user's scripts and tools also
-  read these env vars; do not assume the PAT can be removed or
-  widened.
-- **Stored OAuth credential** — broader-scope token saved by
-  `gh auth login`, stored at `$DOTFILES/config/gh/hosts.yml`. Reserved
-  as a fallback for operations the narrow PAT can't reach
-  (commenting on upstream PRs, filing issues against other orgs, and
-  similar third-party-repo writes).
+- **`GH_TOKEN` env var** — a single **wide-open** PAT exported from the
+  user's shell environment (loaded by `config/shell-startup/000-loadtokens`
+  from `private_dotfiles/api-key/gh`). This is the default credential and
+  is intentionally broad so gh works for anything in the user's normal
+  workflow. **`GITHUB_TOKEN` is deliberately left unset** — gh falls
+  straight through to `GH_TOKEN`. (Per-app tools such as the MCP servers
+  in `bin/mymcp` do **not** use these env vars; they read their own
+  narrowly-scoped tokens directly from `private_dotfiles/api-key/`.)
+- **Stored OAuth credential** — token saved by `gh auth login`, stored at
+  `$DOTFILES/config/gh/hosts.yml`. Reserved as a fallback for operations
+  the env-var PAT can't reach (commenting on upstream PRs, filing issues
+  against other orgs, and similar third-party-repo writes — a fine-grained
+  PAT only reaches repos explicitly granted to it).
 
-`gh` precedence: `GH_TOKEN` > `GITHUB_TOKEN` > stored credential. As
-long as either env var is set, the stored credential is ignored.
+`gh` precedence: `GH_TOKEN` > `GITHUB_TOKEN` > stored credential. With
+`GITHUB_TOKEN` unset, gh uses `GH_TOKEN`; clearing it too (the fallback
+prefix below) drops gh to the stored OAuth credential.
 
 ### Default: use the PAT (no prefix)
 
@@ -98,8 +101,10 @@ gh pr create --title "..." --body "..."
 
 ### Fallback: bypass env vars only when the PAT can't do it
 
-Some `gh` calls will fail because the narrow PAT lacks scope for the
-target repo. Typical error:
+Some `gh` calls will fail because the env-var PAT can't reach the
+target repo — even a wide-open fine-grained PAT only covers repos
+explicitly granted to it, so upstream/third-party repos are out of
+reach. Typical error:
 
 ```text
 GraphQL: Resource not accessible by personal access token
@@ -121,8 +126,9 @@ only**, leaving the shell environment intact. Use this prefix when:
 - A previously-working command starts failing with the same scope
   error after a refactor or repo move.
 
-**Never `unset GH_TOKEN GITHUB_TOKEN` in the shell session itself.**
-The env-var PAT is load-bearing for other tools the user runs.
+**Never `unset GH_TOKEN` in the shell session itself.** It is the
+load-bearing credential for gh and other tools the user runs; clear it
+only inline for a single command (the prefix above).
 
 ### Diagnosing further
 

--- a/tests/shell/test_mymcp.bats
+++ b/tests/shell/test_mymcp.bats
@@ -46,7 +46,37 @@ teardown() {
   assert_output --partial "-y snyk@latest mcp -t stdio"
 }
 
-@test "github refuses to run without GITHUB_TOKEN" {
-  run env -u GITHUB_TOKEN DOTFILES="$FAKE" "$ROOT/bin/mymcp" github
+@test "github fails with a clear error when its token file is missing" {
+  run env PROJECTS_DIR="$BATS_TEST_TMPDIR/projects" DOTFILES="$FAKE" \
+    "$ROOT/bin/mymcp" github
   assert_failure
+
+  run cat "$FAKE"/.mymcp/mymcp-github-*.log
+  assert_output --partial "api-key file not found"
+}
+
+@test "github reads its mcp-github token file and passes it to docker" {
+  local keydir="$BATS_TEST_TMPDIR/projects/private_dotfiles/api-key"
+  mkdir -p "$keydir"
+  printf 'tok-abc123' > "$keydir/mcp-github"
+
+  # Docker stub records both its args and the token it received via the
+  # environment, so we can assert the file's contents reached the server.
+  cat > "$STUB/docker" << EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB/docker.args"
+printf '%s\n' "\$GITHUB_PERSONAL_ACCESS_TOKEN" >> "$STUB/docker.env"
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+
+  run env PROJECTS_DIR="$BATS_TEST_TMPDIR/projects" DOTFILES="$FAKE" \
+    "PATH=$STUB:$PATH" "$ROOT/bin/mymcp" github
+  assert_success
+
+  run cat "$STUB/docker.args"
+  assert_output --partial "ghcr.io/github/github-mcp-server stdio --dynamic-toolsets --tools=get_me,search_code"
+
+  run cat "$STUB/docker.env"
+  assert_output "tok-abc123"
 }


### PR DESCRIPTION
## Summary
- `GH_TOKEN` and `GITHUB_TOKEN` were backed by two separate PATs, both stale → 401s. Collapse to a single wide-open `GH_TOKEN` for the `gh` CLI; `GITHUB_TOKEN` is now deliberately unset (gh falls through to `GH_TOKEN`).
- `bin/mymcp`'s `github()` now reads its own narrow read-only token directly from `api-key/mcp-github` (via a new `read_api_key` helper) instead of `$GITHUB_TOKEN`, so each consumer's token is independent.
- Updated `gh.md` Authentication (v1.2.0) and replaced the stale `GITHUB_TOKEN` test with missing-file + token-from-file success coverage.

## Test plan
- [ ] `bats tests/shell/test_*.bats` is green (159 tests, incl. the two new mymcp cases)
- [ ] After merge: create the wide-open PAT → `private_dotfiles/api-key/gh`, the read-only PAT → `api-key/mcp-github`, delete the orphaned `api-key/github`, open a fresh shell, and confirm `gh api user` returns 200