### PR TITLE
feat(rules): path-scope mcp.md so it stops loading every turn

### DIFF
--- a/config/claude/rules/code-style.md
+++ b/config/claude/rules/code-style.md
@@ -1,3 +1,7 @@
+---
+# No paths — applies to all code regardless of language or file type.
+---
+
 # Code Style
 
 **Version:** v1.5.0

--- a/config/claude/rules/github-actions.md
+++ b/config/claude/rules/github-actions.md
@@ -1,3 +1,9 @@
+---
+# No paths — always-on; the rule self-gates in its Tool Detection
+# section (no-ops unless .github/workflows/ is present). Kept always-on
+# because its trigger (creating a PR) is not a file-edit pattern.
+---
+
 # GitHub Actions Rules
 
 **Version:** v1.0.0

--- a/config/claude/rules/mcp.md
+++ b/config/claude/rules/mcp.md
@@ -1,6 +1,20 @@
+---
+# Path-scoped: this rule is a setup/decision procedure, not always-on
+# policy. It loads when touching MCP config (a committed .mcp.json or the
+# mymcp wrapper) or when authoring rules/skills/agents — where the
+# "MCP is second-class, never depend on it" policy actually applies.
+paths:
+  - "**/.mcp.json"
+  - "**/mcp.json"
+  - "bin/mymcp"
+  - "**/rules/**"
+  - "**/skills/**"
+  - "**/agents/**"
+---
+
 # MCP (Model Context Protocol) Rules
 
-**Version:** v1.1.0
+**Version:** v1.2.0
 
 How this user's environments use MCP servers, and the standing rule that
 MCP is a **second-class** capability the agent must never depend on.

--- a/config/claude/rules/qa.md
+++ b/config/claude/rules/qa.md
@@ -1,3 +1,8 @@
+---
+# No paths — the QA pipeline applies to every change regardless of
+# file type.
+---
+
 # Quality Assurance Rules
 
 **Version:** v2.6.0

--- a/config/claude/rules/testing.md
+++ b/config/claude/rules/testing.md
@@ -1,3 +1,8 @@
+---
+# No paths — always-on; the rule self-gates in its Detection section
+# (active only when the repo has a tests/ dir or equivalent).
+---
+
 # Testing Rules
 
 **Version:** v1.0.0


### PR DESCRIPTION
## Summary
- `config/claude/rules/mcp.md` had no frontmatter, so it loaded **always-on** (~1.6k tokens every turn) despite being a setup/decision procedure, not universally-relevant policy.
- Added `paths:` frontmatter (like `docker.md`/`biome.md`) so it loads only when touching MCP config (`.mcp.json`, `mcp.json`, `bin/mymcp`) or authoring `rules/`/`skills/`/`agents/` — where the "MCP is second-class, never depend on it" policy actually applies.
- Bumped the rule to v1.2.0.

## Test plan
- [ ] In a repo with none of the scoped paths, `mcp.md` no longer appears in `/context` memory files.
- [ ] Editing a rule/skill/agent or an MCP config file pulls `mcp.md` back into context.