### PR TITLE
chore(claude): drop the three decide-later plugins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -834,8 +834,19 @@ that prevents real mistakes just because it is large.
   - [ ] **Trial `ralph-loop`** to evaluate it (autonomous completion loop,
     distinct from `/loop`). It can run unbounded — set a max-iteration cap and
     respect the CLAUDE.md autonomy boundaries.
-  - [ ] **Evaluate `pr-review-toolkit`, `feature-dev`, `security-guidance`**
-    for global fit (keep / drop / vendor) — the decide-later plugins.
+  - [x] **Evaluated `pr-review-toolkit`, `feature-dev`, `security-guidance`**
+    — all dropped (not a good global fit; redundant with built-ins / `qa.md` /
+    `security-scan`; security-guidance was a blocking JS-substring edit hook).
+    Vendor bits below are **surfaced by the repo that needs them** — don't
+    build proactively:
+    - [ ] When a repo's review actually needs them, vendor the unique
+      pr-review lenses (silent-failure, comment-rot, type-design) — or fold
+      into `qa.md`'s code-style audit, which mostly covers them already.
+    - [ ] When a repo wants the phased feature-dev flow, vendor `/feature-dev`
+      as a **skill** driving the built-in Explore/Plan agents (not bundled
+      agents).
+    - [ ] When a repo needs it, add a tiny path-only GH-Actions-injection hook
+      (likely unnecessary — `github-actions.md` already covers the awareness).
 
 ## 🔒 Pre-commit Configuration (HIGH PRIORITY)
 

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -101,3 +101,12 @@ vendor the feature. **Each repo needs its own audit** of what it enables.
   claude-code-setup, `ralph-loop` (to trial — distinct from `/loop`), and
   `pr-review-toolkit` / `feature-dev` / `security-guidance` (decide-later).
   Follow-ups in `TODO.md`.
+- 2026-06-10 — **Plugin audit, round 2 (the three decide-later): all dropped.**
+  `pr-review-toolkit` (6 always-on agents; redundant with built-in `/review`,
+  `/code-review`, `/simplify` + `qa.md`), `feature-dev` (agents dup
+  Explore/Plan; the value was the command's orchestration), and
+  `security-guidance` (a **blocking** PreToolUse hook matching JS/TS/py
+  substrings — false-positives on Bash, references non-existent files;
+  `security-scan` / `semgrep` / `/security-review` already cover it).
+  `enabledPlugins` now 6: context7, the authoring triad, claude-code-setup,
+  ralph-loop. Vendor bits left as surface-when-needed TODOs.

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -21,10 +21,7 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
-    "feature-dev@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
Evaluated `pr-review-toolkit`, `feature-dev`, `security-guidance` — all fail the good-global-fit bar (plugins are user-global, so each must earn always-on, every-repo presence). Dropped all three → `enabledPlugins` **9 → 6** (kept context7, the authoring triad skill-creator/claude-md-management/hookify, claude-code-setup, ralph-loop).

- **pr-review-toolkit** — 6 always-on agents; redundant with built-in `/review`, `/code-review`, `/simplify` and `qa.md` (its unique lenses overlap the code-style audit; `type-design-analyzer` is OOP-only).
- **feature-dev** — its agents duplicate the built-in `Explore`/`Plan`; only the command's orchestration was distinctive.
- **security-guidance** — a **blocking** `PreToolUse` hook matching JS/TS/Python substrings: false-positives on Bash, references non-existent files, and `security-scan` + `semgrep` + `/security-review` already cover it.

Vendor bits recorded as **surface-when-needed** TODOs (the repo that needs them surfaces them). Decisions logged in `SETUP-AUDIT.md`.

## Test plan
- [ ] settings.json valid JSON; `enabledPlugins` lists the 6 kept plugins
- [ ] pre-commit green locally + CI
- [ ] docs/settings only