### PR TITLE
Plugin audit: drop 5 redundant/niche plugins (global-fit pass)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -820,6 +820,22 @@ that prevents real mistakes just because it is large.
   protect. Record decisions + rationale so it is repeatable and not
   re-litigated. Evaluate `claude-code-setup:claude-automation-recommender` for
   the gap-finding part before authoring from scratch.
+- [ ] **Plugin-audit follow-ups (from the 2026-06-10 global-fit pass):**
+  - [ ] `rules/pydantic-ai.md` — path-scoped (`**/*.py`) framework rule
+    capturing pydantic_ai conventions (provider-prefixed model strings, typed
+    `output_type`, `@agent.tool` vs `tool_plain`, `TestModel` via
+    `agent.override`, Logfire), folding in the dropped `pydantic-ai` plugin's
+    guidance. Write when next working with pydantic_ai.
+  - [ ] `git-worktree-workflow`: add a **guarded** "reconcile gone branches"
+    operation — bulk-remove `[gone]` branches and their worktrees — adapting
+    the dropped `commit-commands` `/clean_gone` idea but with the repo's safety
+    posture (confirm each deletion, skip dirty worktrees, no blanket `--force`
+    / `fetch --prune`).
+  - [ ] **Trial `ralph-loop`** to evaluate it (autonomous completion loop,
+    distinct from `/loop`). It can run unbounded — set a max-iteration cap and
+    respect the CLAUDE.md autonomy boundaries.
+  - [ ] **Evaluate `pr-review-toolkit`, `feature-dev`, `security-guidance`**
+    for global fit (keep / drop / vendor) — the decide-later plugins.
 
 ## 🔒 Pre-commit Configuration (HIGH PRIORITY)
 

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -91,3 +91,13 @@ vendor the feature. **Each repo needs its own audit** of what it enables.
   pydantic-ai, jdtls-lsp) left enabled **until their repos are audited**
   (global-impact caveat — they may be needed elsewhere; revisit per-repo).
 - 2026-06-10 — **F (Codecov): deferred** by request.
+- 2026-06-10 — **Plugin audit (global-fit pass; supersedes E above).**
+  Dropped (redundant with built-ins / not a good global fit): `code-review` &
+  `code-simplifier` (built-in `/review`, `/simplify` cover them; the latter
+  was also JS-only and misfit this repo), `commit-commands` (`ship-pr` +
+  `git-worktree-workflow` are stronger, and its `/commit*` violate the staging
+  rules), `jdtls-lsp` and `pydantic-ai` (niche). Kept: the authoring triad
+  (skill-creator / claude-md-management / hookify), context7,
+  claude-code-setup, `ralph-loop` (to trial — distinct from `/loop`), and
+  `pr-review-toolkit` / `feature-dev` / `security-guidance` (decide-later).
+  Follow-ups in `TODO.md`.

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -21,19 +21,14 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true,
-    "pydantic-ai@claude-plugins-official": true,
-    "jdtls-lsp@claude-plugins-official": true
+    "hookify@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {


### PR DESCRIPTION
## Summary
Disable 5 enabled plugins that aren't a good global fit (plugins are user-global, so each must earn always-on, every-repo presence):
- **code-review**, **code-simplifier** — duplicated by built-in `/review` and `/simplify`; code-simplifier's standards are JS/TS-only and misfit this bash/Python repo.
- **commit-commands** — `ship-pr` + `git-worktree-workflow` are stronger, and its `/commit*` violate the repo's staging rules (`git add` broadly vs `git add -u` + explicit paths).
- **jdtls-lsp** (Java-only) and **pydantic-ai** (pydantic_ai-only) — niche, not global.

Enabled plugins go 14 → 9 (kept: context7, the authoring triad skill-creator/claude-md-management/hookify, claude-code-setup, ralph-loop, pr-review-toolkit, feature-dev, security-guidance). Decisions recorded in `SETUP-AUDIT.md`.

Follow-ups added to `TODO.md`: `rules/pydantic-ai.md` (fold the dropped plugin's conventions into a path-scoped rule), a **guarded** "reconcile gone branches" op for `git-worktree-workflow` (salvaged from `/clean_gone`), trial `ralph-loop`, and evaluate the three decide-later plugins.

## Test plan
- [ ] settings.json is valid JSON; `enabledPlugins` lists the 9 kept plugins
- [ ] pre-commit (markdownlint etc.) green locally + CI
- [ ] docs/settings only — no code/behavior change