### PR TITLE
docs(audit): testing-category survey — covered; e2e deferred

### DIFF
--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -47,6 +47,7 @@ new dependency or tool; the audit checks it each run.
 | **Payments** (Stripe/etc.) | `claude-tools` `payment-integration` (Tier-3) |
 | **Linear** (the SaaS) | `claude-plugins` `linear` plugin (board/comment/cycle/issue-enricher) |
 | **A new language** (Go/Rust/TS…) in a repo | the matching `claude-tools` language-expert agent (Tier-3) |
+| **A browser UI / e2e need** (Playwright) | `claude-tools` `frontend-qa-tester` → the qa End-to-end (dim 8) tool |
 
 (Tier-3 "build on first use" items are already watch-like by definition; listed
 here so there's one place to scan.)
@@ -153,7 +154,10 @@ list above.
 - **`qa`** — substantially built (the `*-review` family + python depth); the
   **umbrella, worked last**. Open: nothing required.
 - **`testing`** — covered (`testing.md` + `bats-setup` + `test-review` +
-  `pytest-patterns`).
+  `pytest-patterns` + `qa-check` runs/coverage). Two deferred: **e2e** (qa dim
+  8 has no tool — `frontend-qa-tester` is `SKIP-until` a browser-UI/Playwright
+  need, watch list) and **Codecov** coverage upload (audit finding F, deferred
+  — infra, not a skill).
 - **`gh`/`git`** — covered by rules + skills; open ideas: `resolve-issue`,
   `categorize-issue` (audit backlog).
 - **`documentation`, `troubleshooting`** — **not yet opened**; homes for

--- a/config/claude/audit/mining/claude-plugins.md
+++ b/config/claude/audit/mining/claude-plugins.md
@@ -31,9 +31,9 @@ The architecture/codebase-analysis cluster is the strongest generic find.
 
 | name | type | scope | disp. | reason |
 |------|------|-------|-------|--------|
-| pytest-patterns | skill | generic | CANDIDATE | production pytest/TDD depth — could enrich like fastapi-patterns did |
+| pytest-patterns | skill | generic | ADOPTED | built as the **`pytest-patterns`** skill (testing depth) |
 | typing-patterns | skill | generic | CANDIDATE | Python typing depth (no `type: ignore`) — augments python.md |
-| test-reviewer | agent | generic | CANDIDATE | coverage + test-quality (AAA/naming) analysis |
+| test-reviewer | agent | generic | ADOPTED | built as the **`test-review`** skill |
 | lint:explain, typecheck:explain | cmd | generic | SKIP | no-suppression policy already in ruff.md + python.md; explain = normal agent capability |
 | test:first | cmd | generic | SKIP | testing.md bar; TDD on request |
 | clean:review, clean-code-patterns | cmd/skill | generic | SKIP | code-style.md + qa.md Code-style audit + `/simplify` |

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -20,7 +20,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | standup | generic | CANDIDATE | standup notes from git history + todos |
 | task-init | generic | CANDIDATE | multi-phase task orchestration (overlaps Plan) |
 | tech-debt | generic | CANDIDATE | catalog debt/TODOs/complexity, prioritize by ROI |
-| test-suite | generic | CANDIDATE | test runner + coverage delta + missing-test gen (overlaps qa-check) |
+| test-suite | generic | SKIP | runner + coverage = `qa-check` (Tests dim); missing-test gaps = `test-review` |
 | write-documentation | generic | CANDIDATE | multi-format doc generation (API/arch/DB) |
 | deploy | stack | CANDIDATE | deployment orchestration — infra/repo-specific |
 | rollback | stack | CANDIDATE | recovery/rollback orchestration — infra-specific |
@@ -48,8 +48,8 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
 | refactor-planner | generic | SKIP | refactoring plans + risk — now covered by `modernize` (large) + `/simplify` (small) + `arch-review`/`plan-review` |
 | legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |
-| test-automator | generic | CANDIDATE | test strategy/pyramid planning |
-| frontend-qa-tester | generic | CANDIDATE | Playwright-driven manual QA + bug reports |
+| test-automator | generic | SKIP | test strategy/pyramid = `testing.md` bar + `plan-review` + `test-review` |
+| frontend-qa-tester | generic | SKIP-until browser-UI/e2e | the tool for qa.md's End-to-end dimension (no tool yet); Playwright/browser-specific — build on first browser-UI/e2e need (watch list) |
 | ui-ux-designer | generic | CANDIDATE | design methodology (vs frontend-design's implementation) |
 | devops-troubleshooter | generic | CANDIDATE | incident response / log analysis |
 | web-research-specialist | generic | CANDIDATE | overlaps `/deep-research`; lower priority |


### PR DESCRIPTION
## Summary
Surveyed the **testing** category (per request): covered for current stacks; nothing to build now.
- Fix stale matrix rows: `pytest-patterns` + `test-reviewer` → **ADOPTED** (built as the `pytest-patterns` / `test-review` skills).
- `test-suite` → **SKIP** (`qa-check` runs tests + coverage; `test-review` finds gaps); `test-automator` → **SKIP** (`testing.md` + `plan-review`).
- **`frontend-qa-tester`** → **SKIP-until** browser-UI/e2e — it's the tool for qa.md's **End-to-end** dimension (8, currently no tool), but Playwright/browser-specific. Added to the **watch list**; built on first browser-UI need.
- Note the two deferred testing items in Category status: **e2e** (the SKIP-until above) and **Codecov** coverage upload (audit finding F — infra, not a skill).

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint clean — verified locally)
- [ ] census + matrices reflect the survey; watch list has the e2e trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)