### PR TITLE
refactor(rules): make github-actions.md on-demand and testing.md non-prescriptive

### DIFF
--- a/config/claude/rules/github-actions.md
+++ b/config/claude/rules/github-actions.md
@@ -1,7 +1,10 @@
 ---
-# No paths — always-on; the rule self-gates in its Tool Detection
-# section (no-ops unless .github/workflows/ is present). Kept always-on
-# because its trigger (creating a PR) is not a file-edit pattern.
+# On-demand: auto-loads only when a workflow file is being edited. The
+# other trigger (watching CI after creating a PR) is covered by gh.md —
+# always-on and pointing here — so the agent reads this rule when it
+# actually creates a PR, rather than paying for it every turn.
+paths:
+  - ".github/workflows/**"
 ---
 
 # GitHub Actions Rules

--- a/config/claude/rules/testing.md
+++ b/config/claude/rules/testing.md
@@ -1,83 +1,58 @@
 ---
-# No paths — always-on; the rule self-gates in its Detection section
-# (active only when the repo has a tests/ dir or equivalent).
+# No paths — the testing quality bar applies whenever code is written.
 ---
 
 # Testing Rules
 
-**Version:** v1.0.0
+**Version:** v2.0.0
 
-Language-agnostic conventions for **organizing and running** a repo's tests.
-Interlinked with `qa.md` but deliberately separate: this rule is about
-*test-suite structure*; `qa.md` is about the *QA pipeline* that runs them.
-Each runner's specifics live in its own rule (`bats.md`, `vitest.md`, …).
+What a change must satisfy for tests, and the stance on how to organize
+them. This rule is deliberately **non-prescriptive** about *which* runner,
+file pattern, or directory layout to use — that is the language's and the
+repo's call (see *Where the specifics live*). `qa.md` owns the Tests
+*pipeline* stage that runs them.
 
-## Detection
+## The bar
 
-Active when a repo has a `tests/` directory (or equivalent test files).
+- Code with real logic has tests. Cover **success and failure** paths.
+- Each bug fix adds a regression test that fails before the fix.
+- Never silence a failing test by ignoring it — fix the code, fix the
+  test, or record the debt where the repo tracks it.
 
-## One test root, organized by language
+## Structure — be idiomatic
 
-Keep all tests under a single `tests/` root, split into per-language
-subdirectories. The runners coexist because each discovers only its own file
-pattern — `pytest` ignores `.bats`/`.t`/`.ps1`, `bats` runs only `.bats`,
-`prove` only `.t`, Pester only `*.Tests.ps1`:
+Organize tests the way the **language** they are written in expects, not to
+a fixed cross-language template:
 
-| Language   | Subdir              | Files         | Runner                   |
-|------------|---------------------|---------------|--------------------------|
-| shell      | `tests/shell/`      | `*.bats`      | `bats` (see `bats.md`)   |
-| python     | `tests/python/`     | `test_*.py`   | `pytest`                 |
-| perl       | `tests/perl/`       | `*.t`         | `prove`                  |
-| powershell | `tests/powershell/` | `*.Tests.ps1` | `Invoke-Pester` (Pester) |
+- **Single language** — follow that language's idiomatic test layout and
+  runner conventions. The concrete pattern lives in that language's runner
+  rule (e.g. `bats.md`).
+- **Multiple languages** — keep the languages' tests from colliding. A
+  single `tests/` root split into per-language subdirs is **one** sensible
+  model (this repo: `tests/shell/`, `tests/python/`, …), but it is not the
+  only one — other repos split differently when their own structure calls
+  for it (e.g. tests living in per-component subdirectories). Choose what
+  fits the repo; record the actual choice in its `.claude/TESTS.md`.
 
-A repo only needs subdirs for the languages it actually has. Shared, non-test
-support lives alongside, never mixed into the per-language dirs:
-
-- `tests/helpers/` — shared test support (helpers loaded by tests).
-- `tests/scaffold/` — test-generation machinery (e.g. a meta-test generator).
-
-This consolidates what some ecosystems split out — perl's `t/`, pytest's
-`tests/` — into one root with language subdirs. `t/` is only *required* by
-perl's CPAN/dist build tooling; a repo that runs `prove` by hand can use
-`tests/perl/`.
-
-## Naming
-
-- Hand-written: `test_<component>` in the language's extension
-  (`test_foo.bats`, `test_foo.py`); perl uses `<component>-<case>.t`; Pester
-  `<X>.Tests.ps1`.
-- Generated (e.g. meta-tests): a distinct suffix (e.g. `*.meta.bats`),
-  **gitignored** and produced on demand / in CI rather than committed.
-- Cover success **and** failure paths; add a regression test with each bug
-  fix (see `qa.md`).
-
-## Running
-
-Point each runner at its subdir:
-
-```bash
-bats tests/shell
-pytest tests/python
-prove tests/perl
-pwsh -c 'Invoke-Pester tests/powershell'
-```
-
-CI runs each applicable runner over its subdir; add a language's CI step when
-that subdir gains tests.
+Keep shared, non-test support (helpers, generators) out of wherever the
+per-language tests live.
 
 ## Where the specifics live
 
 | Layer | Holds |
 |-------|-------|
-| This rule (`testing.md`) | the cross-language structure + conventions |
-| Runner rules (`bats.md`, `vitest.md`, …) | each tool's invocation, helper libs, idioms |
+| This rule (`testing.md`) | the quality bar + the "be idiomatic" stance |
+| Runner rules (`bats.md`, …) | each tool's invocation, file pattern, idioms |
 | `qa.md` | the QA pipeline that *runs* the tests (Tests dimension) |
 | repo `.claude/TESTS.md` | that repo's concrete layout, what it tests, coverage policy |
 
 ## Agent Behavior
 
-- Put new tests under `tests/<language>/`, named per the convention; do not
-  scatter tests across ad-hoc directories or mix languages in one subdir.
-- Keep scaffolding/helpers out of the per-language test dirs.
+- Add tests using the idiomatic layout and runner for the **language**,
+  taking the concrete pattern from that language's runner rule and the
+  repo's `.claude/TESTS.md` — do not impose a fixed structure the repo
+  does not already use.
+- Cover success **and** failure paths; add a regression test with each bug
+  fix.
 - Get a repo's concrete layout/policy from its `.claude/TESTS.md`, each
   runner's details from its rule, and pipeline/gating from `qa.md`.


### PR DESCRIPTION
## Summary
- **`github-actions.md` → on-demand.** Path-scoped to `.github/workflows/**`, so it auto-loads only when a workflow file is being edited. Its PR-watch trigger isn't a file edit, but `gh.md` (always-on) already points here, so the agent reads it when it actually creates a PR. Stops costing ~1.3k/turn everywhere.
- **`testing.md` → non-prescriptive.** Removed the fixed language→subdir→runner table, file patterns, and run commands that read as mandates. Rewritten around the quality bar (tests exist; success+failure; regression per bug fix) and a "be idiomatic for the language" stance — this repo's one-root/per-language-subdir layout is offered as *one* sensible multi-language model, not the only one. Concrete runners/patterns/layout defer to per-runner rules and each repo's `.claude/TESTS.md`.

## Test plan
- [ ] In a repo with no `.github/workflows/` edit in play, `github-actions.md` no longer appears in `/context`; editing a workflow file pulls it in.
- [ ] `testing.md` no longer dictates bats/pytest/prove/Pester or `tests/<lang>/` as requirements; reads as principle + idiomatic guidance.