### PR TITLE
feat(claude): wire built-in review commands into qa-check + suggest-cmd guidance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -848,7 +848,23 @@ that prevents real mistakes just because it is large.
     - [ ] When a repo needs it, add a tiny path-only GH-Actions-injection hook
       (likely unnecessary — `github-actions.md` already covers the awareness).
 
-## 🔒 Pre-commit Configuration (HIGH PRIORITY)
+## ⌨️ Custom slash commands: /push and /push-pr (MEDIUM PRIORITY)
+
+Shortcuts for the common ship flow:
+
+- `/push` — commit (if needed) and push the current branch.
+- `/push-pr` — commit, push, and open a PR.
+
+**First evaluate workability.** A slash command is a prompt the model
+executes, so it *can* run git/`gh` (commit → push → `gh pr create`) — but it
+**suggests**, it does not guarantee, and it must respect the protected-branch
+rule (never author on master), the staging discipline (`git add -u` + explicit
+paths, never `-A`/`.`), and the gh approval gates (never open/merge a PR
+without explicit approval — `gh.md`). These largely duplicate the **ship-pr**
+skill, so the real question is whether a thin command that **delegates to
+ship-pr** (or a subset) beats just typing the request. Decide: command vs.
+skill-trigger, the exact scope of each (`/push` = commit+push only), and where
+it lives (global `commands/`).
 
 **Key Rule:** CI/CD Phase N requires Pre-commit Phase N completed first.
 Pre-commit can progress independently. CI/CD cannot lead pre-commit.

--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -144,6 +144,13 @@ Do not invent skills for one-shot tool invocations — those belong in a
 rule. The threshold is "this is a procedure I would write up for a new
 contributor," not "this is how a flag works."
 
+**Rules and skills suggest commands; they cannot call them.** When a
+built-in slash command (`/code-review`, `/security-review`, `/simplify`,
+…) is the right tool for a step in a rule or skill you author, **name it**
+at that step — the model invokes skill-backed commands via its Skill tool,
+so naming is enough to get it run (a suggestion, not a guarantee; for a
+must-run gate, use a hook). Do not reimplement what a command already does.
+
 ## Resource Validity
 
 - Before recommending a tool, library, or pattern, verify it is actively

--- a/config/claude/skills/qa-check/SKILL.md
+++ b/config/claude/skills/qa-check/SKILL.md
@@ -66,9 +66,12 @@ Only the qa-check-specific operational notes (the rest is in `qa.md`):
   against `code-style.md` (plus any repo override in `.claude/`) for the
   conventions no tool enforces: naming, paragraph spacing, section/function
   separators, comment wrap/density, Rule of Three, efficiency by default.
-  Report deviations as findings (see *Code style audit* in `qa.md`).
-- **Security** → defer to the **security-scan** skill; **Build**'s image step
-  → the **containerize** skill.
+  Report deviations as findings (see *Code style audit* in `qa.md`). Invoke
+  the built-in `/code-review` (diff: bugs + cleanups) for the review pass and
+  `/simplify` for cleanup-only — the dedicated commands for this.
+- **Security** → defer to the **security-scan** skill (plus the built-in
+  `/security-review` for a quick pending-changes vuln pass); **Build**'s image
+  step → the **containerize** skill.
 - **CI** is the post-push stage — watch it to green; honour required checks.
 - For a dimension with no tooling (UI/UX, e2e), do the manual pass and flag
   the gap rather than skipping it.


### PR DESCRIPTION
## Summary
After dropping the plugins that bundled review/simplify commands, route the QA/PR flow through the **built-in** commands. Since a rule/skill/hook can only *suggest* a command (not call it), the wiring is "name the command at the right moment so the model invokes it via its Skill tool."

- **`qa-check` skill** (on-demand — not always-on `qa.md`, so no per-turn cost):
  - Code-style audit pass → `/code-review` (diff: bugs + cleanups) and `/simplify`.
  - Security dimension → `/security-review` (alongside the `security-scan` skill).
- **`CLAUDE.md`** authoring rule → "rules and skills suggest commands, they can't call them; name the right built-in command at the step (model invokes skill-backed commands via the Skill tool); use a hook for a must-run gate; don't reimplement a command."
- **`TODO.md`** → captured a `/push` + `/push-pr` custom-command idea with an evaluate-workability-first note (overlaps `ship-pr`; must respect protected-branch/staging/gh-approval rules).

Kept refs out of always-on `qa.md` (tool-agnostic by design) to avoid re-inflating the context we just trimmed.

## Test plan
- [ ] pre-commit (markdownlint) green locally + CI
- [ ] docs/skill only — no code/behavior change