### PR TITLE
docs: MCP/plugin conventions, protected-branch rule, extension-primitive reference

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -753,6 +753,40 @@ after every `Edit` or `Write` on a shell file.
   `PostToolUse` hook receive? (need file path of edited file)
 - [ ] Document hook setup in this repo's WORKFLOW.md once stable
 
+## 🧩 Audit Claude Code Plugins + MCP Servers (MEDIUM PRIORITY)
+
+Enabled plugins live in `~/.claude/settings.json` (`enabledPlugins`); each is
+cached under `~/.claude/plugins/`. **MCP servers in this setup are provided by
+plugins** — an enabled plugin may bundle its own `.mcp.json` (e.g. the github
+plugin shipped a *hosted* server at `https://api.githubcopilot.com/mcp/`
+authed via `${GITHUB_PERSONAL_ACCESS_TOKEN}`). There is no hand-maintained
+global `mcp.json`, so auditing plugins **is** auditing the MCP surface. The
+standing convention is captured in `config/claude/rules/mcp.md`.
+
+- [ ] **Inventory** every enabled plugin: what it does, whether it bundles an
+  MCP server, and whether we actually use it.
+- [ ] **Cull** plugins that duplicate the `gh` CLI / existing rules+skills or
+  go unused. (github plugin already being removed — its hosted MCP server
+  authed with `GITHUB_PERSONAL_ACCESS_TOKEN`, a *different* token than the gh
+  CLI's `GH_TOKEN`; that mismatch was the earlier "sketchy github responses".)
+- [ ] **Gaps**: identify capabilities we want but have no plugin for.
+- [ ] **Record decisions** (keep/remove + why) so the audit is repeatable.
+- [ ] Create a **rule and/or skill to run this audit routinely** — multi-step
+  (inventory → classify → cull → gap-check) ⇒ likely a *skill* per the "When
+  to Propose a Skill" threshold in `CLAUDE.md`. Evaluate the existing
+  `claude-code-setup:claude-automation-recommender` plugin for the gap-finding
+  part before authoring from scratch.
+- [ ] **Cadence:** run the *detailed* audit on a short recurring interval (it
+  should not be a long time between runs — e.g. monthly), not just once. Wire
+  the audit skill to a reminder / `/schedule` routine so it recurs.
+- [ ] **Plugin-aware proposals (behavior rule):** when proposing a new
+  language/tool *rule* or *skill* for a capability, also check whether a
+  **plugin** already provides it (or whether one should be added). Extend
+  `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a Skill*
+  sections and the `rule-coverage.py` hook to cover plugins, not just
+  rules/skills. (Plugins can bundle commands, skills, subagents, hooks, and
+  MCP servers — so they are a first-class option alongside a rule or skill.)
+
 ## 🔒 Pre-commit Configuration (HIGH PRIORITY)
 
 **Key Rule:** CI/CD Phase N requires Pre-commit Phase N completed first.

--- a/TODO.md
+++ b/TODO.md
@@ -753,39 +753,67 @@ after every `Edit` or `Write` on a shell file.
   `PostToolUse` hook receive? (need file path of edited file)
 - [ ] Document hook setup in this repo's WORKFLOW.md once stable
 
-## 🧩 Audit Claude Code Plugins + MCP Servers (MEDIUM PRIORITY)
+## 🔭 Audit the Claude Code Setup (MEDIUM PRIORITY)
 
-Enabled plugins live in `~/.claude/settings.json` (`enabledPlugins`); each is
-cached under `~/.claude/plugins/`. **MCP servers in this setup are provided by
-plugins** — an enabled plugin may bundle its own `.mcp.json` (e.g. the github
-plugin shipped a *hosted* server at `https://api.githubcopilot.com/mcp/`
-authed via `${GITHUB_PERSONAL_ACCESS_TOKEN}`). There is no hand-maintained
-global `mcp.json`, so auditing plugins **is** auditing the MCP surface. The
-standing convention is captured in `config/claude/rules/mcp.md`.
+Periodically audit the **whole** Claude Code setup — CLAUDE.md/memory, rules,
+skills, agents, hooks, commands, plugins, MCP servers, settings — not just
+plugins. Two goals: **context economy** ("just because we have the space
+doesn't mean we should use it" — the efficiency-by-default rule applied to the
+context window) and **right-fit** (each artifact in the correct category,
+lean, and either ours or a deliberately-adopted plugin). See
+`config/claude/EXTENDING.md` for what each primitive is and `rules/mcp.md` for
+the MCP/plugin conventions.
 
