### PR TITLE
feat(claude): Tier-1 qa skills — arch-review + modernize + plan-review

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -202,6 +202,26 @@ decisions are also summarized in the *Decisions log*.
   - [ ] add a tiny path-only GH-Actions-injection hook only if a repo needs it
     (likely unnecessary — `github-actions.md` covers awareness).
 
+### Skill ideas & future categories (not from mining)
+
+- [ ] **`resolve-issue` skill** — orchestrate `gh` issue resolution: fetch
+  issue → **agent** investigates it against the codebase (root cause, "simple
+  or not", proposed fix or a question) → decide → fix → open PR with
+  `Closes #X` → merge. The investigation is an agent; **PR-open and merge stay
+  gated** per `gh.md` ("no PR create/merge without explicit approval") unless a
+  deliberately opted-in autonomous variant with guardrails (trivial-only, after
+  CI green) is built. Tools/category: `gh`.
+- [ ] **`categorize-issue` skill** — triage a `gh` issue: suggest
+  labels/priority/estimate from codebase context and fold it into the repo's
+  TODO triage queue (the `gh.md` *Issues & triage* workflow). Category: `gh`.
+- [ ] **Future top-level categories** (per the "fold into existing categories,
+  new one only if it doesn't fit" guidance):
+  - [ ] **`documentation`** — home for a `write-documentation` skill (the
+    remaining Tier-1 doc-generation item) and doc tooling.
+  - [ ] **`troubleshooting`** — home for a `debug-assistant` skill (the
+    remaining Tier-1 debugging item; distinct from qa — assessing quality vs
+    diagnosing a failure).
+
 ## Decisions log
 
 - 2026-06-10 — **A (MCP plugins): done globally.** terraform + serena

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -61,13 +61,15 @@ Not built — surfaced for the user to choose. Adopt as skills (ADR-0001),
 folding into an existing category where one fits (above) and splitting any
 stack-flavored ones per the layering principle. Grouped by leverage:
 
-**Tier 1 — strong generic, low overlap (best whole-environment wins):**
-architecture/codebase analysis — `dependency-analyzer`/`deps` (coupling,
-circular deps), `arch-review`/`architecture-reviewer`, `tech-debt` (debt
-catalog), `codebase-explorer` — **DONE: consolidated into the `arch-review`
-skill** (`diagram`/Mermaid dropped — not used). Remaining: `modernize` (legacy
-roadmap), `plan-reviewer` (pre-implementation plan QA), `debug-assistant`,
-`deps-update`, `write-documentation`/`documentation-architect`.
+**Tier 1 — strong generic, low overlap (best whole-environment wins).**
+**DONE** (built as skills): the architecture/codebase cluster
+(`dependency-analyzer`/`deps`, `arch-review`/`architecture-reviewer`,
+`tech-debt`, `codebase-explorer`) → the **`arch-review`** skill
+(`diagram`/Mermaid dropped — not used); `modernize` → the **`modernize`**
+skill; `plan-reviewer` → the **`plan-review`** skill. **Remaining:**
+`debug-assistant` (→ a *troubleshooting* category), `deps-update`,
+`write-documentation`/`documentation-architect` (→ a *documentation* category)
+— see the *Skill ideas & future categories* in `SETUP-AUDIT.md`.
 
 **Tier 2 — useful generic, some overlap:**
 `perf-check`/`performance-engineer`,

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -63,10 +63,11 @@ stack-flavored ones per the layering principle. Grouped by leverage:
 
 **Tier 1 — strong generic, low overlap (best whole-environment wins):**
 architecture/codebase analysis — `dependency-analyzer`/`deps` (coupling,
-circular deps), `arch-review`/`architecture-reviewer`, `diagram` (Mermaid),
-`modernize` (legacy roadmap), `codebase-explorer`; `plan-reviewer`
-(pre-implementation plan QA); `tech-debt` (debt catalog); `debug-assistant`;
-`deps-update`; `write-documentation`/`documentation-architect`.
+circular deps), `arch-review`/`architecture-reviewer`, `tech-debt` (debt
+catalog), `codebase-explorer` — **DONE: consolidated into the `arch-review`
+skill** (`diagram`/Mermaid dropped — not used). Remaining: `modernize` (legacy
+roadmap), `plan-reviewer` (pre-implementation plan QA), `debug-assistant`,
+`deps-update`, `write-documentation`/`documentation-architect`.
 
 **Tier 2 — useful generic, some overlap:**
 `perf-check`/`performance-engineer`,

--- a/config/claude/audit/mining/claude-plugins.md
+++ b/config/claude/audit/mining/claude-plugins.md
@@ -13,7 +13,7 @@ The architecture/codebase-analysis cluster is the strongest generic find.
 | dependency-analyzer | agent | generic | CANDIDATE | same, deeper — instability scoring, layer violations |
 | arch-review | cmd | generic | CANDIDATE | architecture audit (layers, DI, anti-patterns) — deeper than `/review` |
 | architecture-reviewer | agent | generic | CANDIDATE | Opus-grade architecture audit (10-point) |
-| diagram | cmd | generic | CANDIDATE | Mermaid architecture diagrams (component/ER/sequence/deploy) |
+| diagram | cmd | generic | SKIP | Mermaid output — not used here (dropped from the arch-review skill) |
 | modernize | cmd | generic | CANDIDATE | legacy assessment + Strangler-Fig roadmap |
 | codebase-explorer | agent | generic | CANDIDATE | fast project-structure discovery (feeds planning) |
 | codebase-analyzer | agent | generic | CANDIDATE | extract entities/endpoints/services from existing code |

--- a/config/claude/skills/arch-review/SKILL.md
+++ b/config/claude/skills/arch-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: arch-review
+description: Assess the architecture and health of an existing codebase as a whole — structure and layering, module coupling and circular dependencies, architecture anti-patterns, and tech-debt hotspots (complexity, duplication, stale TODOs) — with an optional Mermaid diagram. Use for whole-codebase questions, not line-level diff review: "review the architecture", "is this codebase healthy", "find circular dependencies", "what's the coupling like", "where's the tech debt", "map/diagram the modules", "are the layers clean". The tool for qa.md's Code-smell/complexity/maintainability dimension. Distinct from /code-review (diff bugs), /simplify (diff cleanup), /review (a PR).
+---
+
+# arch-review
+
+**Version:** v1.0.0
+
+Assess an **existing codebase as a whole** — its structure, dependencies, and
+debt — and return an actionable health report. This is the concrete tool for
+`qa.md`'s **Code-smell / complexity / maintainability** dimension (dimension
+4), which otherwise says "if nothing covers it, name the gap." It is
+**subject-agnostic**: it works on any language/stack and pulls in what it
+needs from the target.
+
+## What this is (and isn't)
+
+Altitude matters — this sits *above* the diff-level tools, and they don't
+overlap:
+
+- **`arch-review` (this)** — the *whole repo's* structure, coupling, and debt.
+- `/code-review` — correctness bugs in the *current diff*.
+- `/simplify` — reuse/efficiency cleanups in *changed code*.
+- `/review` — a specific PR.
+
+Reach for this when the question is "how healthy/where is the rot," not "is
+this change correct."
+
+## Why a skill that spawns an agent
+
+This is one **skill** (the entry point you invoke and watch) that consolidates
+what upstream split across a command + several agents (`arch-review`,
+`dependency-analyzer`, `tech-debt`, `diagram`) — they are all facets of one
+job, so they are one skill, not four micro-skills.
+
+The **scan itself is read-heavy** (potentially dozens of files), so delegate
+it to a **subagent** — the isolation keeps that intermediate reading out of
+this conversation; only the structured findings come back. Use the **generic**
+`Explore` / `general-purpose` agent with the sharp lens below supplied in the
+prompt; do **not** author a bespoke agent type for it (generic-in-subject,
+specific-in-method — the method lives in the prompt, not a new agent
+definition). For a large repo, fan out **several** analysis agents in parallel
+(one per top-level area) and merge — that parallelism is the other reason to
+use agents here.
+
+## Procedure
+
+1. **Scope.** Identify the source roots and the language(s)/build system
+   (manifest files, entry points). State what's in and out of scope.
+2. **Delegate the scan.** Spawn one (or, for a large repo, several parallel)
+   analysis agent(s) with this lens, and have each **return structured
+   findings only**, not file dumps:
+   - **Structure & layering** — the real module/layer boundaries, and whether
+     dependencies flow one way (e.g. api → service → data) or leak across
+     (layer violations, a UI module importing the DB driver).
+   - **Coupling & cycles** — which modules are highly fanned-in/out; **import
+     cycles** (A→B→A) — call these out explicitly, they're the highest-signal
+     finding.
+   - **Anti-patterns** — god modules, duplicated subsystems, a "utils" junk
+     drawer, business logic in the wrong layer.
+   - **Tech-debt hotspots** — outsized files/functions (complexity),
+     duplicated blocks, stale `TODO`/`FIXME`, dead code, pinned-and-rotting
+     deps. Rank by *impact × churn* where git history is available, not raw
+     size.
+3. **Synthesize** the agents' findings into one report (below). Deduplicate;
+   resolve disagreements by re-reading the specific spot yourself.
+4. **Diagram (optional).** If asked, or if the structure is non-obvious, emit
+   a **Mermaid** diagram of the module/layer graph (mark cycles in red). Keep
+   it to the top ~2 levels — a diagram of everything is noise.
+5. **Report and stop.** Do **not** start refactoring. This skill *assesses*;
+   acting on it is a separate, confirmed step (and turning the findings into a
+   phased plan is the `modernize` skill's job).
+
+## Report shape
+
+Lead with the verdict, then the evidence, ordered by leverage:
+
+```markdown
+## Architecture review — <repo/scope>
+
+**Health:** <one-line take> — biggest risk: <the single worst thing>
+
+### Structure
+- <the real layering, and whether it holds>
+
+### Coupling & cycles
+- ⚠️ Cycle: a → b → a  (<why it bites>)
+- Hotspot: <module> — fanned-in by N modules
+
+### Anti-patterns
+- <pattern> @ `path` — <why it's a problem>
+
+### Tech-debt hotspots (by impact × churn)
+1. `path` — <complexity/duplication/…>, <suggested direction>
+
+### Diagram   (if requested)
+<a Mermaid module/layer graph, per step 4>
+```
+
+Keep it proportional — a small repo gets a short report. Don't pad sections
+with "none found"; omit empty ones.
+
+## Scaling
+
+- **Small repo** (a few modules): scan inline, no agent needed — the isolation
+  buys nothing.
+- **Medium**: one analysis agent.
+- **Large / monorepo**: fan out parallel agents by top-level area, then merge.
+
+State which you did, and flag anything you sampled rather than read in full —
+never let a bounded scan read as exhaustive coverage.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-plugins` tech-lead
+(`arch-review`/`deps`/`diagram`/`dependency-analyzer`) and `claude-tools`
+(`tech-debt`/`database-optimizer` ideas). No upstream code reused. See
+`SOURCE.md`.

--- a/config/claude/skills/arch-review/SKILL.md
+++ b/config/claude/skills/arch-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arch-review
-description: Assess the architecture and health of an existing codebase as a whole — structure and layering, module coupling and circular dependencies, architecture anti-patterns, and tech-debt hotspots (complexity, duplication, stale TODOs) — with an optional Mermaid diagram. Use for whole-codebase questions, not line-level diff review: "review the architecture", "is this codebase healthy", "find circular dependencies", "what's the coupling like", "where's the tech debt", "map/diagram the modules", "are the layers clean". The tool for qa.md's Code-smell/complexity/maintainability dimension. Distinct from /code-review (diff bugs), /simplify (diff cleanup), /review (a PR).
+description: Assess the architecture and health of an existing codebase as a whole — structure and layering, module coupling and circular dependencies, architecture anti-patterns, and tech-debt hotspots (complexity, duplication, stale TODOs). Use for whole-codebase questions, not line-level diff review: "review the architecture", "is this codebase healthy", "find circular dependencies", "what's the coupling like", "where's the tech debt", "are the layers clean". The tool for qa.md's Code-smell/complexity/maintainability dimension. Distinct from /code-review (diff bugs), /simplify (diff cleanup), /review (a PR).
 ---
 
 # arch-review
@@ -31,8 +31,8 @@ this change correct."
 
 This is one **skill** (the entry point you invoke and watch) that consolidates
 what upstream split across a command + several agents (`arch-review`,
-`dependency-analyzer`, `tech-debt`, `diagram`) — they are all facets of one
-job, so they are one skill, not four micro-skills.
+`dependency-analyzer`, `tech-debt`) — they are all facets of one job, so they
+are one skill, not three micro-skills.
 
 The **scan itself is read-heavy** (potentially dozens of files), so delegate
 it to a **subagent** — the isolation keeps that intermediate reading out of
@@ -65,10 +65,7 @@ use agents here.
      size.
 3. **Synthesize** the agents' findings into one report (below). Deduplicate;
    resolve disagreements by re-reading the specific spot yourself.
-4. **Diagram (optional).** If asked, or if the structure is non-obvious, emit
-   a **Mermaid** diagram of the module/layer graph (mark cycles in red). Keep
-   it to the top ~2 levels — a diagram of everything is noise.
-5. **Report and stop.** Do **not** start refactoring. This skill *assesses*;
+4. **Report and stop.** Do **not** start refactoring. This skill *assesses*;
    acting on it is a separate, confirmed step (and turning the findings into a
    phased plan is the `modernize` skill's job).
 
@@ -93,9 +90,6 @@ Lead with the verdict, then the evidence, ordered by leverage:
 
 ### Tech-debt hotspots (by impact × churn)
 1. `path` — <complexity/duplication/…>, <suggested direction>
-
-### Diagram   (if requested)
-<a Mermaid module/layer graph, per step 4>
 ```
 
 Keep it proportional — a small repo gets a short report. Don't pad sections
@@ -114,6 +108,6 @@ never let a bounded scan read as exhaustive coverage.
 ## Provenance
 
 Adapted (idea-level) from the mining census — `claude-plugins` tech-lead
-(`arch-review`/`deps`/`diagram`/`dependency-analyzer`) and `claude-tools`
+(`arch-review`/`deps`/`dependency-analyzer`) and `claude-tools`
 (`tech-debt`/`database-optimizer` ideas). No upstream code reused. See
 `SOURCE.md`.

--- a/config/claude/skills/arch-review/SOURCE.md
+++ b/config/claude/skills/arch-review/SOURCE.md
@@ -1,0 +1,27 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source: the implementation is our own (house style, the
+skill-spawns-generic-agent pattern, the report shape). The ideas were surfaced
+during the 2026-06-11 mining and are recorded in the census.
+
+## Idea sources (NOT tracked)
+
+Recorded in `../../audit/mining/`:
+
+- `ruslan-korneev/claude-plugins` `tech-lead` — `arch-review`, `deps`,
+  `dependency-analyzer`, `diagram` (architecture audit, coupling metrics,
+  circular-dep detection, Mermaid output). MIT.
+- `rafaelkamimura/claude-tools` — `tech-debt`, `database-optimizer`,
+  `code-architecture-reviewer` (debt cataloguing, hotspot ideas). MIT.
+
+## Local design decisions
+
+- **Consolidated** four mined items (a command + several agents) into one
+  skill — they are facets of one job (Rule of Three).
+- **Spawns a generic agent** with the lens in the prompt rather than defining
+  a bespoke agent type (generic-in-subject, specific-in-method).
+- **Assess-only** — turning findings into a phased plan is the (separate)
+  `modernize` skill; acting on them is a confirmed step.
+- Positioned as the tool for `qa.md`'s Code-smell/complexity dimension, above
+  the diff-level `/code-review` · `/simplify` · `/review`.

--- a/config/claude/skills/arch-review/SOURCE.md
+++ b/config/claude/skills/arch-review/SOURCE.md
@@ -10,15 +10,16 @@ during the 2026-06-11 mining and are recorded in the census.
 Recorded in `../../audit/mining/`:
 
 - `ruslan-korneev/claude-plugins` `tech-lead` — `arch-review`, `deps`,
-  `dependency-analyzer`, `diagram` (architecture audit, coupling metrics,
-  circular-dep detection, Mermaid output). MIT.
+  `dependency-analyzer` (architecture audit, coupling metrics, circular-dep
+  detection). MIT. (Its `diagram`/Mermaid output was **dropped** — not used.)
 - `rafaelkamimura/claude-tools` — `tech-debt`, `database-optimizer`,
   `code-architecture-reviewer` (debt cataloguing, hotspot ideas). MIT.
 
 ## Local design decisions
 
-- **Consolidated** four mined items (a command + several agents) into one
-  skill — they are facets of one job (Rule of Three).
+- **Consolidated** three mined items (a command + several agents) into one
+  skill — they are facets of one job (Rule of Three). The `diagram`/Mermaid
+  item was dropped (Mermaid isn't used here).
 - **Spawns a generic agent** with the lens in the prompt rather than defining
   a bespoke agent type (generic-in-subject, specific-in-method).
 - **Assess-only** — turning findings into a phased plan is the (separate)

--- a/config/claude/skills/modernize/SKILL.md
+++ b/config/claude/skills/modernize/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: modernize
+description: Turn an assessment of aging/legacy code into a phased, incremental migration roadmap (Strangler-Fig) — define the target end-state, decompose into independently-shippable phases sequenced by risk and dependency, each with a done-condition, a safety net, and a rollback. Use for "modernize this", "migration plan", "how do we get off X", "phase out the legacy Y", "incremental refactor roadmap". Plans, does not execute. Composes with the arch-review skill (which assesses). qa / maintainability.
+---
+
+# modernize
+
+**Version:** v1.0.0
+
+The forward-looking partner to **arch-review**: arch-review says *where the
+rot is*; `modernize` says *how to dig out of it — safely, in shippable
+increments*. It produces a **plan**, not changes. Subject-agnostic.
+
+## When to reach for it
+
+You have aging code, a framework/library you want off of, or an architecture
+that arch-review flagged — and you need a route from here to there that
+doesn't require a big-bang rewrite or a long-lived broken branch.
+
+## Type / composition
+
+A **skill** (a planning procedure you invoke and watch). If you don't already
+have an assessment, it **invokes the `arch-review` skill** first rather than
+re-deriving the analysis (DRY — reuse the skill, don't duplicate its work).
+
+## Procedure
+
+1. **Target end-state.** State concretely what "modernized" means here — the
+   new pattern/library/architecture — and tie each part to a specific
+   arch-review finding it resolves. One tight paragraph; resist gold-plating
+   (no end-state goals that weren't asked for).
+2. **Strangler-Fig decomposition.** Carve the work into phases where the **new
+   coexists with the old** and usage cuts over incrementally — never a
+   flag-day rewrite. Each phase must be **independently shippable and
+   reversible** on its own.
+3. **Sequence by risk × dependency.** Enabling/low-risk groundwork first
+   (extract the seam, add the safety net); the riskiest cutover last, behind a
+   flag where possible. Name the hard dependencies (B can't start before A).
+4. **Per phase, specify:** scope, an **observable done-condition**, the
+   **rollback**, and the **safety net** required *before* touching it — for
+   code without tests, characterization tests come first (`testing.md`).
+5. **Flag the danger.** Call out the one or two phases most likely to go
+   wrong, and the **seam** (the interface/boundary) that makes incremental
+   cutover possible at all — if there isn't one, creating it is phase 1.
+
+## Output
+
+A phased roadmap, riskiest steps flagged, each phase shippable and reversible:
+
+```markdown
+## Modernization roadmap — <what → what>
+
+**End-state:** <the target, and the arch-review findings it resolves>
+**Seam:** <the boundary that enables incremental cutover>
+
+| Phase | Does | Done when | Rollback | Safety net |
+|-------|------|-----------|----------|------------|
+| 1 | <groundwork> | <observable> | <how> | <tests/flag> |
+| … | | | | |
+
+⚠️ Riskiest: phase N — <why, and the mitigation>
+```
+
+**Plan only — do not start migrating.** Executing a phase is a separate,
+confirmed step.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-plugins` tech-lead
+`modernize` (Strangler-Fig roadmap idea). No upstream code reused. See
+`SOURCE.md`.

--- a/config/claude/skills/modernize/SOURCE.md
+++ b/config/claude/skills/modernize/SOURCE.md
@@ -1,0 +1,22 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+arch-review composition, the roadmap shape).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-plugins.md`:
+
+- `ruslan-korneev/claude-plugins` `tech-lead` `modernize` — legacy assessment
+  + phased Strangler-Fig migration roadmap. MIT.
+
+## Local design decisions
+
+- **Composes with `arch-review`** (invokes it for the assessment) rather than
+  re-deriving structure analysis — DRY across skills.
+- **Plan-only**, with an explicit safety-net + rollback per phase and a
+  characterization-tests-first rule (`testing.md`); execution is a separate,
+  confirmed step.
+- Positioned under qa / maintainability — the forward-looking partner to
+  `arch-review`.

--- a/config/claude/skills/plan-review/SKILL.md
+++ b/config/claude/skills/plan-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: plan-review
+description: Review an implementation plan or proposal BEFORE building it — surface risky or unverified assumptions, missing edge cases and failure modes, sequencing/dependency problems, blast radius, scope creep, testability gaps, and simpler alternatives. The pre-implementation QA gate (the "before" to /code-review's "after"). Use for "review this plan", "poke holes in this approach", "what am I missing before I build this", "is this plan sound", "critique this design". Reviews the plan; does not rewrite it.
+---
+
+# plan-review
+
+**Version:** v1.0.0
+
+Critique an implementation plan **before any code exists** — the cheapest
+place to catch a wrong approach. Subject-agnostic.
+
+## Altitude (why it's distinct)
+
+- **built-in `Plan`** — *creates* a plan.
+- **`plan-review` (this)** — *critiques* a plan, pre-implementation.
+- `/code-review` — reviews the *code* after it's written.
+
+A flaw caught here costs a sentence; the same flaw caught in `/code-review`
+costs a rewrite.
+
+## Type / agent use
+
+A **skill** (a focused review you invoke). The plan is usually text already in
+context, so no agent is needed — **except** for one high-value case: when the
+plan makes **claims about the codebase** ("module X is isolated", "nothing
+else calls Y"), spawn an agent to **verify those assumptions against the actual
+code** and return confirm/refute. That's the textbook agent job — an isolated
+check whose *answer* is what matters.
+
+## Review lens
+
+Work the plan against these, hardest-hitting first:
+
+- **Approach soundness** — does it actually solve the stated problem? Is there
+  a materially simpler route?
+- **Assumptions** — which load-bearing assumptions are unverified? Verify the
+  codebase ones (agent, above); flag the rest as risks.
+- **Blast radius** — what can it break, is it reversible, what about
+  back-compat / data migration?
+- **Missing cases** — failure modes, error handling, edge/empty/large inputs,
+  concurrency, partial failure.
+- **Sequencing** — ordering and dependency hazards; can it ship incrementally
+  or is it all-or-nothing?
+- **Testability** — how is each step verified — success **and** failure paths
+  (`testing.md`)?
+- **Scope** — gold-plating / unrequested generality (scope discipline), or the
+  opposite: under-scoped, a step hand-waved.
+- **Consistency** — does it fit the repo's existing conventions and patterns,
+  or invent a foreign one?
+
+## Output
+
+A verdict plus findings ranked by severity — **surface what to fix, don't
+rewrite the plan** (the author revises):
+
+```markdown
+## Plan review — <plan>
+
+**Verdict:** sound | sound with fixes | reconsider — <one line>
+
+1. 🔴 <the risk/gap> — <why it bites> → <suggested adjustment>
+2. 🟡 …
+```
+
+Omit categories with nothing to say; don't pad. If a codebase assumption was
+agent-verified, mark it (✓ verified / ✗ refuted).
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools` `plan-reviewer`.
+No upstream code reused. See `SOURCE.md`.

--- a/config/claude/skills/plan-review/SKILL.md
+++ b/config/claude/skills/plan-review/SKILL.md
@@ -24,9 +24,9 @@ costs a rewrite.
 A **skill** (a focused review you invoke). The plan is usually text already in
 context, so no agent is needed — **except** for one high-value case: when the
 plan makes **claims about the codebase** ("module X is isolated", "nothing
-else calls Y"), spawn an agent to **verify those assumptions against the actual
-code** and return confirm/refute. That's the textbook agent job — an isolated
-check whose *answer* is what matters.
+else calls Y"), spawn an agent to **verify those assumptions against the
+actual code** and return confirm/refute. That's the textbook agent job — an
+isolated check whose *answer* is what matters.
 
 ## Review lens
 

--- a/config/claude/skills/plan-review/SOURCE.md
+++ b/config/claude/skills/plan-review/SOURCE.md
@@ -1,0 +1,20 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+review lens, the agent-verifies-codebase-assumptions pattern).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `plan-reviewer` — pre-implementation plan QA
+  (risk and flaw detection before building). MIT.
+
+## Local design decisions
+
+- **Reviews, does not rewrite** — surfaces findings for the author to revise.
+- **Agent only for codebase-assumption verification** — the one place
+  isolation earns its keep; the review itself runs in the main context.
+- Positioned under qa as the "before" gate complementing `/code-review`'s
+  "after"; distinct from the built-in `Plan` (which creates plans).


### PR DESCRIPTION
## Summary
The **Tier-1 qa cluster** from the mining backlog, built as skills (kept in one PR per request).

- **`arch-review`** — assess a whole codebase (structure/layering, coupling + circular deps, anti-patterns, tech-debt hotspots). Consolidates four mined items into one skill; delegates the read-heavy scan to a *generic* subagent (lens in the prompt). The tool for `qa.md`'s Code-smell/complexity dimension. (Mermaid/`diagram` dropped — unused.)
- **`modernize`** — turn an assessment into a phased **Strangler-Fig** migration roadmap; composes with `arch-review`; plan-only with per-phase done/rollback/safety-net.
- **`plan-review`** — pre-implementation plan QA (the "before" to `/code-review`'s "after"); reviews a plan, spawns an agent **only** to verify the plan's codebase assumptions.

**Type reasoning** (per the discussion): each is a *skill* (procedure you invoke and watch), not a rule (not passive policy) nor a bare agent (you want the result in-context); agents appear *underneath* as isolated workers for the heavy/parallel reading — generic-in-subject, specific-in-method, lens supplied in the prompt. Adapted idea-level (no upstream code; ADR-0002).

Also: census Tier-1 marked DONE; SETUP-AUDIT audit backlog gains the `resolve-issue` + `categorize-issue` skill ideas (gh; PR-open/merge stay gated) and the future `documentation` + `troubleshooting` categories.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] `arch-review`, `modernize`, `plan-review` appear in the skill list and trigger appropriately
- [ ] Prose wraps at 78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
