### PR TITLE
docs(audit): code-style survey — nothing to adopt; category status

### DIFF
--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -135,6 +135,13 @@ library/tool, front-loaded, not deferred. Items: language-expert agents
 
 ## Category status (so audits don't re-survey)
 
+**Snapshot of the current repos/stacks — not "closed forever."** A **new repo**
+(or a new language/framework in an existing one) **re-opens every category** for
+re-evaluation against it — `code-style` most obviously (a new language carries
+its own style conventions and formatter/linter), but **all** of them. "Complete"
+here means "covered for what we build today." Pairs with the global-re-eval
+principle (claude-audit skill) and the `SKIP-until` watch list above.
+
 - **`code-style`** — **complete as-is; nothing to adopt.** It is documented
   policy (`code-style.md`) + per-language formatters/linters (`ruff.md`,
   `shfmt`, …) + the qa *Code-style audit* dimension executed by `/code-review`

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -135,12 +135,13 @@ library/tool, front-loaded, not deferred. Items: language-expert agents
 
 ## Category status (so audits don't re-survey)
 
-**Snapshot of the current repos/stacks — not "closed forever."** A **new repo**
-(or a new language/framework in an existing one) **re-opens every category** for
-re-evaluation against it — `code-style` most obviously (a new language carries
-its own style conventions and formatter/linter), but **all** of them. "Complete"
-here means "covered for what we build today." Pairs with the global-re-eval
-principle (claude-audit skill) and the `SKIP-until` watch list above.
+**Snapshot of the current repos/stacks — not "closed forever."** A **new
+repo** (or a new language/framework in an existing one) **re-opens every
+category** for re-evaluation against it — `code-style` most obviously (a new
+language carries its own style conventions and formatter/linter), but **all**
+of them. "Complete" here means "covered for what we build today." Pairs with
+the global-re-eval principle (claude-audit skill) and the `SKIP-until` watch
+list above.
 
 - **`code-style`** — **complete as-is; nothing to adopt.** It is documented
   policy (`code-style.md`) + per-language formatters/linters (`ruff.md`,

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -132,3 +132,21 @@ library/tool, front-loaded, not deferred. Items: language-expert agents
 `deploy`/`rollback`/`deployment-engineer`/
 `devops-troubleshooter`/`cloud-architect`, the FastAPI scaffolders
 (`module`/`endpoint`/`migrate-*`), pydantic-ai + Logfire skills.
+
+## Category status (so audits don't re-survey)
+
+- **`code-style`** — **complete as-is; nothing to adopt.** It is documented
+  policy (`code-style.md`) + per-language formatters/linters (`ruff.md`,
+  `shfmt`, …) + the qa *Code-style audit* dimension executed by `/code-review`
+  and `/simplify`. Every mined code-style item (clean-code-patterns,
+  code-refactor-master/code-architecture-reviewer, ruff-patterns,
+  refactor-planner) is SKIP — covered. A skill adds nothing over the rule
+  (and style is personal preference — a rule's job, not a skill's).
+- **`qa`** — substantially built (the `*-review` family + python depth); the
+  **umbrella, worked last**. Open: nothing required.
+- **`testing`** — covered (`testing.md` + `bats-setup` + `test-review` +
+  `pytest-patterns`).
+- **`gh`/`git`** — covered by rules + skills; open ideas: `resolve-issue`,
+  `categorize-issue` (audit backlog).
+- **`documentation`, `troubleshooting`** — **not yet opened**; homes for
+  `write-documentation` and `debug-assistant` (the remaining Tier-1 items).

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -46,7 +46,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
 | api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
 | backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
-| refactor-planner | generic | CANDIDATE | refactoring plans + risk (planning vs execution) |
+| refactor-planner | generic | SKIP | refactoring plans + risk — now covered by `modernize` (large) + `/simplify` (small) + `arch-review`/`plan-review` |
 | legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |
 | test-automator | generic | CANDIDATE | test strategy/pyramid planning |
 | frontend-qa-tester | generic | CANDIDATE | Playwright-driven manual QA + bug reports |


### PR DESCRIPTION
## Summary
Surveyed the mining census for the **code-style** category across all tiers (per request): **nothing to adopt at any tier.** Code-style is covered by documented policy (`code-style.md`) + per-language formatters/linters + the qa *Code-style audit* dimension executed by `/code-review` and `/simplify`. A skill adds nothing over the rule (and style is personal preference — a rule's job).

- Downgrade the stale **`refactor-planner`** CANDIDATE → **SKIP** (now covered by `modernize` (large) + `/simplify` (small) + `arch-review`/`plan-review`).
- Add a **Category status** section to the census so future audits don't re-walk this: code-style complete; qa/testing/gh/git covered; `documentation` + `troubleshooting` not yet opened.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] census shows refactor-planner SKIP + a Category status section

🤖 Generated with [Claude Code](https://claude.com/claude-code)