### PR TITLE
docs(audit): qa-is-umbrella + split-categories audit checks

### DIFF
--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -63,6 +63,22 @@ Don't force it — a genuinely new area (e.g. an `architecture`/`docs` family)
 earns its own top-level category. The default is "extend a family," the
 exception is "open a new one."
 
+**Split a category that's outgrown itself.** Folding-in is the default, but a
+category can grow **too big or too spread out** — so **each audit checks
+whether any top-level category should split** into separate ones (e.g. a
+bulging `qa` shedding `documentation` / `troubleshooting`, or a `tools`
+grab-bag separating by tool). Splitting is the release valve that keeps
+fold-in from creating a junk drawer.
+
+**`qa` is the umbrella — work it last.** `qa` (and the `qa-check` skill)
+aggregates the other categories — code-style, testing, security,
+documentation, performance — plus its own pipeline discipline, even though
+each of those stays its own category. So when **mining or otherwise
+creating/modifying rules/skills**, build/adopt the category-specific pieces
+**first** and touch `qa` **last** — then **wire them in**: `qa.md` names the
+tool and `qa-check` composes it. Updating `qa` before its pieces exist
+guarantees the wiring gap (a review skill that nothing calls).
+
 ---
 
 ## Round 2026-06-11 — FastAPI/SQLAlchemy/Python mining
@@ -102,9 +118,9 @@ review skills, the arch-review family): `perf-check`/`performance-engineer` →
 `accessibility-specialist` → **`a11y-review`**; `pytest-patterns` →
 **`pytest-patterns`** skill (testing depth) and `typing-patterns` →
 **`typing-patterns`** skill (typing depth, paired with `python.md`).
-**Remaining:** `security-auditor` (overlaps `security-scan` +
-`/security-review` — decide), `ui-ux-designer`, `handoff`, `standup`,
-`dev-docs-update`, `brainstorm`.
+`security-auditor` → **SKIP** (overlaps `security-scan` + `/security-review`).
+**Remaining (not qa):** `ui-ux-designer`, `handoff`, `standup`,
+`dev-docs-update`, `brainstorm` — workflow/UX items for later categories.
 
 **Tier 3 — external libraries/frameworks/tools: global, built on first use.**
 These are all guidance about something *foreign to the repo*, so per ADR-0003

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -42,7 +42,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | database-optimizer | generic | CANDIDATE | query/index/N+1 — SQLAlchemy half in sqlalchemy-patterns; generic lens novel |
 | performance-engineer | generic | CANDIDATE | profiling/load/Core-Web-Vitals (broader than database-optimizer) |
 | accessibility-specialist | generic | CANDIDATE | WCAG/ARIA/keyboard — novel a11y lens |
-| security-auditor | generic | CANDIDATE | deeper OWASP/auth/crypto audit (vs `/security-review`) |
+| security-auditor | generic | SKIP | overlaps `security-scan` skill + `/security-review`; deeper-audit lens not worth a separate skill now |
 | documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
 | api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
 | backend-architect | generic | CANDIDATE | API/schema/caching design patterns |

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -67,7 +67,10 @@ log) — the canonical methodology and living record. In short:
    stack's specifics bleeding into it**? A generic primitive should be a thin
    stack-agnostic layer that points to path-scoped per-stack patterns (see
    *Layer the generic over the specific* in `EXTENDING.md`); flag a Python-
-   flavored "generic" agent that would mislead a Go-only repo.
+   flavored "generic" agent that would mislead a Go-only repo. Also check the
+   **categories themselves**: has a top-level category grown **too big or too
+   spread out** and need **splitting** (e.g. `qa` shedding `documentation` /
+   `troubleshooting`)? Splitting is the counter-move to over-folding.
 3. **Recommend** by **cost × (1 − relevance)** — trim weight, never
    guardrails. Apply the placement ladder from `EXTENDING.md` (global+lazy >
    per-repo) and the plugin/MCP rules from `rules/mcp.md` (plugins are global
@@ -123,9 +126,12 @@ because it arrived in a different form. **Placement:** anything about a
 repo-foreign library/tool is built **global**, on first use (ADR-0003) — not
 repo-local, not deferred; and **fold a new capability into an existing
 top-level category** (`code-style` / `testing` / `qa` / `gh` / `git`) rather
-than spawning a new one unless it genuinely doesn't fit. Record sources in the
-*Idea sources* registry; a per-artifact `SOURCE.md` only on implementation
-reuse (ADR-0002).
+than spawning a new one unless it genuinely doesn't fit. **`qa` is the
+umbrella — work it last:** it aggregates the other categories, so build the
+category-specific pieces first and touch `qa` (and `qa-check`) last, wiring
+the new pieces in (`qa.md` names them, `qa-check` composes them). Record
+sources in the *Idea sources* registry; a per-artifact `SOURCE.md` only on
+implementation reuse (ADR-0002).
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
Two standing audit/authoring notes from the session, plus a SKIP:
- **`qa` is the umbrella — work it last.** `qa`/`qa-check` aggregates the other categories (code-style, testing, security, documentation, performance) plus its own pipeline discipline. So when mining or creating/modifying rules/skills, build the category-specific pieces **first** and touch `qa` **last**, then **wire them in** (`qa.md` names them, `qa-check` composes them) — otherwise the wiring gap recurs (a review skill nothing calls).
- **Each audit checks whether a category should split** — the counter-move to over-folding: a top-level category can grow too big / too spread out and need splitting (e.g. `qa` shedding `documentation`/`troubleshooting`). Keeps fold-in from creating a junk drawer.
- Formally **SKIP `security-auditor`** (overlaps `security-scan` + `/security-review`).

Recorded in the **claude-audit skill** (right-fit step + mining placement note) and the **mining-census** categorization section.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] claude-audit skill carries both notes; census categorization section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)