### PR TITLE
feat(claude): Tier-2 qa review skills + SKIP-until watch list

### DIFF
--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -19,12 +19,37 @@ Every mined repo gets its own complete matrix file.
   user decides**. Judged by value to *any* repo, not just the one being
   audited. An agent/command can be a CANDIDATE even though we'd reimplement it
   as a skill.
-- **SKIP** — covered by existing tooling, niche/domain-locked, meta-infra, or
-  already adopted. Reason given.
+- **SKIP** (permanent) — already covered by our tooling, redundant, meta-infra,
+  or already adopted. Won't resurface. Reason given.
+- **SKIP-until `<trigger>`** (conditional) — legitimately skipped *now* because
+  a precondition isn't met (a tool we don't use, a domain we're not in), but it
+  **flips to CANDIDATE when the trigger fires** (usually "first use of X" —
+  ADR-0003). The SKIP stands; the trigger keeps it findable. All `SKIP-until`
+  items are collected in the **Watch list** below.
 
 Disposition reflects **generic value to the whole environment**, then overlap
 with existing built-ins / skills / rules, then the "layer the generic over the
 specific" principle (`EXTENDING.md`).
+
+## Watch list — `SKIP-until` triggers
+
+When a trigger below becomes true (you start using the tool / enter the
+domain), re-promote the item to CANDIDATE. Check this list when adopting any
+new dependency or tool; the audit checks it each run.
+
+| Trigger (first use of…) | Re-promotes |
+|-------------------------|-------------|
+| **Mermaid** (diagrams anywhere) | `claude-plugins` `diagram` → an arch/structure diagram step |
+| **Logfire** (observability) | `pydantic/skills` `logfire-instrumentation`/`-query`/`-ui` |
+| **`pydantic_ai`** (building LLM agents) | `pydantic/skills` `building-pydantic-ai-agents`, `pydantic-ai-harness`; the deferred `rules/pydantic-ai.md` |
+| **External SSO** integration | `claude-tools` `multi-system-sso-authentication` |
+| **GraphQL** | `claude-tools` `graphql-architect` (Tier-3) |
+| **Payments** (Stripe/etc.) | `claude-tools` `payment-integration` (Tier-3) |
+| **Linear** (the SaaS) | `claude-plugins` `linear` plugin (board/comment/cycle/issue-enricher) |
+| **A new language** (Go/Rust/TS…) in a repo | the matching `claude-tools` language-expert agent (Tier-3) |
+
+(Tier-3 "build on first use" items are already watch-like by definition; listed
+here so there's one place to scan.)
 
 ## Adopting a CANDIDATE — fold into existing categories
 
@@ -71,11 +96,14 @@ skill; `plan-reviewer` → the **`plan-review`** skill. **Remaining:**
 `write-documentation`/`documentation-architect` (→ a *documentation* category)
 — see the *Skill ideas & future categories* in `SETUP-AUDIT.md`.
 
-**Tier 2 — useful generic, some overlap:**
-`perf-check`/`performance-engineer`,
-`test-reviewer`, `pytest-patterns`/`typing-patterns` (Python depth, like
-fastapi-patterns), `accessibility-specialist`, `security-auditor`,
-`ui-ux-designer`, `handoff`, `standup`, `dev-docs-update`, `brainstorm`.
+**Tier 2 — useful generic, some overlap.** **DONE** (built as qa-dimension
+review skills, the arch-review family): `perf-check`/`performance-engineer` →
+**`perf-review`**; `test-reviewer` → **`test-review`**;
+`accessibility-specialist` → **`a11y-review`**. **Remaining:**
+`pytest-patterns`/`typing-patterns` (Python depth, like fastapi-patterns —
+python-scoped, not qa), `security-auditor` (overlaps `security-scan` +
+`/security-review` — decide), `ui-ux-designer`, `handoff`, `standup`,
+`dev-docs-update`, `brainstorm`.
 
 **Tier 3 — external libraries/frameworks/tools: global, built on first use.**
 These are all guidance about something *foreign to the repo*, so per ADR-0003

--- a/config/claude/audit/mining/claude-plugins.md
+++ b/config/claude/audit/mining/claude-plugins.md
@@ -13,7 +13,7 @@ The architecture/codebase-analysis cluster is the strongest generic find.
 | dependency-analyzer | agent | generic | CANDIDATE | same, deeper — instability scoring, layer violations |
 | arch-review | cmd | generic | CANDIDATE | architecture audit (layers, DI, anti-patterns) — deeper than `/review` |
 | architecture-reviewer | agent | generic | CANDIDATE | Opus-grade architecture audit (10-point) |
-| diagram | cmd | generic | SKIP | Mermaid output — not used here (dropped from the arch-review skill) |
+| diagram | cmd | generic | SKIP-until Mermaid | Mermaid output — not used; dropped from arch-review. Re-promote on first Mermaid use (watch list) |
 | modernize | cmd | generic | CANDIDATE | legacy assessment + Strangler-Fig roadmap |
 | codebase-explorer | agent | generic | CANDIDATE | fast project-structure discovery (feeds planning) |
 | codebase-analyzer | agent | generic | CANDIDATE | extract entities/endpoints/services from existing code |
@@ -56,4 +56,4 @@ The architecture/codebase-analysis cluster is the strongest generic find.
 
 | name | scope | disp. | reason |
 |------|-------|-------|--------|
-| board, comment, cycle, delete, linear-api, issue-enricher (×6) | niche | SKIP | Linear SaaS integration — only if the user adopts Linear |
+| board, comment, cycle, delete, linear-api, issue-enricher (×6) | niche | SKIP-until Linear | Linear SaaS integration — re-promote if the user adopts Linear (watch list) |

--- a/config/claude/skills/a11y-review/SKILL.md
+++ b/config/claude/skills/a11y-review/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: a11y-review
+description: Audit a user interface for accessibility (WCAG) — semantic markup, keyboard navigation and focus order, ARIA correctness, color contrast, screen-reader labelling, accessible forms/error messaging, and reduced-motion. Use for "accessibility review", "a11y audit", "is this accessible", "WCAG check", "keyboard navigation", "screen reader support", "contrast check". The tool for qa.md's UI/UX & accessibility dimension. UI repos only — N/A for headless/CLI/library code.
+---
+
+# a11y-review
+
+**Version:** v1.0.0
+
+Audit a **user interface** for accessibility against WCAG. The tool for
+`qa.md`'s **UI/UX & accessibility** dimension, which says to do the manual
+pass **even when no tooling exists yet**. Framework-agnostic (any UI stack).
+
+## Applicability — check first
+
+This applies only to repos that render a **UI**. For a headless service, CLI,
+or library, say "**N/A — no UI**" and stop. (A terminal UI has its own
+constraints; treat WCAG as inspiration, not a literal checklist, there.)
+
+## What it checks
+
+A manual pass — automated checkers catch ~30% of issues; the rest is judgment:
+
+- **Semantic structure** — real landmarks/headings/lists/buttons, not
+  `div`-soup; one logical reading order.
+- **Keyboard** — every interactive element reachable and operable by keyboard;
+  a visible focus indicator; no traps; **focus order** matches visual order;
+  focus managed on route/modal changes.
+- **ARIA** — only where semantics fall short, and *correct* (right role/state,
+  `aria-*` that matches reality) — wrong ARIA is worse than none.
+- **Names & labels** — every control/image/icon has an accessible name; form
+  fields have associated labels; errors are announced and tied to their field.
+- **Contrast** — text and meaningful UI meets WCAG AA contrast; information is
+  not conveyed by **color alone**.
+- **Motion/media** — respects `prefers-reduced-motion`; media has
+  captions/alternatives.
+
+## Type / agent use
+
+A **skill** you invoke. Reading a large component tree can be delegated to a
+**subagent** that returns the violations; the judgment calls (is this ARIA
+*right*? is the focus order sane?) stay with you.
+
+## Output
+
+```markdown
+## Accessibility review — <scope>   (WCAG 2.x AA)
+
+1. 🔴 `component` — <barrier, e.g. icon button has no accessible name> → <fix>
+2. 🟡 <contrast/focus-order/…> → <fix>
+```
+
+Rank by **barrier severity** — a keyboard trap or an unlabelled control blocks
+users entirely; a minor contrast miss degrades. **Assess only**; applying
+fixes is a separate step. Note what needs a real assistive-tech / manual check you
+couldn't fully perform from the code.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools`
+`accessibility-specialist`. No upstream code reused. See `SOURCE.md`.

--- a/config/claude/skills/a11y-review/SKILL.md
+++ b/config/claude/skills/a11y-review/SKILL.md
@@ -52,8 +52,8 @@ A **skill** you invoke. Reading a large component tree can be delegated to a
 
 Rank by **barrier severity** — a keyboard trap or an unlabelled control blocks
 users entirely; a minor contrast miss degrades. **Assess only**; applying
-fixes is a separate step. Note what needs a real assistive-tech / manual check you
-couldn't fully perform from the code.
+fixes is a separate step. Note what needs a real assistive-tech / manual
+check you couldn't fully perform from the code.
 
 ## Provenance
 

--- a/config/claude/skills/a11y-review/SOURCE.md
+++ b/config/claude/skills/a11y-review/SOURCE.md
@@ -1,0 +1,21 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+applicability gate, WCAG manual-pass framing).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `accessibility-specialist` —
+  WCAG/ARIA/keyboard audit. MIT.
+
+## Local design decisions
+
+- **Applicability gate** — N/A for headless/CLI/library repos (most of this
+  user's work); only runs against a real UI.
+- **Manual pass** per `qa.md` (automated checkers miss most issues); judgment
+  calls stay in-context, bulk component reads delegated to a subagent.
+- **Assess only**; positioned as the tool for `qa.md`'s UI/UX & accessibility
+  dimension.

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -107,6 +107,14 @@ Produce a disposition table (ADOPT / CANDIDATE / SKIP + one-line reason) and
 record it in `config/claude/audit/mining-census.md`. Fan the enumeration out
 to read-only agents so it doesn't consume the audit's own context.
 
+**SKIP is two things.** A permanent **SKIP** (covered/redundant) won't come
+back; a conditional **`SKIP-until <trigger>`** (a tool we don't use, a domain
+we're not in) **flips to CANDIDATE when the trigger fires** — don't bury it as a
+plain SKIP. Every `SKIP-until` goes on the census **Watch list**; check that
+list whenever a new dependency/tool is adopted (and each audit run), and
+re-promote what the trigger unlocks. Never *rewrite* the original SKIP — it was
+right when made; the trigger is what resurfaces it.
+
 **Judging.** Score each item by **generic value to *any* repo** first, then
 overlap with existing built-ins/skills/rules, then the layering principle.
 Consider an agent or command a CANDIDATE **even if we'd reimplement it as a

--- a/config/claude/skills/perf-review/SKILL.md
+++ b/config/claude/skills/perf-review/SKILL.md
@@ -8,8 +8,9 @@ description: Assess the runtime performance of code — find hotspots, algorithm
 **Version:** v1.0.0
 
 Assess **runtime performance** and return findings ranked by *measured*
-impact. Subject-agnostic. This is the tool for `qa.md`'s **Performance & load**
-dimension, and it follows `qa.md`'s **measure-first** stance to the letter:
+impact. Subject-agnostic. This is the tool for `qa.md`'s **Performance &
+load** dimension, and it follows `qa.md`'s **measure-first** stance to the
+letter:
 premature optimization is itself a smell.
 
 ## Measure first — the rule that governs this skill

--- a/config/claude/skills/perf-review/SKILL.md
+++ b/config/claude/skills/perf-review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: perf-review
+description: Assess the runtime performance of code — find hotspots, algorithmic-complexity problems, N+1/query issues, needless allocation/copying, sync-in-async, missing caching, and resource leaks — measure-first, ranked by measured impact. Use for "is this slow", "where's the bottleneck", "profile this", "performance review", "will this scale", "why is this endpoint slow". The tool for qa.md's Performance & load dimension. Distinct from arch-review (structure) — this is runtime behavior.
+---
+
+# perf-review
+
+**Version:** v1.0.0
+
+Assess **runtime performance** and return findings ranked by *measured*
+impact. Subject-agnostic. This is the tool for `qa.md`'s **Performance & load**
+dimension, and it follows `qa.md`'s **measure-first** stance to the letter:
+premature optimization is itself a smell.
+
+## Measure first — the rule that governs this skill
+
+> Do **not** call something slow, or change it for speed, without evidence.
+
+Establish a **baseline** (profile, benchmark, or a measured latency / memory /
+throughput number) before claiming a problem or proposing a fix. A finding
+without a measurement behind it is a hypothesis, and must be labelled as one.
+
+## Type / agent use
+
+A **skill** you invoke. The measurement/profiling step can be **read- and
+output-heavy** (profiler dumps, large traces) — delegate that to a
+**subagent** that runs/reads the profile and returns just the hotspots,
+keeping the noise out of this conversation.
+
+## What to look for
+
+Once you have a baseline, hunt — hottest path first:
+
+- **Algorithmic complexity** — accidental O(n²) (nested scans), work repeated
+  per-iteration that could be hoisted out of the loop.
+- **Data access** — N+1 queries, missing indexes, fetching more than used,
+  chatty round-trips.
+- **Allocation/copying** — buffering a whole collection when streaming would
+  do, copies that aren't used (the efficiency-by-default rule in
+  `code-style.md`).
+- **Concurrency** — blocking calls on an async path; serial work that could be
+  parallel; lock contention.
+- **Caching** — recomputation of stable results; absent memoization at a hot,
+  pure boundary.
+- **Resource lifecycle** — leaks (unclosed handles/connections), unbounded
+  growth, missing back-pressure under load.
+
+## Output
+
+Lead with the measured baseline, then findings by impact:
+
+```markdown
+## Performance review — <scope>
+
+**Baseline:** <the measurement — p95 latency / mem / throughput, and how taken>
+
+1. 🔴 `path` — <hotspot>, measured <evidence> → <direction> (est. <impact>)
+2. 🟡 <hypothesis, NOT yet measured> — <how to confirm>
+```
+
+Separate **measured** findings from **hypotheses**. **Assess and recommend —
+do not optimize** in this pass; an actual change is a separate, measured
+before/after step (`qa.md`). Flag anything sampled rather than measured in
+full.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools` `perf-check` /
+`performance-engineer` (+ `database-optimizer` for the data-access lens). No
+upstream code reused. See `SOURCE.md`.

--- a/config/claude/skills/perf-review/SOURCE.md
+++ b/config/claude/skills/perf-review/SOURCE.md
@@ -1,0 +1,25 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style,
+measure-first framing, agent-for-profiling pattern).
+
+## Idea sources (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `perf-check` / `performance-engineer` —
+  profiling, bottleneck detection, load. MIT.
+- `rafaelkamimura/claude-tools` `database-optimizer` — the data-access / N+1
+  lens. MIT.
+
+## Local design decisions
+
+- **Measure-first is the governing rule** (`qa.md` optimization stance):
+  baseline before claiming or fixing; separate measured findings from
+  hypotheses.
+- **Assess-only** — an actual optimization is a separate, measured
+  before/after step, not part of this pass.
+- The profiling step is delegated to a subagent (read/output-heavy).
+- Positioned as the tool for `qa.md`'s Performance & load dimension; distinct
+  from `arch-review` (structure vs runtime).

--- a/config/claude/skills/test-review/SKILL.md
+++ b/config/claude/skills/test-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: test-review
+description: Assess the quality and coverage of a test suite — does it cover success AND failure paths, is there a regression test per past bug, are tests well-structured (arrange-act-assert, intent-revealing names) and not brittle/over-mocked, what edge cases are missing. Use for "review the tests", "are these tests any good", "test coverage gaps", "is this well tested", "what's missing from the test suite". The tool for qa.md's Tests dimension (quality, not execution). Distinct from qa-check (runs the tests) and /code-review (reviews a diff).
+---
+
+# test-review
+
+**Version:** v1.0.0
+
+Assess a **test suite's quality and coverage** — not whether it passes
+(`qa-check` runs it), but whether it's *worth* passing. Subject-agnostic; the
+bar comes from `testing.md`.
+
+## What it checks (the bar is `testing.md`)
+
+- **Success *and* failure paths** — the headline gap. A suite that only
+  asserts the happy path is half a suite; flag every behavior whose
+  failure/error path is untested.
+- **Regression coverage** — does each past bug fix have a test that would fail
+  without the fix? Name behaviors with no guarding test.
+- **Structure** — arrange-act-assert clarity, one behavior per test,
+  intent-revealing names (`code-style.md`). A test you can't read won't be
+  trusted or maintained.
+- **Brittleness** — over-mocking (tests that assert implementation, not
+  behavior), order-dependence, hidden shared state, time/randomness not
+  pinned, assertions too loose (or too tight to refactor through).
+- **Edge cases** — empty/large/boundary inputs, concurrency, partial failure —
+  the cases real bugs hide in.
+
+## Type / agent use
+
+A **skill** you invoke. For a large suite, delegate the read to a **subagent**
+that maps tests → behaviors-covered and returns the gaps, keeping the file-by-
+file reading out of this conversation.
+
+## Output
+
+```markdown
+## Test review — <scope>
+
+**Coverage take:** <one line — biggest gap, usually failure paths>
+
+### Untested failure paths
+- `subject` — <the error/edge behavior with no test>
+
+### Missing regression tests
+- <past bug / risky behavior> — no guarding test
+
+### Quality issues
+- `test` — <brittle/over-mocked/unclear> → <fix>
+```
+
+Prioritize **untested failure paths and missing regressions** — they're where
+real defects slip through. **Assess only**; writing the missing tests is a
+separate step (use the repo's runner / `bats-setup` etc.). Don't report a raw
+coverage % as if it were quality — a 90%-happy-path suite is worse than it
+looks.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-plugins` python
+`test-reviewer` (coverage + AAA/quality analysis). No upstream code reused.
+See `SOURCE.md`.

--- a/config/claude/skills/test-review/SOURCE.md
+++ b/config/claude/skills/test-review/SOURCE.md
@@ -1,0 +1,22 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+testing.md bar, the agent-maps-coverage pattern).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-plugins.md`:
+
+- `ruslan-korneev/claude-plugins` python `test-reviewer` — coverage + test
+  quality (AAA, naming, responsibility). MIT.
+
+## Local design decisions
+
+- The quality bar is **`testing.md`** (success **and** failure paths,
+  regression-per-bug); not a raw coverage %.
+- **Assess only** — runs nothing (that's `qa-check`) and writes nothing (the
+  runner / `bats-setup` do that).
+- Large-suite read delegated to a subagent.
+- Positioned as the tool for `qa.md`'s Tests dimension (quality), distinct
+  from qa-check (execution) and `/code-review` (diff).


### PR DESCRIPTION
## Summary
**Tier-2 qa cluster** — the `arch-review` assessment-skill family, each a skill that delegates heavy reading to a *generic* subagent:
- **`perf-review`** — runtime performance, **measure-first** (qa.md Performance & load); separates measured findings from hypotheses.
- **`test-review`** — test-suite *quality/coverage* against the `testing.md` bar (success **and** failure paths, regression-per-bug); not execution (that's qa-check).
- **`a11y-review`** — WCAG/accessibility audit for UI repos (explicit N/A gate for headless/CLI/library).

**Method refinement — the SKIP-resurfacing gap** (per your point): split `SKIP` into permanent **SKIP** vs conditional **`SKIP-until <trigger>`**, which flips back to CANDIDATE when the trigger fires. Added a census **Watch list** of triggers (Mermaid, Logfire, `pydantic_ai`, SSO, GraphQL, payments, Linear, a new language) checked on adopting any new tool; relabelled `diagram` and `linear`; documented in the claude-audit skill. The original SKIP is never rewritten — the trigger resurfaces it.

Census Tier-2 marked DONE.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] `perf-review`, `test-review`, `a11y-review` in the skill list & trigger appropriately
- [ ] Watch list present in mining-census.md; `diagram`/`linear` show `SKIP-until`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
