### PR TITLE
feat(claude): pytest/typing-patterns skills + wire qa review skills

### DIFF
--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -99,9 +99,10 @@ skill; `plan-reviewer` → the **`plan-review`** skill. **Remaining:**
 **Tier 2 — useful generic, some overlap.** **DONE** (built as qa-dimension
 review skills, the arch-review family): `perf-check`/`performance-engineer` →
 **`perf-review`**; `test-reviewer` → **`test-review`**;
-`accessibility-specialist` → **`a11y-review`**. **Remaining:**
-`pytest-patterns`/`typing-patterns` (Python depth, like fastapi-patterns —
-python-scoped, not qa), `security-auditor` (overlaps `security-scan` +
+`accessibility-specialist` → **`a11y-review`**; `pytest-patterns` →
+**`pytest-patterns`** skill (testing depth) and `typing-patterns` →
+**`typing-patterns`** skill (typing depth, paired with `python.md`).
+**Remaining:** `security-auditor` (overlaps `security-scan` +
 `/security-review` — decide), `ui-ux-designer`, `handoff`, `standup`,
 `dev-docs-update`, `brainstorm`.
 

--- a/config/claude/rules/python.md
+++ b/config/claude/rules/python.md
@@ -6,7 +6,12 @@ paths:
 
 # Python Rules
 
-**Version:** v2.3.0
+**Version:** v2.4.0
+
+For concrete depth beyond these conventions — pytest technique (fixtures,
+mocking discipline, async, flakiness) and typing technique (TypedDict,
+Protocol, generics, narrowing, avoiding `# type: ignore`) — invoke the
+**pytest-patterns** and **typing-patterns** skills.
 
 ## Detection
 

--- a/config/claude/rules/qa.md
+++ b/config/claude/rules/qa.md
@@ -147,7 +147,16 @@ reason to restructure this doc.
 | This rule (`qa.md`) | dimensions, ordering, discipline (generic) | "run a formatter, then lint, then type-check" |
 | Repo `.claude/` QA doc | the repo's concrete tools + commands + required checks | "`npm run check` then `tsc -b` then `npm test`" |
 | Per-tool rules (detection-activated) | each tool's invocation/config | `biome.md`, `semgrep.md`, … |
-| Skills | forcing functions that run it | **qa-check**, composing **security-scan** + **containerize** |
+| Skills | forcing functions that run it | **qa-check**, composing **security-scan**, **containerize**, and the per-dimension review skills below |
+
+Several dimensions have a global, cross-language **review skill** that
+`qa-check` composes (these *assess* a whole codebase — distinct from the
+diff-level `/code-review` · `/simplify`, and from *running* the suite):
+**arch-review** (4 — code-smell/complexity/maintainability), **test-review** (6
+— test-suite *quality*, vs executing), **a11y-review** (7 — UI/UX &
+accessibility), **perf-review** (10 — performance). Python implementation depth:
+**pytest-patterns**, **typing-patterns**. These are *our* tools, named here as
+the standing ones; per-repo concrete tools still live in the repo's QA doc.
 
 ## The repo QA doc covers every dimension, with a status
 

--- a/config/claude/skills/pytest-patterns/SKILL.md
+++ b/config/claude/skills/pytest-patterns/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: pytest-patterns
+description: Concrete pytest depth for Python — fixture design (scope, yield-teardown, factory-as-fixture, conftest hierarchy), mocking discipline (patch where it's used, AsyncMock vs MagicMock, spec/autospec, mock at boundaries not internals), real-dependency-over-mock for DBs, freezing time/randomness, parametrize with ids and failure cases, pytest.raises(match=...), branch coverage, and pytest-xdist isolation. Use when writing or improving Python tests and you want the deeper how beyond "use pytest" and the testing.md bar. Triggers: "write tests for this", "pytest fixture", "mock this", "freeze time in a test", "parametrize", "why is this test flaky", "async test".
+---
+
+# pytest-patterns
+
+**Version:** v1.0.0
+
+The deep *how* for Python tests with pytest. **The bar comes from
+`testing.md`** (cover success **and** failure paths; a regression test per
+bug) — this skill
+is the technique to meet it well. Generic Python; for DB-layer test setup see
+the **sqlalchemy-patterns** skill, for the bash analog see **bats-setup**.
+
+## Fixtures
+
+- **Scope deliberately** — `function` (default, isolated) unless setup is
+  expensive and safely shared (`module`/`session`). A shared-scope fixture
+  that holds mutable state is a flakiness source.
+- **Teardown via `yield`** — set up, `yield` the value, tear down after:
+
+  ```python
+  @pytest.fixture
+  def client():
+      c = make_client()
+      yield c
+      c.close()
+  ```
+
+- **Factory-as-fixture** — when tests need *many* objects with tweaks, yield a
+  *callable* instead of one object:
+
+  ```python
+  @pytest.fixture
+  def make_user():
+      def _make(**over):
+          return User(email="a@b.com", **over)
+      return _make
+  ```
+
+- **conftest hierarchy** — shared fixtures in `tests/conftest.py`;
+  area-specific ones in `tests/<area>/conftest.py`. Don't import fixtures; let
+  pytest discover them.
+
+## Mocking discipline
+
+- **Patch where it's *used*, not where it's defined** —
+  `patch("app.svc.client")` (the module that calls it), not
+  `patch("app.client")`. The #1 mocking bug.
+- **`AsyncMock` for async, `MagicMock` for sync** — mixing raises `TypeError`;
+  an un-awaited `MagicMock` "passes" while testing nothing.
+- **`spec=`/`autospec=True`** so the mock rejects calls the real object can't
+  make — an unspecced mock accepts anything and hides drift.
+- **Mock at boundaries, not internals** — patch the HTTP/clock/filesystem
+  edge, not your own functions. Tests that assert *implementation* break on
+  every
+  refactor; tests that assert *behavior* don't.
+- **Prefer a real dependency when it's cheap** — for the database, a real test
+  DB with per-test transaction rollback beats a mocked session (you test real
+  SQL/constraints). Session setup: **sqlalchemy-patterns**.
+
+## Freezing time and randomness
+
+Patch at the **use site**, and keep the constructor working with `side_effect`
+so non-frozen calls still build values:
+
+```python
+with patch("app.svc.datetime") as m:
+    m.now.return_value = FIXED
+    m.side_effect = lambda *a, **k: datetime(*a, **k)
+```
+
+A test that depends on real `now()`/`random()` is flaky by construction — pin
+them.
+
+## Parametrize — including the failure cases
+
+Use `ids=` for readable output, and parametrize the **failure/edge** inputs
+too (that's the `testing.md` bar, not just the happy path):
+
+```python
+@pytest.mark.parametrize("raw,ok", [
+    ("a@b.com", True), ("@b.com", False), ("", False),
+], ids=["valid", "no-local", "empty"])
+def test_email(raw, ok):
+    assert is_valid(raw) is ok
+```
+
+## Exceptions, coverage, parallelism
+
+- **Assert the error, not just that one occurs** — `pytest.raises(ValueError,
+  match=r"not found")`; the `match` guards against the *wrong* error passing.
+- **Branch coverage > line coverage** — `--cov-branch`. 100% lines with
+  untested branches is false confidence (and misses the failure paths).
+- **Parallel with `pytest-xdist`** — give each worker its own external state
+  (e.g. DB name keyed by `worker_id`) or parallel runs corrupt each other.
+
+## Provenance
+
+Adapted from the mining census — `claude-plugins` python `pytest-patterns`
+(implementation detail reused: fixture/conftest scoping, the patch-where-used
+rule, the frozen-time `side_effect` recipe, xdist worker isolation). Stripped
+of its dependency-injector/SQLAlchemy specifics (those live in the relevant
+skills). See `SOURCE.md`.

--- a/config/claude/skills/pytest-patterns/SOURCE.md
+++ b/config/claude/skills/pytest-patterns/SOURCE.md
@@ -1,0 +1,33 @@
+# Source / provenance
+
+## Tracked source (implementation detail used)
+
+| Upstream repo | Path | License | SHA at adaptation |
+|---------------|------|---------|-------------------|
+| `ruslan-korneev/claude-plugins` | `plugins/python/skills/pytest-patterns/` (SKILL + references) | MIT | `62a0c1c` (full: `62a0c1cf8da56e54de9e550753e3cf783e7ee391`) |
+
+Details reused: fixture/conftest scoping guidance, the "patch where it's used"
+rule, the frozen-time `side_effect` recipe, and the pytest-xdist
+worker-isolation scheme.
+
+Adaptation date: 2026-06-11.
+
+## Deliberate divergences
+
+- **Stripped the stack specifics** — the upstream is heavily
+  dependency-injector + SQLAlchemy flavored (`FakeSessionMaker`, session
+  rollback fixtures); those belong in `fastapi-patterns` /
+  `sqlalchemy-patterns` (the layering principle, `EXTENDING.md`). This skill
+  stays generic pytest.
+- **Bar comes from `testing.md`** (success + failure paths,
+  regression-per-bug); the skill is technique, not policy.
+
+## Check the tracked source for new ideas
+
+```bash
+gh api "repos/ruslan-korneev/claude-plugins/commits?path=plugins/python/skills/pytest-patterns&per_page=1" \
+  --jq '.[0] | "\(.sha[0:7])  \(.commit.committer.date)"'
+```
+
+If the SHA differs, skim for new recipes; bump the SHA/date here and the
+**Version** in `SKILL.md`.

--- a/config/claude/skills/qa-check/SKILL.md
+++ b/config/claude/skills/qa-check/SKILL.md
@@ -72,6 +72,14 @@ Only the qa-check-specific operational notes (the rest is in `qa.md`):
 - **Security** → defer to the **security-scan** skill (plus the built-in
   `/security-review` for a quick pending-changes vuln pass); **Build**'s image
   step → the **containerize** skill.
+- **Whole-codebase dimension reviews** (an across-the-repo pass, not the diff)
+  → route to the review skills: **arch-review** (code-smell/complexity/
+  maintainability), **perf-review** (performance — measure-first),
+  **test-review** (test-suite *quality*, distinct from the Tests step that
+  *runs* them), **a11y-review** (UI/UX & accessibility — UI repos). They assess
+  and report; they don't mutate. For Python depth invoke **pytest-patterns** /
+  **typing-patterns**. Run these when the change (or the request) is about a
+  dimension's health, not on every trivial diff.
 - **CI** is the post-push stage — watch it to green; honour required checks.
 - For a dimension with no tooling (UI/UX, e2e), do the manual pass and flag
   the gap rather than skipping it.

--- a/config/claude/skills/typing-patterns/SKILL.md
+++ b/config/claude/skills/typing-patterns/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: typing-patterns
+description: Concrete Python typing depth — fix type errors instead of silencing them, TypedDict (NotRequired/Required/total) over dict[str, Any], Protocol (structural) vs ABC, generics (TypeVar bound/constraints, the 3.12 class[T] syntax, ParamSpec for decorators), Literal, overload, narrowing (TypeGuard/isinstance/assert), Sequence/Mapping over list/dict in signatures, NewType, Self, Annotated, and using cast/Any only as a last resort. Use when adding or fixing Python type annotations and you want the deeper how beyond "run mypy" and the python.md policy. Triggers: "type this properly", "fix this type error without type:ignore", "TypedDict", "Protocol", "generic class/function", "overload", "narrow this type", "what's the right annotation".
+---
+
+# typing-patterns
+
+**Version:** v1.0.0
+
+The deep *how* for Python type annotations. **The policy comes from
+`python.md`** (mypy/pyright; never a bare `# type: ignore` — justify with
+`[code]` + a reason) — this skill is what to write *instead* of reaching for
+the escape hatch.
+
+## Fix the error, don't silence it
+
+A type error is usually a real one. Before `# type: ignore`, ask what the
+checker actually caught — most often a missing `None` check, a too-wide type,
+or a real bug:
+
+```python
+# not:  return db.get(id)  # type: ignore
+user = db.get(id)
+if user is None:
+    raise NotFoundError(id)
+return user                 # now genuinely User, no ignore
+```
+
+`# type: ignore[code]` with a reason is the rare, documented last resort
+(`python.md`) — not the first move.
+
+## Shapes over `dict[str, Any]`
+
+`dict[str, Any]` defeats the checker. Name the shape with **`TypedDict`**, and
+control optionality per-field:
+
+```python
+from typing import TypedDict, NotRequired
+
+class UserCreate(TypedDict):
+    email: str
+    name: str
+    age: NotRequired[int]          # optional key; or `total=False` for all
+```
+
+Now `data["emial"]` and a missing `email` are caught.
+
+## Structural typing — `Protocol` over ABC
+
+When you need "anything with this shape," a `Protocol` types it without
+forcing inheritance:
+
+```python
+from typing import Protocol
+
+class Readable(Protocol):
+    def read(self) -> str: ...
+
+def load(src: Readable) -> str:    # any object with read() qualifies
+    return src.read()
+```
+
+## Generics
+
+- **`TypeVar` with `bound`/constraints** — keep generic functions honest:
+  `T = TypeVar("T", bound=BaseModel)` (subtypes only);
+  `S = TypeVar("S", str, bytes)` (one of those two).
+- **3.12 syntax** — `class Repository[T]:` /
+  `def first[T](xs: list[T]) -> T:`; cleaner than the `Generic[T]` base.
+- **`ParamSpec`** — preserve a wrapped function's *exact* signature through a
+  decorator: `def deco(f: Callable[P, R]) -> Callable[P, R]:` with
+  `*args: P.args, **kwargs: P.kwargs`.
+
+## Precision: `Literal`, `overload`, narrowing
+
+- **`Literal`** for exact values — `Status = Literal["pending", "shipped"]`;
+  the checker rejects `"shpped"`.
+- **`@overload`** when the return type depends on the argument type — declare
+  each signature, then one implementation.
+- **Narrowing** — `isinstance`/`assert`, and **`TypeGuard`** for custom
+  predicates:
+
+  ```python
+  def all_str(xs: list[object]) -> TypeGuard[list[str]]:
+      return all(isinstance(x, str) for x in xs)
+  ```
+
+## Signatures and nominal types
+
+- **`Sequence`/`Mapping`/`Iterable` over `list`/`dict`** in *parameters* —
+  accept the read-only contract; return concrete types.
+- **`NewType`** to stop primitive mix-ups — `UserId = NewType("UserId", int)`
+  so a bare `int` won't pass where a `UserId` is wanted.
+- **`Self`** for chainable/builder methods; **`Annotated`** to attach metadata
+  (validators, units) to a type.
+
+## Last resorts
+
+`cast(...)` and `Any` switch the checker *off* for that value — `Any` then
+spreads silently downstream. Prefer real validation (e.g. a pydantic
+`TypeAdapter`) to assert a shape at runtime; if you must `cast`, comment why
+it's safe.
+
+## Provenance
+
+Adapted **idea-level** from the mining census — `claude-plugins` python
+`typing-patterns`. The recipes are general Python typing knowledge rendered in
+house style; no upstream implementation reused. See `SOURCE.md`.

--- a/config/claude/skills/typing-patterns/SOURCE.md
+++ b/config/claude/skills/typing-patterns/SOURCE.md
@@ -1,0 +1,21 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source: the recipes (TypedDict, Protocol, generics,
+narrowing, NewType, …) are general Python typing knowledge, written in house
+style. The `claude-plugins` skill surfaced the *idea* of a typing-depth skill.
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-plugins.md`:
+
+- `ruslan-korneev/claude-plugins` python `typing-patterns` — "no
+  `type: ignore`" typing depth. MIT.
+
+## Local design decisions
+
+- **Policy lives in `python.md`** (mypy/pyright, justify any `# type:
+  ignore`); this skill is the *technique* to avoid needing the ignore.
+- Categorized as Python **typing** depth (pairs with `python.md`), not
+  testing — distinct from `pytest-patterns` despite both being Python-depth
+  skills.


### PR DESCRIPTION
## Summary
Two Python implementation-**depth** skills (the `fastapi-patterns`/`sqlalchemy-patterns` pattern), plus the **qa wiring** you flagged.

- **`pytest-patterns`** — generic pytest technique (fixture design, mocking discipline incl. patch-where-used / AsyncMock vs MagicMock / spec, real-DB-over-mock, freezing time, parametrize *with failure cases*, branch coverage, xdist) to meet the `testing.md` bar. Cites `claude-plugins` (impl detail reused); **stripped of its DI/SQLAlchemy specifics** (those live in the relevant skills — the layering principle).
- **`typing-patterns`** — typing technique (TypedDict, Protocol, generics incl. `ParamSpec`/3.12 syntax, `Literal`/`overload`, `TypeGuard` narrowing, `NewType`, "fix it, don't `# type: ignore`") backing `python.md`'s policy. Idea-level. `python.md` cross-links both.
- **Wiring (the gap):** the review skills were "the tool for qa.md dimension X" but `qa.md`/`qa-check` never named them. Now `qa.md`'s Skills row + a per-dimension note (arch-review 4, test-review 6, a11y-review 7, perf-review 10; pytest/typing depth) name them as our standing tools, and **`qa-check` composes them** via a routing bullet.

Census Tier-2 marked done.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] `pytest-patterns`, `typing-patterns` in the skill list & trigger
- [ ] `qa.md` + `qa-check` reference the review skills; `python.md` cross-links the depth skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)