### PR TITLE
docs: audit-setup clarifications — global re-eval expected; layer generic over specific

### DIFF
--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -169,3 +169,36 @@ context-economy pull the same way:
 Avoid duplicating a capability across repos: copies drift and are
 error-prone, even with an agent maintaining them. Keep it global wherever it
 can be made to load lazily.
+
+### Layer the generic over the specific
+
+A capability that is *mostly* generic but carries language- or
+framework-specific details (an API-doc generator, a test scaffolder, a
+"clean-code" reviewer) should be built in **two layers** — never as one
+artifact with a single stack's specifics baked in:
+
+1. **A thin, stack-agnostic layer** describing *what* to do in terms true for
+   every language — qa-check's "format, then lint, then type-check"; an
+   api-documenter's "extract the public surface, document each symbol, show
+   usage." It carries no Python/Go/TS-only assumptions.
+2. **The stack-specific pattern it points to** — the concrete *how*, kept in a
+   path-scoped rule or an on-demand skill that loads only on that stack
+   (`fastapi-patterns` on `**/*.py`; a hypothetical `godoc-patterns` on
+   `**/*.go`). The thin layer **delegates** here instead of hard-coding it.
+
+Why: one language's specifics inside a generic artifact **mislead every other
+repo**. An `api-documenter` that quietly assumes docstrings and type hints is
+confusing — even wrong — in a Go-only repo like packwiz. Splitting the layers
+keeps the generic part reusable everywhere and the specifics correct only
+where they apply. This is the three-tier *Configuration Migration* model (in
+`CLAUDE.md`) applied **inside** one capability — and exactly why `qa.md` is
+tool-agnostic and the `fastapi.md` rule points to the `fastapi-patterns`
+skill.
+
+**When mining other repos for ideas** (the audit's *Idea sources*): a borrowed
+item that fuses generic intent with one stack's specifics — like
+`claude-tools`'s `api-documenter` agent — should be **split, not vendored
+whole**. Lift the generic intent into a thin rule/skill, and re-home (or newly
+write) the stack-specific half as a path-scoped pattern. Often the right form
+is *not* the original's — adopt the idea, then choose the kind (rule/skill)
+that fits, rather than copying the agent verbatim.

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -116,7 +116,9 @@ decisions are also summarized in the *Decisions log*.
 - [ ] **Cadence.** Run `claude-audit` on a cadence — a quick pass *often*
   (enabled plugins/MCP, obvious always-on bloat) and a deeper audit
   *periodically*. Wire it to a reminder / `/schedule`. Each detailed run
-  records decisions here.
+  records decisions here. Expect the **global** config to be re-evaluated from
+  many repos — possibly several times a day; that repetition is by design (see
+  the claude-audit skill, *Global is re-evaluated from every repo*).
 - [ ] **Context-load tiering.** Classify every artifact by *when* it loads:
   always-on (every turn: global CLAUDE.md, unscoped rules, enabled MCP tool
   schemas — the expensive tier), on-demand (path-scoped rules, skills, deferred

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -63,7 +63,11 @@ log) — the canonical methodology and living record. In short:
    audit's own reading does not consume the context it is protecting.
 2. **Classify** every artifact by load tier (always-on / on-demand / isolated)
    and assess right-fit: is it the correct *kind* (rule vs skill vs hook vs
-   command) and in the right *place*?
+   command), in the right *place*, and — for anything generic — **free of one
+   stack's specifics bleeding into it**? A generic primitive should be a thin
+   stack-agnostic layer that points to path-scoped per-stack patterns (see
+   *Layer the generic over the specific* in `EXTENDING.md`); flag a Python-
+   flavored "generic" agent that would mislead a Go-only repo.
 3. **Recommend** by **cost × (1 − relevance)** — trim weight, never
    guardrails. Apply the placement ladder from `EXTENDING.md` (global+lazy >
    per-repo) and the plugin/MCP rules from `rules/mcp.md` (plugins are global

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -19,6 +19,27 @@ from.
 2. **Local** — the current repo's own Claude setup: its `.claude/` (CLAUDE.md,
    rules, skills) and any per-repo MCP/plugin needs.
 
+## Global is re-evaluated from every repo — by design
+
+The global config is shared across many repos, so the audit re-examines it
+**every time it runs, from whatever repo invoked it** — quite possibly several
+times in a single day. That repetition is expected, not wasted work:
+
+- Each repo exercises the shared languages/frameworks differently and brings
+  its **own quirks**. A gap, rough edge, or missing rule that only one repo
+  surfaces is still a **global** gap worth fixing once, for every repo that
+  shares that stack.
+- So "I already audited the global config earlier today" is **not** a reason
+  to skip it. Re-evaluate it from *this* repo's vantage.
+- Resolve each quirk to the right scope: **iron it out globally** when it
+  helps every repo on that stack (a new or improved rule or skill, landed via
+  the dotfiles PR), or **document it locally** in the repo's `.claude/`
+  when it is genuinely repo-specific. Either way the quirk becomes a decision,
+  not a recurring surprise.
+
+Treat the global config as a living thing many repos keep sharpening — the
+more vantage points it is audited from, the better it fits all of them.
+
 ## Running from another repo — modify dotfiles, scoped
 
 When invoked outside the dotfiles repo, the audit **modifies the dotfiles


### PR DESCRIPTION
Two audit-setup documentation clarifications (held together at the user's request).

## Summary
- **Global re-eval from many repos is expected** (`claude-audit` skill + `SETUP-AUDIT.md` Cadence): the audit re-examines the global config every run, from any repo — possibly several times a day — by design. Each repo surfaces its own quirks on shared stacks; a gap one repo hits is a global gap worth fixing/documenting once.
- **"Layer the generic over the specific"** (`EXTENDING.md` + a right-fit check in the `claude-audit` skill): a mostly-generic capability with language/framework specifics should be two layers — a thin stack-agnostic layer describing *what*, pointing to a path-scoped per-stack pattern for the *how*. Baking one language's specifics into a "generic" artifact misleads other-stack repos (a docstring/type-hint-assuming api-documenter is wrong in a Go-only repo like packwiz). Includes a mining corollary: split borrowed mixed artifacts, don't vendor whole.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] Prose wraps at 78 cols
- [ ] `SETUP-AUDIT.md` Cadence references the skill's global-re-eval section
- [ ] `claude-audit` right-fit step references EXTENDING.md's layering section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
