### PR TITLE
docs(audit): full mining census, source-discovery, and repo-foreign placement (ADR-0003)

### DIFF
--- a/config/claude/.gitignore
+++ b/config/claude/.gitignore
@@ -18,3 +18,5 @@
 !hooks/**
 !adr/
 !adr/**
+!audit/
+!audit/**

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -202,3 +202,31 @@ whole**. Lift the generic intent into a thin rule/skill, and re-home (or newly
 write) the stack-specific half as a path-scoped pattern. Often the right form
 is *not* the original's — adopt the idea, then choose the kind (rule/skill)
 that fits, rather than copying the agent verbatim.
+
+### Foreign to the repo → global, and front-loaded
+
+Guidance about anything **foreign to the current repo** — a third-party
+library / framework / tool, **or our own code that lives in a *different*
+repo** — belongs in the **global generic layer** (a global skill or
+path-scoped rule), **even if only this one repo uses it today**. "Foreign to
+this repo" means "shared by nature": it already exists outside this repo and
+*will* recur in another one. So author the full global artifact the **first**
+time you need it, while already in context — not a repo-local half-job you
+have to remember to generalize later. Front-load the grunt work; you are
+spending it anyway. (ADR-0003.)
+
+Repo-local `.claude/` is therefore reserved for *this repo's own* code,
+architecture, and quirks — never for an external dependency.
+
+This is **not** a violation of the Rule of Three (`code-style.md`), which
+guards against speculatively abstracting *your own* code before the pattern is
+proven. An external library is not speculative — it is already stable, and
+"foreign to this repo" *is* the signal that the third instance is effectively
+guaranteed. So:
+
+- **Our own repo-specific pattern** → repo-local; wait for the third instance
+  before abstracting.
+- **A library/tool foreign to the repo** → global immediately, on first use.
+
+The build/skip decision is still "do we use it at all" — but *when* we do
+build, the placement is global, and the timing is now.

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -96,8 +96,12 @@ again. The two are distinct by design:
 | `rafaelkamimura/claude-tools` | Layered-architecture ideas; candidate commands (`adr`, `tech-debt`, `debug-assistant`) and agents (`database-optimizer`, `api-documenter`) | MIT | 2026-06-11 | No (ideas only) |
 | `pydantic/skills` (official) | Pydantic AI **agent-framework** + Logfire skills — relevant only if we adopt LLM agents or Logfire observability; not used today | MIT (check) | 2026-06-11 | No |
 
-Open mining follow-up (agents/commands worth evaluating) is in the *Audit
-backlog* below.
+The **full disposition census** of every item in these repos (every agent /
+command / hook / skill considered, ADOPT/CANDIDATE/SKIP + reason) is in
+`audit/mining-census.md`. The open CANDIDATE backlog lives there too. The
+source-discovery method (official-first → stars+recency+health; the >1yr
+staleness gate) and the full-census/generic-lens practice are documented in the
+**claude-audit** skill (*Mining repos for ideas*).
 
 ## Audit backlog
 
@@ -255,3 +259,14 @@ decisions are also summarized in the *Decisions log*.
   `SOURCE.md` only on implementation reuse). The dotfiles-system `docs/adr/`
   area is out of audit scope — created when its first decision arises. Landed
   via dotfiles PR.
+- 2026-06-11 — **Full mining census + discovery method (corrective).** The
+  earlier mining evaluated a pre-filtered shortlist of 9 and under-weighted
+  generic, whole-environment value. Corrected: charted **all ~158 items** across
+  the four repos into `audit/mining-census.md` (ADOPT/CANDIDATE/SKIP + reason),
+  and documented two practices in the claude-audit skill — **source discovery**
+  (official-first → stars+recency+maintenance-health; >1yr staleness gate,
+  re-evaluate not discard) and **full-census + generic-lens mining** (enumerate
+  the whole surface, judge by value to *any* repo, treat an agent/command as a
+  candidate even when reimplemented as a skill). Surfaced a tiered CANDIDATE
+  backlog (strongest: the architecture/codebase-analysis cluster). Landed via
+  dotfiles PR.

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -270,3 +270,11 @@ decisions are also summarized in the *Decisions log*.
   candidate even when reimplemented as a skill). Surfaced a tiered CANDIDATE
   backlog (strongest: the architecture/codebase-analysis cluster). Landed via
   dotfiles PR.
+- 2026-06-11 — **Placement refinement (ADR-0003).** Guidance for anything
+  *foreign to the current repo* (a third-party library, or our own code in a
+  different repo) is **global and front-loaded** — authored as a global
+  skill/rule the first time any repo uses it, even for single-repo use, rather
+  than repo-local or deferred. Corrected the mining census Tier-3 mislabel
+  ("per-repo need" → global/build-on-first-use) and documented the principle in
+  `EXTENDING.md`. Reconciles with the Rule of Three (which guards *our own*
+  code, not stable external libraries).

--- a/config/claude/adr/0003-foreign-library-guidance-is-global.md
+++ b/config/claude/adr/0003-foreign-library-guidance-is-global.md
@@ -1,0 +1,59 @@
+# ADR-0003: Guidance for repo-foreign libraries is global, front-loaded
+
+- **Status:** Accepted
+- **Date:** 2026-06-11
+
+## Context
+
+`EXTENDING.md` says global+lazy beats per-repo copies, and "layer the generic
+over the specific." But the *placement and timing* for a library used by only
+**one** repo today was left ambiguous, and the mining census mislabeled such
+items "adopt per-repo-need" — implying repo-local, or deferral until several
+repos need them. The Rule of Three (`code-style.md`) also nudges "wait for the
+third instance" before abstracting, which seems to argue for deferral. The
+user works across many repos in different languages, and the same external
+libraries recur across them.
+
+## Decision
+
+Guidance (a skill, rule, etc.) about anything **foreign to the current
+repo** — a third-party library/framework/tool, **or our own code hosted in a
+different repo** — lives in the **global generic layer**, **even if only one
+repo uses it today**, and is authored the **first** time it is needed, not
+deferred.
+
+"Foreign to this repo" = shared by nature: it already exists outside this repo
+and will recur in another. Repo-local `.claude/` is reserved for *this repo's
+own* code, architecture, and quirks — never for an external dependency. The
+build/skip decision is still "do we use it at all"; but when we build, the
+placement is global and the timing is now.
+
+## Alternatives considered
+
+### Defer to repo-local until more repos need it (Rule of Three) — rejected
+
+The "third instance" is effectively guaranteed for a shared library, so
+deferral only means re-discovering the need later and redoing the work
+out-of-context. The Rule of Three guards against speculatively abstracting
+*our own* code before a pattern is proven; an external library is not
+speculative — it is already stable, and "foreign to the repo" is itself the
+signal that it will recur.
+
+### Keep it global but build lazily (only when a 2nd repo appears) — rejected
+
+Same remember-and-redo-later cost. Front-loading while already doing the grunt
+work for the first repo is strictly cheaper than context-switching back to it
+later.
+
+## Consequences
+
+- On first use of an external library in any repo, its guidance is authored as
+  a global artifact (path-scoped rule / on-demand skill) — as already done for
+  FastAPI, SQLAlchemy, pydantic.
+- The mining census "Tier 3" is about *whether/when* to build (when first
+  used), not *where* (always global).
+- Our-own-repo patterns stay repo-local and continue to follow the Rule of
+  Three — this decision applies only to repo-foreign things.
+- Accepted cost: a little up-front work for a library that might never recur.
+  Cheaper than deferred re-work and the risk of forgetting. Recorded in
+  `EXTENDING.md` → *Foreign to the repo → global, and front-loaded*.

--- a/config/claude/adr/README.md
+++ b/config/claude/adr/README.md
@@ -15,6 +15,7 @@ decision; immutable once Accepted (supersede, don't rewrite).
 |----|-------|--------|------|
 | [0001](0001-skills-over-custom-commands.md) | Skills over custom commands for invokable procedures | Accepted | 2026-06-11 |
 | [0002](0002-adapt-not-vendor-provenance.md) | Adapt-not-vendor; SOURCE.md only on implementation reuse | Accepted | 2026-06-11 |
+| [0003](0003-foreign-library-guidance-is-global.md) | Guidance for repo-foreign libraries is global, front-loaded | Accepted | 2026-06-11 |
 
 ## Statuses
 

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -1,14 +1,15 @@
 # Mining census
 
-Full disposition tables for every repo mined for ideas during audits. The
-*Idea sources* registry in `SETUP-AUDIT.md` is the index; this file is the
-**complete mapping** — every agent / command / hook / skill considered and why
-it was or wasn't adopted. Audit-only (not context-loaded).
+The index + explanations for repos mined for ideas during audits. The *Idea
+sources* registry in `SETUP-AUDIT.md` is the higher-level index; this file
+explains the method and links the **complete mapping** — every agent / command
+/ hook / skill considered and why it was or wasn't adopted, in a **per-repo
+matrix file** under `mining/`. Audit-only (not context-loaded).
 
 **Why a full census:** an audit improves the *whole* dev environment, so good
 *generic* tooling should spread to every repo. Charting only a curated
 shortlist hides what was skipped and biases toward the current repo's stack.
-Each mined repo gets a complete table here.
+Every mined repo gets its own complete matrix file.
 
 ## Disposition key
 
@@ -25,158 +26,40 @@ Disposition reflects **generic value to the whole environment**, then overlap
 with existing built-ins / skills / rules, then the "layer the generic over the
 specific" principle (`EXTENDING.md`).
 
+## Adopting a CANDIDATE — fold into existing categories
+
+When a CANDIDATE is built, **try to fit it into an existing top-level
+category** rather than spawning a new one: `code-style`, `testing`, `qa`,
+tools (`gh`,
+`git`), etc. Most mined items map cleanly — `tech-debt`/`arch-review`/
+`dependency-analyzer` → **qa**; `test-reviewer`/`test-suite` → **testing**;
+`pytest-patterns`/`typing-patterns` → the language depth under **qa/testing**.
+Don't force it — a genuinely new area (e.g. an `architecture`/`docs` family)
+earns its own top-level category. The default is "extend a family," the
+exception is "open a new one."
+
 ---
 
 ## Round 2026-06-11 — FastAPI/SQLAlchemy/Python mining
 
-Sources (all MIT; see *Idea sources* for SHAs/recency): `rafaelkamimura/
-claude-tools`, `ruslan-korneev/claude-plugins`, `pydantic/skills`,
-`fastapi/fastapi`. **~158 items charted.** Already actioned this round: the
-`fastapi-patterns` / `sqlalchemy-patterns` skills and the `adr` skill; the
-rest of the CANDIDATEs are an open backlog (triage at the end).
+Sources (all MIT; see *Idea sources* for SHAs/recency). **~158 items
+charted.** Already actioned: the `fastapi-patterns` / `sqlalchemy-patterns`
+skills and the `adr` skill; the rest of the CANDIDATEs are the backlog below.
 
-### claude-tools — commands (32)
+Per-repo matrices:
 
-| name | scope | disp. | reason |
-|------|-------|-------|--------|
-| brainstorm | generic | CANDIDATE | deep requirements ideation; pairs with built-in Plan |
-| bslist | generic | CANDIDATE | list/resume past brainstorm sessions |
-| debug-assistant | generic | CANDIDATE | structured debugging harness (stack-trace → repro → fix) |
-| deps-update | generic | CANDIDATE | dependency auditor w/ compat testing + changelog |
-| dev-docs | generic | CANDIDATE | spec → implementation plan + checklist |
-| dev-docs-update | generic | CANDIDATE | capture session state before context-limit reset |
-| env-sync | generic | CANDIDATE | .env sync/validation/secret rotation (security-sensitive) |
-| handoff | generic | CANDIDATE | task-transfer / onboarding doc generation |
-| perf-check | generic | CANDIDATE | profiling (CPU/mem/DB/API) — multi-language |
-| read-specs | generic | CANDIDATE | spec → tasks + flow diagrams |
-| standup | generic | CANDIDATE | standup notes from git history + todos |
-| task-init | generic | CANDIDATE | multi-phase task orchestration (overlaps Plan) |
-| tech-debt | generic | CANDIDATE | catalog debt/TODOs/complexity, prioritize by ROI |
-| test-suite | generic | CANDIDATE | test runner + coverage delta + missing-test gen (overlaps qa-check) |
-| write-documentation | generic | CANDIDATE | multi-format doc generation (API/arch/DB) |
-| deploy | stack | CANDIDATE | deployment orchestration — infra/repo-specific |
-| rollback | stack | CANDIDATE | recovery/rollback orchestration — infra-specific |
-| commit | generic | SKIP | overlaps git/gh rules + ship-pr; msg-gen fights the staging rules |
-| mr-draft | stack | SKIP | PR-description gen; overlaps ship-pr + gh PR format; PT-BR |
-| review-code | generic | SKIP | built-in `/code-review` + `/simplify` |
-| security-scan | generic | SKIP | `security-scan` skill |
-| create-skill | generic | SKIP | `skill-creator` plugin |
-| sync-config | generic | SKIP | meta — this dotfiles repo + chezmoi already do config-as-code |
-| todo-worktree | generic | SKIP | `git-worktree-workflow` skill |
-| close/fetch/update-azure-task (×3) | niche | SKIP | Azure DevOps-locked |
-| generate-interview, interview-analysis-template, interview-context-storage, pdf-to-markdown, screen-resume (×5) | niche | SKIP | HR/recruitment — not dev tooling |
-
-### claude-tools — agents (46)
-
-| name | scope | disp. | reason |
-|------|-------|-------|--------|
-| plan-reviewer | generic | CANDIDATE | pre-implementation plan QA (before vs after code) — strong, novel |
-| dependency-analyzer-style (see tech-lead) | generic | — | (its analog is in tech-lead; see below) |
-| database-optimizer | generic | CANDIDATE | query/index/N+1 — SQLAlchemy half in sqlalchemy-patterns; generic lens novel |
-| performance-engineer | generic | CANDIDATE | profiling/load/Core-Web-Vitals (broader than database-optimizer) |
-| accessibility-specialist | generic | CANDIDATE | WCAG/ARIA/keyboard — novel a11y lens |
-| security-auditor | generic | CANDIDATE | deeper OWASP/auth/crypto audit (vs `/security-review`) |
-| documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
-| api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
-| backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
-| refactor-planner | generic | CANDIDATE | refactoring plans + risk (planning vs execution) |
-| legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |
-| test-automator | generic | CANDIDATE | test strategy/pyramid planning |
-| frontend-qa-tester | generic | CANDIDATE | Playwright-driven manual QA + bug reports |
-| ui-ux-designer | generic | CANDIDATE | design methodology (vs frontend-design's implementation) |
-| devops-troubleshooter | generic | CANDIDATE | incident response / log analysis |
-| web-research-specialist | generic | CANDIDATE | overlaps `/deep-research`; lower priority |
-| ai-engineer | generic | CANDIDATE | LLM/RAG/agent patterns — relevant if building AI features |
-| deployment-engineer, cloud-architect, data-engineer, ml-engineer | stack | CANDIDATE | infra/data/ML — per-repo need |
-| payment-integration, graphql-architect | stack | CANDIDATE | domain-specific but high-value when relevant |
-| python-pro, typescript-expert, golang-pro, rust-pro | stack | CANDIDATE | language-expert personas — low priority, rules already encode per-lang policy |
-| nextjs-app-router-developer, frontend-developer | stack | CANDIDATE | Next.js — overlaps `frontend-design`; low priority |
-| code-architecture-reviewer, code-refactor-master, code-reviewer, debugger | generic | SKIP | overlap `/code-review`, `/simplify`, built-in Explore |
-| data-scientist | stack | SKIP | BigQuery-locked |
-| arbitrage-bot, blockchain-developer, crypto-analyst, crypto-risk-manager, crypto-trader, defi-strategist, quant-analyst (×7) | niche | SKIP | crypto/DeFi/quant-finance |
-| directus-developer, drupal-developer, laravel-vue-developer, php-developer, game-developer, mobile-developer (×6) | niche | SKIP | framework/language not in the user's stack |
-
-### claude-tools — skills (5) + hooks (5)
-
-| name | type | scope | disp. | reason |
-|------|------|-------|-------|--------|
-| fastapi-clean-architecture | skill | generic | CANDIDATE | DDD/clean-arch layering — extends fastapi-patterns (weigh foreign idioms) |
-| multi-system-sso-authentication | skill | stack | CANDIDATE | only if integrating external SSO |
-| async-testing-expert | skill | generic | SKIP | testing.md + bats-setup; async patterns are testing.md's domain |
-| skill-developer | skill | generic | SKIP | meta — skill-creator plugin covers it |
-| brazilian-financial-integration | skill | niche | SKIP | BR fintech (boleto/PIX/CPF) |
-| skill-activation-prompt(.ts/.sh), post-tool-use-tracker.sh, hooks.json, package.json (×5) | hook/config | generic | SKIP | meta-infra, Node/JS-hardcoded; not user-facing capabilities |
-
-### claude-plugins — tech-lead plugin (16 cmd, 9 agent, 4 skill)
-
-The architecture/codebase-analysis cluster is the strongest generic find.
-
-| name | type | scope | disp. | reason |
-|------|------|-------|-------|--------|
-| deps | cmd | generic | CANDIDATE | module dependency analysis + coupling metrics (Ca/Ce/I), circular deps |
-| dependency-analyzer | agent | generic | CANDIDATE | same, deeper — instability scoring, layer violations |
-| arch-review | cmd | generic | CANDIDATE | architecture audit (layers, DI, anti-patterns) — deeper than `/review` |
-| architecture-reviewer | agent | generic | CANDIDATE | Opus-grade architecture audit (10-point) |
-| diagram | cmd | generic | CANDIDATE | Mermaid architecture diagrams (component/ER/sequence/deploy) |
-| modernize | cmd | generic | CANDIDATE | legacy assessment + Strangler-Fig roadmap |
-| codebase-explorer | agent | generic | CANDIDATE | fast project-structure discovery (feeds planning) |
-| codebase-analyzer | agent | generic | CANDIDATE | extract entities/endpoints/services from existing code |
-| planning-agent | agent | generic | CANDIDATE | deep planning w/ memory anchors (overlaps built-in Plan) |
-| feature-designer | agent | generic | CANDIDATE | greenfield BR/US/AC design |
-| design | cmd | generic | CANDIDATE | interactive architecture design + scaffold |
-| feature-specification | skill | generic | CANDIDATE | structured spec format (BR/US/AC) |
-| architecture-patterns | skill | stack | CANDIDATE | FastAPI/SQLAlchemy system patterns — overlaps our skills |
-| dev, execute, execution-agent, tdd-workflow | cmd/agent/skill | generic | CANDIDATE-low | TDD orchestration — overlaps built-in Plan + manual TDD |
-| adr | cmd | generic | SKIP | **adopted** as the `adr` skill |
-| review, code-review (skill), code-reviewer, quick-reviewer | cmd/skill/agent | generic | SKIP | overlap `/code-review`, `/review`, `/simplify` |
-| features:init/add/status/graph/analyze/design (×6) | cmd | niche | SKIP | feature-spec-workflow scaffolding (adopt only with that workflow) |
-
-### claude-plugins — python plugin (10 cmd, 4 skill, 1 agent, 1 hook)
-
-| name | type | scope | disp. | reason |
-|------|------|-------|-------|--------|
-| pytest-patterns | skill | generic | CANDIDATE | production pytest/TDD depth — could enrich like fastapi-patterns did |
-| typing-patterns | skill | generic | CANDIDATE | Python typing depth (no `type: ignore`) — augments python.md |
-| test-reviewer | agent | generic | CANDIDATE | coverage + test-quality (AAA/naming) analysis |
-| lint:explain, typecheck:explain | cmd | generic | SKIP | no-suppression policy already in ruff.md + python.md; explain = normal agent capability |
-| test:first | cmd | generic | SKIP | testing.md bar; TDD on request |
-| clean:review, clean-code-patterns | cmd/skill | generic | SKIP | code-style.md + qa.md Code-style audit + `/simplify` |
-| lint, lint:config, typecheck, ruff-patterns | cmd/skill | generic | SKIP | ruff.md + python.md + qa-check pipeline |
-| test:fixture, test:mock | cmd | generic | SKIP | low-level helpers; testing.md covers |
-| hooks.json (ruff/mypy on edit) | hook | generic | SKIP | conflicts with "auto-fixers run once" (pre-commit) — already declined |
-
-### claude-plugins — fastapi plugin (5 cmd, 2 skill, 1 agent)
-
-| name | type | scope | disp. | reason |
-|------|------|-------|-------|--------|
-| fastapi:module | cmd | stack | CANDIDATE | full-module generator — speed over fastapi-patterns prose |
-| fastapi:endpoint | cmd | stack | CANDIDATE | endpoint+service+test scaffolder |
-| fastapi:migrate:create | cmd | stack | CANDIDATE | Alembic create w/ enum-downgrade auto-fix |
-| fastapi:migrate:check / migration-reviewer | cmd/agent | stack | CANDIDATE | pre-apply migration review — automates the sqlalchemy-patterns checklist |
-| fastapi:dto | cmd | stack | SKIP | DTO patterns in fastapi-patterns |
-| fastapi-patterns, alembic-patterns | skill | stack | SKIP | adopted / covered by alembic.md |
-
-### claude-plugins — linear plugin (4 cmd, 1 skill, 1 agent)
-
-| name | scope | disp. | reason |
-|------|-------|-------|--------|
-| board, comment, cycle, delete, linear-api, issue-enricher (×6) | niche | SKIP | Linear SaaS integration — only if the user adopts Linear |
-
-### pydantic/skills (5) + fastapi official (1)
-
-| name | scope | disp. | reason |
-|------|-------|-------|--------|
-| building-pydantic-ai-agents, pydantic-ai-harness | niche | CANDIDATE-if-building-agents | the `pydantic_ai` agent framework — see the deferred `rules/pydantic-ai.md` backlog item |
-| logfire-instrumentation, logfire-query, logfire-ui | niche | CANDIDATE-if-adopting-Logfire | observability platform — adopt if Logfire is used |
-| fastapi (official) | stack | SKIP | covered by fastapi.md + fastapi-patterns; **re-mine on FastAPI version bumps** |
+- [`mining/claude-tools.md`](mining/claude-tools.md) — `rafaelkamimura/claude-tools` (93 items)
+- [`mining/claude-plugins.md`](mining/claude-plugins.md) — `ruslan-korneev/claude-plugins` (4 plugins, 59 items)
+- [`mining/pydantic-skills.md`](mining/pydantic-skills.md) — `pydantic/skills`, official (5)
+- [`mining/fastapi.md`](mining/fastapi.md) — `fastapi/fastapi` official skill (1)
 
 ---
 
 ## Open CANDIDATE backlog (triage)
 
 Not built — surfaced for the user to choose. Adopt as skills (ADR-0001),
-splitting any stack-flavored ones per the layering principle. Grouped by
-leverage:
+folding into an existing category where one fits (above) and splitting any
+stack-flavored ones per the layering principle. Grouped by leverage:
 
 **Tier 1 — strong generic, low overlap (best whole-environment wins):**
 architecture/codebase analysis — `dependency-analyzer`/`deps` (coupling,

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -191,7 +191,11 @@ circular deps), `arch-review`/`architecture-reviewer`, `diagram` (Mermaid),
 fastapi-patterns), `accessibility-specialist`, `security-auditor`,
 `ui-ux-designer`, `handoff`, `standup`, `dev-docs-update`, `brainstorm`.
 
-**Tier 3 — adopt per-repo-need (stack/specialized):** language-expert agents
+**Tier 3 — external libraries/frameworks/tools: global, built on first use.**
+These are all guidance about something *foreign to the repo*, so per ADR-0003
+they live in the **global** generic layer (not repo-local), and the only
+question is *when* to build — answer: the first time any repo uses the
+library/tool, front-loaded, not deferred. Items: language-expert agents
 (python/go/rust/ts), `graphql-architect`, `payment-integration`,
 `ai-engineer`, `data-engineer`/`ml-engineer`,
 `deploy`/`rollback`/`deployment-engineer`/

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -1,0 +1,199 @@
+# Mining census
+
+Full disposition tables for every repo mined for ideas during audits. The
+*Idea sources* registry in `SETUP-AUDIT.md` is the index; this file is the
+**complete mapping** — every agent / command / hook / skill considered and why
+it was or wasn't adopted. Audit-only (not context-loaded).
+
+**Why a full census:** an audit improves the *whole* dev environment, so good
+*generic* tooling should spread to every repo. Charting only a curated
+shortlist hides what was skipped and biases toward the current repo's stack.
+Each mined repo gets a complete table here.
+
+## Disposition key
+
+- **ADOPT** — clear, high-value, low-overlap; build it (as a skill per
+  ADR-0001, or a rule/hook if that's the right kind).
+- **CANDIDATE** — genuinely worth considering for the global setup; **the
+  user decides**. Judged by value to *any* repo, not just the one being
+  audited. An agent/command can be a CANDIDATE even though we'd reimplement it
+  as a skill.
+- **SKIP** — covered by existing tooling, niche/domain-locked, meta-infra, or
+  already adopted. Reason given.
+
+Disposition reflects **generic value to the whole environment**, then overlap
+with existing built-ins / skills / rules, then the "layer the generic over the
+specific" principle (`EXTENDING.md`).
+
+---
+
+## Round 2026-06-11 — FastAPI/SQLAlchemy/Python mining
+
+Sources (all MIT; see *Idea sources* for SHAs/recency): `rafaelkamimura/
+claude-tools`, `ruslan-korneev/claude-plugins`, `pydantic/skills`,
+`fastapi/fastapi`. **~158 items charted.** Already actioned this round: the
+`fastapi-patterns` / `sqlalchemy-patterns` skills and the `adr` skill; the
+rest of the CANDIDATEs are an open backlog (triage at the end).
+
+### claude-tools — commands (32)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| brainstorm | generic | CANDIDATE | deep requirements ideation; pairs with built-in Plan |
+| bslist | generic | CANDIDATE | list/resume past brainstorm sessions |
+| debug-assistant | generic | CANDIDATE | structured debugging harness (stack-trace → repro → fix) |
+| deps-update | generic | CANDIDATE | dependency auditor w/ compat testing + changelog |
+| dev-docs | generic | CANDIDATE | spec → implementation plan + checklist |
+| dev-docs-update | generic | CANDIDATE | capture session state before context-limit reset |
+| env-sync | generic | CANDIDATE | .env sync/validation/secret rotation (security-sensitive) |
+| handoff | generic | CANDIDATE | task-transfer / onboarding doc generation |
+| perf-check | generic | CANDIDATE | profiling (CPU/mem/DB/API) — multi-language |
+| read-specs | generic | CANDIDATE | spec → tasks + flow diagrams |
+| standup | generic | CANDIDATE | standup notes from git history + todos |
+| task-init | generic | CANDIDATE | multi-phase task orchestration (overlaps Plan) |
+| tech-debt | generic | CANDIDATE | catalog debt/TODOs/complexity, prioritize by ROI |
+| test-suite | generic | CANDIDATE | test runner + coverage delta + missing-test gen (overlaps qa-check) |
+| write-documentation | generic | CANDIDATE | multi-format doc generation (API/arch/DB) |
+| deploy | stack | CANDIDATE | deployment orchestration — infra/repo-specific |
+| rollback | stack | CANDIDATE | recovery/rollback orchestration — infra-specific |
+| commit | generic | SKIP | overlaps git/gh rules + ship-pr; msg-gen fights the staging rules |
+| mr-draft | stack | SKIP | PR-description gen; overlaps ship-pr + gh PR format; PT-BR |
+| review-code | generic | SKIP | built-in `/code-review` + `/simplify` |
+| security-scan | generic | SKIP | `security-scan` skill |
+| create-skill | generic | SKIP | `skill-creator` plugin |
+| sync-config | generic | SKIP | meta — this dotfiles repo + chezmoi already do config-as-code |
+| todo-worktree | generic | SKIP | `git-worktree-workflow` skill |
+| close/fetch/update-azure-task (×3) | niche | SKIP | Azure DevOps-locked |
+| generate-interview, interview-analysis-template, interview-context-storage, pdf-to-markdown, screen-resume (×5) | niche | SKIP | HR/recruitment — not dev tooling |
+
+### claude-tools — agents (46)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| plan-reviewer | generic | CANDIDATE | pre-implementation plan QA (before vs after code) — strong, novel |
+| dependency-analyzer-style (see tech-lead) | generic | — | (its analog is in tech-lead; see below) |
+| database-optimizer | generic | CANDIDATE | query/index/N+1 — SQLAlchemy half in sqlalchemy-patterns; generic lens novel |
+| performance-engineer | generic | CANDIDATE | profiling/load/Core-Web-Vitals (broader than database-optimizer) |
+| accessibility-specialist | generic | CANDIDATE | WCAG/ARIA/keyboard — novel a11y lens |
+| security-auditor | generic | CANDIDATE | deeper OWASP/auth/crypto audit (vs `/security-review`) |
+| documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
+| api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
+| backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
+| refactor-planner | generic | CANDIDATE | refactoring plans + risk (planning vs execution) |
+| legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |
+| test-automator | generic | CANDIDATE | test strategy/pyramid planning |
+| frontend-qa-tester | generic | CANDIDATE | Playwright-driven manual QA + bug reports |
+| ui-ux-designer | generic | CANDIDATE | design methodology (vs frontend-design's implementation) |
+| devops-troubleshooter | generic | CANDIDATE | incident response / log analysis |
+| web-research-specialist | generic | CANDIDATE | overlaps `/deep-research`; lower priority |
+| ai-engineer | generic | CANDIDATE | LLM/RAG/agent patterns — relevant if building AI features |
+| deployment-engineer, cloud-architect, data-engineer, ml-engineer | stack | CANDIDATE | infra/data/ML — per-repo need |
+| payment-integration, graphql-architect | stack | CANDIDATE | domain-specific but high-value when relevant |
+| python-pro, typescript-expert, golang-pro, rust-pro | stack | CANDIDATE | language-expert personas — low priority, rules already encode per-lang policy |
+| nextjs-app-router-developer, frontend-developer | stack | CANDIDATE | Next.js — overlaps `frontend-design`; low priority |
+| code-architecture-reviewer, code-refactor-master, code-reviewer, debugger | generic | SKIP | overlap `/code-review`, `/simplify`, built-in Explore |
+| data-scientist | stack | SKIP | BigQuery-locked |
+| arbitrage-bot, blockchain-developer, crypto-analyst, crypto-risk-manager, crypto-trader, defi-strategist, quant-analyst (×7) | niche | SKIP | crypto/DeFi/quant-finance |
+| directus-developer, drupal-developer, laravel-vue-developer, php-developer, game-developer, mobile-developer (×6) | niche | SKIP | framework/language not in the user's stack |
+
+### claude-tools — skills (5) + hooks (5)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| fastapi-clean-architecture | skill | generic | CANDIDATE | DDD/clean-arch layering — extends fastapi-patterns (weigh foreign idioms) |
+| multi-system-sso-authentication | skill | stack | CANDIDATE | only if integrating external SSO |
+| async-testing-expert | skill | generic | SKIP | testing.md + bats-setup; async patterns are testing.md's domain |
+| skill-developer | skill | generic | SKIP | meta — skill-creator plugin covers it |
+| brazilian-financial-integration | skill | niche | SKIP | BR fintech (boleto/PIX/CPF) |
+| skill-activation-prompt(.ts/.sh), post-tool-use-tracker.sh, hooks.json, package.json (×5) | hook/config | generic | SKIP | meta-infra, Node/JS-hardcoded; not user-facing capabilities |
+
+### claude-plugins — tech-lead plugin (16 cmd, 9 agent, 4 skill)
+
+The architecture/codebase-analysis cluster is the strongest generic find.
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| deps | cmd | generic | CANDIDATE | module dependency analysis + coupling metrics (Ca/Ce/I), circular deps |
+| dependency-analyzer | agent | generic | CANDIDATE | same, deeper — instability scoring, layer violations |
+| arch-review | cmd | generic | CANDIDATE | architecture audit (layers, DI, anti-patterns) — deeper than `/review` |
+| architecture-reviewer | agent | generic | CANDIDATE | Opus-grade architecture audit (10-point) |
+| diagram | cmd | generic | CANDIDATE | Mermaid architecture diagrams (component/ER/sequence/deploy) |
+| modernize | cmd | generic | CANDIDATE | legacy assessment + Strangler-Fig roadmap |
+| codebase-explorer | agent | generic | CANDIDATE | fast project-structure discovery (feeds planning) |
+| codebase-analyzer | agent | generic | CANDIDATE | extract entities/endpoints/services from existing code |
+| planning-agent | agent | generic | CANDIDATE | deep planning w/ memory anchors (overlaps built-in Plan) |
+| feature-designer | agent | generic | CANDIDATE | greenfield BR/US/AC design |
+| design | cmd | generic | CANDIDATE | interactive architecture design + scaffold |
+| feature-specification | skill | generic | CANDIDATE | structured spec format (BR/US/AC) |
+| architecture-patterns | skill | stack | CANDIDATE | FastAPI/SQLAlchemy system patterns — overlaps our skills |
+| dev, execute, execution-agent, tdd-workflow | cmd/agent/skill | generic | CANDIDATE-low | TDD orchestration — overlaps built-in Plan + manual TDD |
+| adr | cmd | generic | SKIP | **adopted** as the `adr` skill |
+| review, code-review (skill), code-reviewer, quick-reviewer | cmd/skill/agent | generic | SKIP | overlap `/code-review`, `/review`, `/simplify` |
+| features:init/add/status/graph/analyze/design (×6) | cmd | niche | SKIP | feature-spec-workflow scaffolding (adopt only with that workflow) |
+
+### claude-plugins — python plugin (10 cmd, 4 skill, 1 agent, 1 hook)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| pytest-patterns | skill | generic | CANDIDATE | production pytest/TDD depth — could enrich like fastapi-patterns did |
+| typing-patterns | skill | generic | CANDIDATE | Python typing depth (no `type: ignore`) — augments python.md |
+| test-reviewer | agent | generic | CANDIDATE | coverage + test-quality (AAA/naming) analysis |
+| lint:explain, typecheck:explain | cmd | generic | SKIP | no-suppression policy already in ruff.md + python.md; explain = normal agent capability |
+| test:first | cmd | generic | SKIP | testing.md bar; TDD on request |
+| clean:review, clean-code-patterns | cmd/skill | generic | SKIP | code-style.md + qa.md Code-style audit + `/simplify` |
+| lint, lint:config, typecheck, ruff-patterns | cmd/skill | generic | SKIP | ruff.md + python.md + qa-check pipeline |
+| test:fixture, test:mock | cmd | generic | SKIP | low-level helpers; testing.md covers |
+| hooks.json (ruff/mypy on edit) | hook | generic | SKIP | conflicts with "auto-fixers run once" (pre-commit) — already declined |
+
+### claude-plugins — fastapi plugin (5 cmd, 2 skill, 1 agent)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| fastapi:module | cmd | stack | CANDIDATE | full-module generator — speed over fastapi-patterns prose |
+| fastapi:endpoint | cmd | stack | CANDIDATE | endpoint+service+test scaffolder |
+| fastapi:migrate:create | cmd | stack | CANDIDATE | Alembic create w/ enum-downgrade auto-fix |
+| fastapi:migrate:check / migration-reviewer | cmd/agent | stack | CANDIDATE | pre-apply migration review — automates the sqlalchemy-patterns checklist |
+| fastapi:dto | cmd | stack | SKIP | DTO patterns in fastapi-patterns |
+| fastapi-patterns, alembic-patterns | skill | stack | SKIP | adopted / covered by alembic.md |
+
+### claude-plugins — linear plugin (4 cmd, 1 skill, 1 agent)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| board, comment, cycle, delete, linear-api, issue-enricher (×6) | niche | SKIP | Linear SaaS integration — only if the user adopts Linear |
+
+### pydantic/skills (5) + fastapi official (1)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| building-pydantic-ai-agents, pydantic-ai-harness | niche | CANDIDATE-if-building-agents | the `pydantic_ai` agent framework — see the deferred `rules/pydantic-ai.md` backlog item |
+| logfire-instrumentation, logfire-query, logfire-ui | niche | CANDIDATE-if-adopting-Logfire | observability platform — adopt if Logfire is used |
+| fastapi (official) | stack | SKIP | covered by fastapi.md + fastapi-patterns; **re-mine on FastAPI version bumps** |
+
+---
+
+## Open CANDIDATE backlog (triage)
+
+Not built — surfaced for the user to choose. Adopt as skills (ADR-0001),
+splitting any stack-flavored ones per the layering principle. Grouped by
+leverage:
+
+**Tier 1 — strong generic, low overlap (best whole-environment wins):**
+architecture/codebase analysis — `dependency-analyzer`/`deps` (coupling,
+circular deps), `arch-review`/`architecture-reviewer`, `diagram` (Mermaid),
+`modernize` (legacy roadmap), `codebase-explorer`; `plan-reviewer`
+(pre-implementation plan QA); `tech-debt` (debt catalog); `debug-assistant`;
+`deps-update`; `write-documentation`/`documentation-architect`.
+
+**Tier 2 — useful generic, some overlap:**
+`perf-check`/`performance-engineer`,
+`test-reviewer`, `pytest-patterns`/`typing-patterns` (Python depth, like
+fastapi-patterns), `accessibility-specialist`, `security-auditor`,
+`ui-ux-designer`, `handoff`, `standup`, `dev-docs-update`, `brainstorm`.
+
+**Tier 3 — adopt per-repo-need (stack/specialized):** language-expert agents
+(python/go/rust/ts), `graphql-architect`, `payment-integration`,
+`ai-engineer`, `data-engineer`/`ml-engineer`,
+`deploy`/`rollback`/`deployment-engineer`/
+`devops-troubleshooter`/`cloud-architect`, the FastAPI scaffolders
+(`module`/`endpoint`/`migrate-*`), pydantic-ai + Logfire skills.

--- a/config/claude/audit/mining/claude-plugins.md
+++ b/config/claude/audit/mining/claude-plugins.md
@@ -1,0 +1,59 @@
+# Mining matrix — `ruslan-korneev/claude-plugins`
+
+Part of the mining census (`../mining-census.md` has the disposition key and
+the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 4 plugins, 59 items.
+
+## tech-lead plugin (16 cmd, 9 agent, 4 skill)
+
+The architecture/codebase-analysis cluster is the strongest generic find.
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| deps | cmd | generic | CANDIDATE | module dependency analysis + coupling metrics (Ca/Ce/I), circular deps |
+| dependency-analyzer | agent | generic | CANDIDATE | same, deeper — instability scoring, layer violations |
+| arch-review | cmd | generic | CANDIDATE | architecture audit (layers, DI, anti-patterns) — deeper than `/review` |
+| architecture-reviewer | agent | generic | CANDIDATE | Opus-grade architecture audit (10-point) |
+| diagram | cmd | generic | CANDIDATE | Mermaid architecture diagrams (component/ER/sequence/deploy) |
+| modernize | cmd | generic | CANDIDATE | legacy assessment + Strangler-Fig roadmap |
+| codebase-explorer | agent | generic | CANDIDATE | fast project-structure discovery (feeds planning) |
+| codebase-analyzer | agent | generic | CANDIDATE | extract entities/endpoints/services from existing code |
+| planning-agent | agent | generic | CANDIDATE | deep planning w/ memory anchors (overlaps built-in Plan) |
+| feature-designer | agent | generic | CANDIDATE | greenfield BR/US/AC design |
+| design | cmd | generic | CANDIDATE | interactive architecture design + scaffold |
+| feature-specification | skill | generic | CANDIDATE | structured spec format (BR/US/AC) |
+| architecture-patterns | skill | stack | CANDIDATE | FastAPI/SQLAlchemy system patterns — overlaps our skills |
+| dev, execute, execution-agent, tdd-workflow | cmd/agent/skill | generic | CANDIDATE-low | TDD orchestration — overlaps built-in Plan + manual TDD |
+| adr | cmd | generic | SKIP | **adopted** as the `adr` skill |
+| review, code-review (skill), code-reviewer, quick-reviewer | cmd/skill/agent | generic | SKIP | overlap `/code-review`, `/review`, `/simplify` |
+| features:init/add/status/graph/analyze/design (×6) | cmd | niche | SKIP | feature-spec-workflow scaffolding (adopt only with that workflow) |
+
+## python plugin (10 cmd, 4 skill, 1 agent, 1 hook)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| pytest-patterns | skill | generic | CANDIDATE | production pytest/TDD depth — could enrich like fastapi-patterns did |
+| typing-patterns | skill | generic | CANDIDATE | Python typing depth (no `type: ignore`) — augments python.md |
+| test-reviewer | agent | generic | CANDIDATE | coverage + test-quality (AAA/naming) analysis |
+| lint:explain, typecheck:explain | cmd | generic | SKIP | no-suppression policy already in ruff.md + python.md; explain = normal agent capability |
+| test:first | cmd | generic | SKIP | testing.md bar; TDD on request |
+| clean:review, clean-code-patterns | cmd/skill | generic | SKIP | code-style.md + qa.md Code-style audit + `/simplify` |
+| lint, lint:config, typecheck, ruff-patterns | cmd/skill | generic | SKIP | ruff.md + python.md + qa-check pipeline |
+| test:fixture, test:mock | cmd | generic | SKIP | low-level helpers; testing.md covers |
+| hooks.json (ruff/mypy on edit) | hook | generic | SKIP | conflicts with "auto-fixers run once" (pre-commit) — already declined |
+
+## fastapi plugin (5 cmd, 2 skill, 1 agent)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| fastapi:module | cmd | stack | CANDIDATE | full-module generator — speed over fastapi-patterns prose |
+| fastapi:endpoint | cmd | stack | CANDIDATE | endpoint+service+test scaffolder |
+| fastapi:migrate:create | cmd | stack | CANDIDATE | Alembic create w/ enum-downgrade auto-fix |
+| fastapi:migrate:check / migration-reviewer | cmd/agent | stack | CANDIDATE | pre-apply migration review — automates the sqlalchemy-patterns checklist |
+| fastapi:dto | cmd | stack | SKIP | DTO patterns in fastapi-patterns |
+| fastapi-patterns, alembic-patterns | skill | stack | SKIP | adopted / covered by alembic.md |
+
+## linear plugin (4 cmd, 1 skill, 1 agent)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| board, comment, cycle, delete, linear-api, issue-enricher (×6) | niche | SKIP | Linear SaaS integration — only if the user adopts Linear |

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -1,0 +1,75 @@
+# Mining matrix — `rafaelkamimura/claude-tools`
+
+Part of the mining census (`../mining-census.md` has the disposition key and
+the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
+
+## commands (32)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| brainstorm | generic | CANDIDATE | deep requirements ideation; pairs with built-in Plan |
+| bslist | generic | CANDIDATE | list/resume past brainstorm sessions |
+| debug-assistant | generic | CANDIDATE | structured debugging harness (stack-trace → repro → fix) |
+| deps-update | generic | CANDIDATE | dependency auditor w/ compat testing + changelog |
+| dev-docs | generic | CANDIDATE | spec → implementation plan + checklist |
+| dev-docs-update | generic | CANDIDATE | capture session state before context-limit reset |
+| env-sync | generic | CANDIDATE | .env sync/validation/secret rotation (security-sensitive) |
+| handoff | generic | CANDIDATE | task-transfer / onboarding doc generation |
+| perf-check | generic | CANDIDATE | profiling (CPU/mem/DB/API) — multi-language |
+| read-specs | generic | CANDIDATE | spec → tasks + flow diagrams |
+| standup | generic | CANDIDATE | standup notes from git history + todos |
+| task-init | generic | CANDIDATE | multi-phase task orchestration (overlaps Plan) |
+| tech-debt | generic | CANDIDATE | catalog debt/TODOs/complexity, prioritize by ROI |
+| test-suite | generic | CANDIDATE | test runner + coverage delta + missing-test gen (overlaps qa-check) |
+| write-documentation | generic | CANDIDATE | multi-format doc generation (API/arch/DB) |
+| deploy | stack | CANDIDATE | deployment orchestration — infra/repo-specific |
+| rollback | stack | CANDIDATE | recovery/rollback orchestration — infra-specific |
+| commit | generic | SKIP | overlaps git/gh rules + ship-pr; msg-gen fights the staging rules |
+| mr-draft | stack | SKIP | PR-description gen; overlaps ship-pr + gh PR format; PT-BR |
+| review-code | generic | SKIP | built-in `/code-review` + `/simplify` |
+| security-scan | generic | SKIP | `security-scan` skill |
+| create-skill | generic | SKIP | `skill-creator` plugin |
+| sync-config | generic | SKIP | meta — this dotfiles repo + chezmoi already do config-as-code |
+| todo-worktree | generic | SKIP | `git-worktree-workflow` skill |
+| close/fetch/update-azure-task (×3) | niche | SKIP | Azure DevOps-locked |
+| generate-interview, interview-analysis-template, interview-context-storage, pdf-to-markdown, screen-resume (×5) | niche | SKIP | HR/recruitment — not dev tooling |
+
+## agents (46)
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| plan-reviewer | generic | CANDIDATE | pre-implementation plan QA (before vs after code) — strong, novel |
+| database-optimizer | generic | CANDIDATE | query/index/N+1 — SQLAlchemy half in sqlalchemy-patterns; generic lens novel |
+| performance-engineer | generic | CANDIDATE | profiling/load/Core-Web-Vitals (broader than database-optimizer) |
+| accessibility-specialist | generic | CANDIDATE | WCAG/ARIA/keyboard — novel a11y lens |
+| security-auditor | generic | CANDIDATE | deeper OWASP/auth/crypto audit (vs `/security-review`) |
+| documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
+| api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
+| backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
+| refactor-planner | generic | CANDIDATE | refactoring plans + risk (planning vs execution) |
+| legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |
+| test-automator | generic | CANDIDATE | test strategy/pyramid planning |
+| frontend-qa-tester | generic | CANDIDATE | Playwright-driven manual QA + bug reports |
+| ui-ux-designer | generic | CANDIDATE | design methodology (vs frontend-design's implementation) |
+| devops-troubleshooter | generic | CANDIDATE | incident response / log analysis |
+| web-research-specialist | generic | CANDIDATE | overlaps `/deep-research`; lower priority |
+| ai-engineer | generic | CANDIDATE | LLM/RAG/agent patterns — relevant if building AI features |
+| deployment-engineer, cloud-architect, data-engineer, ml-engineer | stack | CANDIDATE | infra/data/ML — build when first used (ADR-0003) |
+| payment-integration, graphql-architect | stack | CANDIDATE | domain-specific but high-value when relevant |
+| python-pro, typescript-expert, golang-pro, rust-pro | stack | CANDIDATE | language-expert personas — low priority, rules already encode per-lang policy |
+| nextjs-app-router-developer, frontend-developer | stack | CANDIDATE | Next.js — overlaps `frontend-design`; low priority |
+| code-architecture-reviewer, code-refactor-master, code-reviewer, debugger | generic | SKIP | overlap `/code-review`, `/simplify`, built-in Explore |
+| data-scientist | stack | SKIP | BigQuery-locked |
+| arbitrage-bot, blockchain-developer, crypto-analyst, crypto-risk-manager, crypto-trader, defi-strategist, quant-analyst (×7) | niche | SKIP | crypto/DeFi/quant-finance |
+| directus-developer, drupal-developer, laravel-vue-developer, php-developer, game-developer, mobile-developer (×6) | niche | SKIP | framework/language not in the user's stack |
+
+## skills (5) + hooks (5)
+
+| name | type | scope | disp. | reason |
+|------|------|-------|-------|--------|
+| fastapi-clean-architecture | skill | generic | CANDIDATE | DDD/clean-arch layering — extends fastapi-patterns (weigh foreign idioms) |
+| multi-system-sso-authentication | skill | stack | CANDIDATE | only if integrating external SSO |
+| async-testing-expert | skill | generic | SKIP | testing.md + bats-setup; async patterns are testing.md's domain |
+| skill-developer | skill | generic | SKIP | meta — skill-creator plugin covers it |
+| brazilian-financial-integration | skill | niche | SKIP | BR fintech (boleto/PIX/CPF) |
+| skill-activation-prompt(.ts/.sh), post-tool-use-tracker.sh, hooks.json, package.json (×5) | hook/config | generic | SKIP | meta-infra, Node/JS-hardcoded; not user-facing capabilities |

--- a/config/claude/audit/mining/fastapi.md
+++ b/config/claude/audit/mining/fastapi.md
@@ -1,0 +1,9 @@
+# Mining matrix — `fastapi/fastapi` (official `.agents/skills`)
+
+Part of the mining census (`../mining-census.md` has the disposition key and
+the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 1 skill.
+First-party.
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| fastapi (official) | stack | SKIP | covered by `fastapi.md` + `fastapi-patterns`; **re-mine on FastAPI version bumps** (authoritative source) |

--- a/config/claude/audit/mining/pydantic-skills.md
+++ b/config/claude/audit/mining/pydantic-skills.md
@@ -1,0 +1,16 @@
+# Mining matrix — `pydantic/skills` (official)
+
+Part of the mining census (`../mining-census.md` has the disposition key and
+the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 5 skills.
+First-party (re-mine on releases).
+
+| name | scope | disp. | reason |
+|------|-------|-------|--------|
+| building-pydantic-ai-agents, pydantic-ai-harness | niche | CANDIDATE-if-building-agents | the `pydantic_ai` agent framework — see the deferred `rules/pydantic-ai.md` backlog item |
+| logfire-instrumentation, logfire-query, logfire-ui | niche | CANDIDATE-if-adopting-Logfire | observability platform — adopt if Logfire is used |
+
+Note: these are the `pydantic_ai` **agent framework** + Logfire
+observability — **not** pydantic-the-validation-library (covered by
+`fastapi-patterns` /
+`python.md`). Per ADR-0003 they'd be global skills, built the first time any
+repo adopts pydantic-ai or Logfire.

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -111,8 +111,10 @@ to read-only agents so it doesn't consume the audit's own context.
 overlap with existing built-ins/skills/rules, then the layering principle.
 Consider an agent or command a CANDIDATE **even if we'd reimplement it as a
 skill** (skills over commands — ADR-0001). Don't dismiss a good generic tool
-because it arrived in a different form. Record sources in the *Idea sources*
-registry; a per-artifact `SOURCE.md` only on implementation reuse (ADR-0002).
+because it arrived in a different form. **Placement:** anything about a
+repo-foreign library/tool is built **global**, on first use (ADR-0003) — not
+repo-local, not deferred. Record sources in the *Idea sources* registry; a
+per-artifact `SOURCE.md` only on implementation reuse (ADR-0002).
 
 ## Guardrails
 

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -113,8 +113,11 @@ Consider an agent or command a CANDIDATE **even if we'd reimplement it as a
 skill** (skills over commands — ADR-0001). Don't dismiss a good generic tool
 because it arrived in a different form. **Placement:** anything about a
 repo-foreign library/tool is built **global**, on first use (ADR-0003) — not
-repo-local, not deferred. Record sources in the *Idea sources* registry; a
-per-artifact `SOURCE.md` only on implementation reuse (ADR-0002).
+repo-local, not deferred; and **fold a new capability into an existing
+top-level category** (`code-style` / `testing` / `qa` / `gh` / `git`) rather
+than spawning a new one unless it genuinely doesn't fit. Record sources in the
+*Idea sources* registry; a per-artifact `SOURCE.md` only on implementation
+reuse (ADR-0002).
 
 ## Guardrails
 

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -80,6 +80,40 @@ log) — the canonical methodology and living record. In short:
    findings. Convert "evaluate later" items into `TODO.md` follow-ups,
    surfaced by the repo that needs them.
 
+## Mining repos for ideas
+
+An audit improves the **whole** dev environment, not just the current repo —
+so the strongest finds are *generic* tools that spread everywhere. When the
+audit looks to external repos for ideas:
+
+**Finding a source.** If the *Idea sources* registry (`SETUP-AUDIT.md`) has no
+repo covering an aspect of the current repo, go find one. Rank by:
+
+1. **Official / first-party first** — the tool's or framework's own org (e.g.
+   `pydantic/skills`, `fastapi/.agents`). Authoritative; tracks the tool's
+   versions. Re-mine these on the tool's version bumps.
+2. **Otherwise third-party**, ranked by a bundle, not stars alone: **stars**
+   (adoption) **+ recency** (last commit) **+ maintenance health** (open-issue
+   ratio, contributor count). Stars are laggy and gameable; recency catches
+   the popular-but-abandoned repo. Take the top 2–3.
+3. **Staleness gate:** last commit **> 1 year** → flag for re-evaluation, do
+   **not** auto-discard. Some stable tools rarely change; judge on fit, not
+   age alone.
+
+**Charting it — full census, no pre-filtering.** Enumerate the **entire**
+surface (every agent / command / hook / skill), not a curated shortlist — a
+shortlist hides what was skipped and biases toward the current repo's stack.
+Produce a disposition table (ADOPT / CANDIDATE / SKIP + one-line reason) and
+record it in `config/claude/audit/mining-census.md`. Fan the enumeration out
+to read-only agents so it doesn't consume the audit's own context.
+
+**Judging.** Score each item by **generic value to *any* repo** first, then
+overlap with existing built-ins/skills/rules, then the layering principle.
+Consider an agent or command a CANDIDATE **even if we'd reimplement it as a
+skill** (skills over commands — ADR-0001). Don't dismiss a good generic tool
+because it arrived in a different form. Record sources in the *Idea sources*
+registry; a per-artifact `SOURCE.md` only on implementation reuse (ADR-0002).
+
 ## Guardrails
 
 - **Second-class MCP/plugins** — never make a rule/skill depend on one.


### PR DESCRIPTION
Two related audit-setup improvements (the second refines the first).

## 1. Full mining census + source-discovery method
- **Corrective**: the earlier mining showed only a pre-filtered shortlist of 9. This charts **all ~158 items** across the four mined repos into `config/claude/audit/mining-census.md` (ADOPT/CANDIDATE/SKIP + reason) with a tiered CANDIDATE backlog (strongest: the architecture/codebase-analysis cluster).
- claude-audit skill gains a **Mining repos for ideas** section: **source discovery** (official-first → stars+recency+health; >1yr staleness gate, re-evaluate not discard) and **full-census + generic-lens** (enumerate the whole surface; judge by value to any repo; an agent/command can be a candidate even when reimplemented as a skill).

## 2. Placement refinement — repo-foreign library guidance is global, front-loaded (ADR-0003)
- Guidance for anything **foreign to the current repo** (a third-party library, or our own code in a different repo) lives in the **global generic layer**, even for single-repo use, authored the **first** time any repo needs it — not repo-local, not deferred. "Foreign to this repo" = shared-by-nature → it recurs elsewhere; front-load the work in context.
- Reconciled with the Rule of Three (which guards *our own* code, not stable external libraries). Documented in `EXTENDING.md`; fixes the census Tier-3 mislabel; placement note added to the audit mining step.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] `config/claude/audit/` tracked (gitignore allowlist); census present
- [ ] ADR-0003 in `config/claude/adr/` + indexed in the README
- [ ] EXTENDING.md + claude-audit skill carry the new principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