-- [ ] **Inventory** every enabled plugin: what it does, whether it bundles an
-  MCP server, and whether we actually use it.
-- [ ] **Cull** plugins that duplicate the `gh` CLI / existing rules+skills or
-  go unused. (github plugin already being removed — its hosted MCP server
-  authed with `GITHUB_PERSONAL_ACCESS_TOKEN`, a *different* token than the gh
-  CLI's `GH_TOKEN`; that mismatch was the earlier "sketchy github responses".)
-- [ ] **Gaps**: identify capabilities we want but have no plugin for.
-- [ ] **Record decisions** (keep/remove + why) so the audit is repeatable.
-- [ ] Create a **rule and/or skill to run this audit routinely** — multi-step
-  (inventory → classify → cull → gap-check) ⇒ likely a *skill* per the "When
-  to Propose a Skill" threshold in `CLAUDE.md`. Evaluate the existing
-  `claude-code-setup:claude-automation-recommender` plugin for the gap-finding
-  part before authoring from scratch.
-- [ ] **Cadence:** run the *detailed* audit on a short recurring interval (it
-  should not be a long time between runs — e.g. monthly), not just once. Wire
-  the audit skill to a reminder / `/schedule` routine so it recurs.
-- [ ] **Plugin-aware proposals (behavior rule):** when proposing a new
-  language/tool *rule* or *skill* for a capability, also check whether a
-  **plugin** already provides it (or whether one should be added). Extend
-  `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a Skill*
-  sections and the `rule-coverage.py` hook to cover plugins, not just
-  rules/skills. (Plugins can bundle commands, skills, subagents, hooks, and
-  MCP servers — so they are a first-class option alongside a rule or skill.)
+**Measure first** (`qa.md` — optimize on measurement, not guesswork): use
+`/context` to baseline what actually consumes the window before trimming.
+Always-on memory/rules and enabled tool/MCP schemas are the usual
+heavyweights. Trim by *measured cost × low relevance* — never delete guidance
+that prevents real mistakes just because it is large.
+
+- [ ] **Context-load tiering.** Classify every artifact by *when* it loads:
+  - *Always-on* (every turn): global CLAUDE.md, rules with no path-scope,
+    enabled MCP tool schemas → the expensive tier; keep ruthlessly lean.
+  - *On-demand* (when relevant): path-scoped rules (`paths:` frontmatter),
+    skills (description-matched / invoked), deferred MCP tools (ToolSearch).
+  - *Isolated* (own context): agents → ~free to the main thread.
+  Highest-leverage lever: push always-on content down a tier — path-scope a
+  single-language rule, extract a verbose CLAUDE.md procedure into a skill,
+  delegate heavy reading to an agent.
+- [ ] **Recategorize / split / merge.** For each artifact ask whether it is
+  the right *kind*: a "rule" that is really a procedure → skill; a "rule" that
+  must happen every time → hook; a bloated multi-tool rule → split per tool;
+  content duplicated across rules → dedupe to one canonical source (Rule of
+  Three). Improve or move as needed.
+- [ ] **Plugins / MCP dimension** (the original plugin audit): inventory every
+  enabled plugin (what it does, what it bundles, whether used); cull
+  duplicates of the `gh` CLI / existing rules+skills and unused ones; remember
+  plugins carry context cost (their commands/skills/agents/MCP schemas).
+  MCP servers here come *from* plugins (no hand-maintained `mcp.json`).
+  (github plugin already removed — its MCP server authed with
+  `GITHUB_PERSONAL_ACCESS_TOKEN` vs the gh CLI's `GH_TOKEN`; that token
+  mismatch was the earlier "sketchy github responses".)
+- [ ] **Build vs. adopt.** For each capability (have or want), weigh a
+  maintained plugin/skill against our own: adopt when it is good and lean;
+  **vendor-and-modify** per the borrow-existing convention (awesome-agent-
+  skills, officialskills.sh — see *Claude Rules Files*), recording a
+  `SOURCE.md`; write our own when the plugin is bloated/over-scoped for the
+  context it costs. Weigh context cost against maintenance burden explicitly.
+- [ ] **Plugin-aware proposals (behavior rule).** When proposing a new
+  rule/skill for a capability, also check whether a plugin provides it or
+  should be added. Extend `CLAUDE.md`'s *Missing or Conflicting Tool Rules* +
+  *When to Propose a Skill* and the `rule-coverage.py` hook. **Bias to
+  surfacing in the moment:** propose it even when the right category/location
+  is unclear — getting it suggested matters more than placing it perfectly,
+  and the audit's recategorize step re-homes it. Expect several audits before
+  some items settle (MVP — keep progressing).
+- [ ] **Cadence + form.** A quick pass *often* (enabled plugins/MCP, obvious
+  always-on bloat) and a deeper audit *periodically* (recategorize,
+  build-vs-adopt), with a short interval between detailed runs. This is
+  multi-step with decisions ⇒ a **skill** — and one that should *run via an
+  agent* so the audit's own reading does not eat the context it is meant to
+  protect. Record decisions + rationale so it is repeatable and not
+  re-litigated. Evaluate `claude-code-setup:claude-automation-recommender` for
+  the gap-finding part before authoring from scratch.
 
 ## 🔒 Pre-commit Configuration (HIGH PRIORITY)
 

--- a/config/claude/.gitignore
+++ b/config/claude/.gitignore
@@ -4,6 +4,7 @@
 
 !.gitignore
 !CLAUDE.md
+!EXTENDING.md
 !settings.json
 !rules/
 !rules/**

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -1,0 +1,148 @@
+# Claude Code Extension Primitives
+
+**Version:** v1.0.0
+
+A reference for the building blocks used to customize Claude Code — what
+each one is and when to reach for it. They are **not** interchangeable;
+each sits at a different layer (passive context vs. active procedure vs.
+delegated worker vs. deterministic harness action).
+
+This is a global reference (it deploys to `~/.claude/`). It describes
+Claude Code itself, not any one repo.
+
+## At a glance
+
+| Primitive | What it is | Active? | Runs where | Reach |
+|-----------|-----------|---------|------------|-------|
+| Memory / `CLAUDE.md` | Always-loaded instructions | Passive | — | Every turn |
+| Rule | Scoped standing policy/reference | Passive | — | Relevant turns |
+| Skill | A procedure the model invokes | Active | My context | One task, inline |
+| Agent (subagent) | A delegated worker | Active | Its own context | Isolated/parallel task |
+| Hook | A shell command on a lifecycle event | Active | The harness (not the model) | Deterministic enforcement |
+| Command (slash) | A named, user-triggered prompt/action | Active | My context | On demand |
+| MCP server | External tools/data over MCP | Active | External process/endpoint | Tools a CLI lacks |
+| Plugin | A bundle of the above | — | — | Packaging / distribution |
+
+## Memory / `CLAUDE.md` (the foundation)
+
+**What:** User-written instructions the harness loads every session (user,
+project, and repo scope). Everything else builds on top of it.
+**When:** Stable, always-relevant context — who you are, project goals,
+hard conventions you want present in *every* turn.
+
+## Rule
+
+**What:** A scoped, standing policy or reference — here, the versioned
+files under `config/claude/rules/` (= `~/.claude/rules/`), pulled in
+through the memory/`CLAUDE.md` layer (optionally path-scoped via
+frontmatter so a rule attaches only for relevant files). It is a
+memory-organization **convention**, *not* a Claude-native auto-loading
+engine and *not* a plugin component. (Cursor, by contrast, has a native,
+glob-auto-discovered Rules feature; Claude keeps standing policy in the
+memory layer instead — which is why a plugin can't ship a rule.)
+**When:** "How we always do X" — naming, tool invocation/flags, error
+posture, workflow policy. Passive guidance the model should follow, not a
+procedure it runs. Reach for a rule when the knowledge is judgment-shaped
+and should quietly shape behavior.
+
+## Skill
+
+**What:** A packaged procedure the model invokes and follows inline — a
+`SKILL.md` of instructions plus optional scripts/resources. Runs in the
+current context; no separate process.
+**When:** A repeatable multi-step task (three or more steps, with
+decisions or branches) you want done consistently — e.g. `ship-pr`,
+`qa-check`, `bats-setup`. Reach for a skill when you'd write the procedure
+up for a new contributor.
+
+## Agent (subagent)
+
+**What:** A separate Claude instance spawned via the Task/Agent tool, with
+its own fresh context window, its own system prompt, and a restricted tool
+set. It runs autonomously and returns only its result to the main loop.
+**When:** Fan-out / parallel work, or context isolation — a focused
+sub-task whose intermediate reading and output you don't want filling your
+main context (broad searches, a self-contained review). Use it when you'd
+hand the job to a teammate and just want the conclusion.
+
+## Hook
+
+**What:** A shell command the harness runs on a lifecycle event
+(`PreToolUse`, `PostToolUse`, …), configured in `settings.json`. It fires
+deterministically — the model does not decide whether to.
+**When:** Enforcement that must not depend on the model remembering —
+auto-format on edit, block a disallowed action, inject context on an
+event. The `rule-coverage.py` `PostToolUse` hook is an example (nags when
+a language/dependency has no matching rule).
+
+## Command (slash command)
+
+**What:** A named, user-triggered prompt or action (e.g. `/commit`,
+`/qa`), defined under `commands/` and shippable in plugins. Typing it
+expands to its prompt/instruction.
+**When:** A canned action you want to fire by name on demand. Lighter than
+a skill — a shortcut/prompt rather than a full procedure (though skills can
+also be slash-invoked).
+
+## MCP server
+
+**What:** An external process or endpoint that provides tools and/or data
+to the model over the Model Context Protocol. Registered by scope
+(local/project/user) or bundled in a plugin.
+**When:** To give the model capabilities a CLI can't, or a deliberately
+restricted capability boundary. Treat as **second-class** — never depend
+on one in a rule or skill (see `rules/mcp.md`).
+
+## Plugin
+
+**What:** An installable bundle (from a marketplace) that packages one or
+more **commands, skills, agents, hooks, and/or MCP servers** — the
+distribution/sharing unit. It can **not** carry rules; standing policy
+lives in the memory layer, not in a shipped package.
+**When:** To install someone else's capability set, or to package and
+share your own. A plugin is a *container*, not a new kind of capability.
+
+## Choosing between them
+
+Decision shortcuts:
+
+- Must happen every time, regardless of whether the model remembers →
+  **Hook** (deterministic).
+- Standing policy/knowledge that should shape behavior → **Rule** (or
+  `CLAUDE.md` for always-on).
+- A repeatable multi-step procedure with decisions → **Skill**.
+- Work you want done in isolation or in parallel (keep big output out of
+  the main thread) → **Agent**.
+- A canned action you trigger by name → **Command**.
+- Tools/data a CLI can't give the model → **MCP server** (second-class).
+- Packaging several of these to install/share → **Plugin**.
+
+Key contrasts:
+
+- **Rule vs Skill** — a rule is *passive policy* ("always do X this way");
+  a skill is an *active procedure* you invoke ("the steps to do X"). Both
+  run in my context.
+- **Skill vs Agent** — a skill runs in *my* context (I follow its steps);
+  an agent runs in its *own* context and returns only a result. Use an
+  agent for parallel fan-out or to keep heavy intermediate work out of the
+  main thread.
+- **Rule vs Hook** — a rule relies on the model choosing to follow it; a
+  hook is enforced by the harness no matter what. Use a hook when "must,
+  every time" (format-on-edit, block-on-condition); a rule when judgment
+  is involved.
+- **An agent is never a substitute for a rule** — they answer different
+  questions: a rule *encodes policy*; an agent *executes a task*.
+
+Worked examples:
+
+- **Git workflow** → rules (branch naming, branch protection, staging
+  discipline) **plus** a skill (`git-worktree-workflow`'s multi-step
+  procedure). *Not* an agent: it is deterministic, touches your working
+  tree, and you want its state visible in your own context — delegating it
+  to an isolated worker would hide exactly what you need to see.
+- **qa-check** → a skill (it orchestrates the pipeline from the repo's QA
+  doc). Agents fit *underneath or around* it, not instead of it: the skill
+  can *spawn* agents to run independent QA dimensions in parallel, and you
+  can *invoke* qa-check via an agent to keep its verbose lint/test output
+  out of your main context. Skill and agent compose — they are not an
+  either/or.

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.3.0
+**Version:** v1.4.0
 
 ## Commit Messages
 
@@ -77,6 +77,27 @@ When a repo's default branch should be PR-only, protect it in **two layers**
 The local hook is a convenience, not a substitute — without the server-side
 ruleset, anyone (or any tool) without the hook installed can still push. The
 repo's concrete ruleset/config lives in its `.claude/` docs.
+
+## Never Work Directly on a Protected Branch
+
+A protected branch exists to *receive* PRs, not to author on. **Never make
+changes while a protected branch is checked out — neither edits nor
+commits.** This applies to **any** protected branch, not just the default
+(`master` / `main`): if a repo protects `develop`, `release/*`, or anything
+else, the same rule holds.
+
+Before touching a single file, **create or switch to a working branch**
+(`feature/…`, `bugfix/…`, `docs/…`, or a worktree — see *Branch Naming* and
+the **git-worktree-workflow** skill). Branch **first**, then edit. Do not
+edit on the protected branch intending to create the branch afterward — even
+though uncommitted changes carry across `git checkout -b`, accumulating work
+on the protected branch is exactly the habit this rule forbids (one slip and
+the change is committed where it must never land).
+
+To tell whether a branch is protected: a server-side ruleset / branch
+protection, a local `no-commit-to-branch` hook (above), or the repo's
+`.claude/` docs name it. When in doubt, treat the default branch as
+protected.
 
 ## Worktrees
 
@@ -205,6 +226,10 @@ The deleted branch should no longer appear in the output.
 - NEVER force-delete a branch silently — always confirm with the user.
 - NEVER amend published commits or skip hooks without explicit user approval.
 - NEVER push to the default branch without user confirmation.
+- NEVER make changes (edits or commits) while a **protected branch** is
+  checked out — create/switch to a working branch FIRST, then edit. Applies
+  to ANY protected branch, not just the default. See *Never Work Directly on
+  a Protected Branch*.
 - Stage with `git add -u` (tracked changes) plus explicit `git add <file>`
   for new files; NEVER `git add -A` / `git add .` (they sweep up untracked
   scratch into the commit). See *Staging*.

--- a/config/claude/rules/mcp.md
+++ b/config/claude/rules/mcp.md
@@ -1,0 +1,70 @@
+# MCP (Model Context Protocol) Rules
+
+**Version:** v1.0.0
+
+How this user's environments use MCP servers, and the standing rule that
+MCP is a **second-class** capability the agent must never depend on.
+
+## How MCP servers are configured (Claude Code)
+
+- **Plugins provide most MCP servers.** Enabled plugins (`enabledPlugins`
+  in `~/.claude/settings.json`) each may bundle a `.mcp.json` under
+  `~/.claude/plugins/`. There is **no hand-maintained global `mcp.json`** —
+  if you can't find one, that is why. Auditing plugins audits the MCP
+  surface (see `TODO.md`).
+- **Hand-registered servers** use
+  `claude mcp add <name> [--scope ...] -- <cmd>`, stored by scope:
+  - **local** (default) — `~/.claude.json`, keyed to one project, **not
+    committed**. This is the idiomatic **per-repo opt-in**.
+  - **project** — committed `.mcp.json` at the repo root; travels with the
+    repo to anyone who clones it.
+  - **user** — `~/.claude.json` top level; active for **all** projects.
+- **Precedence** (highest first): local > project > user > plugin >
+  connectors. The winning scope's entry is used whole — fields are not
+  merged across scopes.
+- A Cursor `mcp.json` uses the same `{"mcpServers": {...}}` shape, so an
+  entry ports directly — but choose a scope deliberately; do not leave a
+  copy at user scope (that makes it always-on everywhere).
+
+## MCP is second-class — the CLI is the engine
+
+- **Never depend on an MCP server in a rule or skill.** No server is
+  guaranteed present (other hosts, no docker, no token, mid-session
+  disconnects). A documented workflow must work with the MCP server
+  **absent**.
+- For GitHub specifically the **`gh` CLI is canonical** (see `gh.md`,
+  `git.md`, `github-actions.md`, and the `ship-pr` /
+  `git-worktree-workflow` skills). MCP github tools are an **opportunistic
+  read convenience** used only when a server happens to be connected —
+  never the primary path, and never a fallback chain that ends at
+  unrestricted `gh` (that buys the cost of both lanes and the safety of
+  neither).
+- If a **hard capability boundary** is the goal (an unattended or
+  less-trusted agent that must not write), do the opposite of fallback:
+  run a **read-only, tool-restricted MCP server as the only access and
+  remove the CLI + token** from that agent's environment.
+
+## Per-repo opt-in pattern
+
+`bin/mymcp` is the centralized "define once" wrapper for this user's local
+MCP servers — the real logic (docker invocation, token file, flags) lives
+there. A repo opts in by registering a thin local-scope switch pointing at
+it:
+
+```bash
+claude mcp add github -- mymcp github   # --scope local default; not committed
+```
+
+Per-server tokens are read directly from `private_dotfiles/api-key/` by the
+wrapper, **not** from `GH_TOKEN` / `GITHUB_TOKEN` (see `gh.md` and the
+`api-key/README.md`).
+
+## Agent Behavior
+
+- Treat MCP as optional: prefer the CLI (`gh`, etc.) for any documented
+  workflow; use MCP tools only as a convenience when one is present.
+- Never write a rule/skill step that fails if an MCP server is missing.
+- When adding a personal MCP server, default to **local scope** in the
+  specific repo; use project scope only to share it via the repo itself.
+- Plugin = MCP surface: when auditing or removing plugins, account for any
+  MCP server they bundle (see the plugin audit in `TODO.md`).

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,4 +1,19 @@
 {
+  "model": "opus",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/rule-coverage.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/bin/statusline.sh",
@@ -6,7 +21,6 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "github@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
@@ -33,20 +47,5 @@
     }
   },
   "effortLevel": "high",
-  "editorMode": "vim",
-  "model": "opus",
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ~/.claude/hooks/rule-coverage.py",
-            "timeout": 15
-          }
-        ]
-      }
-    ]
-  }
+  "editorMode": "vim"
 }


### PR DESCRIPTION
## Summary
- Add `config/claude/rules/mcp.md` — MCP is second-class to the CLI, plugins are the MCP surface in Claude Code, personal servers opt in per-repo via local scope.
- Add `git.md` rule: never make changes while **any** protected branch is checked out (branch first); bump to v1.4.0.
- Remove the github marketplace plugin (done manually via `/plugin`) — its hosted MCP server authed via `GITHUB_PERSONAL_ACCESS_TOKEN`, a different token than the gh CLI's `GH_TOKEN`, which caused inconsistent results. Also commits two pre-existing settings deltas (model, rule-coverage hook).
- Add `config/claude/EXTENDING.md` — reference for the extension primitives (rule/skill/agent/hook/command/MCP/plugin): what each is + when to use; allowlisted in the dir's `.gitignore`.
- `TODO.md`: a full "Audit the Claude Code Setup" item (context economy + right-fit), superseding the plugin-only audit.

## Test plan
- [ ] pre-commit passes (markdownlint, etc.) — green locally and in CI
- [ ] No behavior/code change; docs + settings only