### PR TITLE
feat(claude/docs): open the documentation category

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -216,14 +216,31 @@ decisions are also summarized in the *Decisions log*.
   TODO triage queue (the `gh.md` *Issues & triage* workflow). Category: `gh`.
 - [ ] **Future top-level categories** (per the "fold into existing categories,
   new one only if it doesn't fit" guidance):
-  - [ ] **`documentation`** — home for a `write-documentation` skill (the
-    remaining Tier-1 doc-generation item) and doc tooling.
+  - [x] **`documentation`** — **opened** 2026-06-11: `rules/documentation.md`
+    (the doc bar + form stance) + the `write-documentation` skill. Doc tooling
+    (`markdownlint.md`) and the `adr` skill compose in. See *Decisions log*.
   - [ ] **`troubleshooting`** — home for a `debug-assistant` skill (the
     remaining Tier-1 debugging item; distinct from qa — assessing quality vs
     diagnosing a failure).
 
 ## Decisions log
 
+- 2026-06-11 — **Opened the `documentation` category.** Added an always-on
+  `rules/documentation.md` (the doc **bar** + the "right form per audience"
+  **stance**), modeled on `testing.md`, as the canonical home for what had
+  been scattered: `code-style.md` keeps the writing *mechanics*,
+  `markdownlint.md` the *linter*, `qa.md` dim 13 the *pipeline gate* — dim 13
+  now **points to** `documentation.md` for the bar instead of restating the
+  audience list (qa wired last, per the umbrella rule). Built the Tier-1
+  **`write-documentation`** skill (the authoring *how*), consolidating three
+  mined items — `write-documentation` + `documentation-architect` +
+  `api-documenter` (folded as the API-doc mode; FastAPI auto-OpenAPI layered
+  to `fastapi-patterns`). **Deliberately held out** of the category as
+  adjacent-but-different: `handoff`/`standup`/`dev-docs-update` (session
+  continuity) and `dev-docs`/`read-specs`/`feature-specification` (spec→plan)
+  — a future *workflow*/planning category, not product docs. Idea-level
+  adaptation (ADR-0002): no upstream code reused, `SOURCE.md` records the
+  census ideas. Landed via dotfiles PR.
 - 2026-06-10 — **A (MCP plugins): done globally.** terraform + serena
   disabled (user-level); re-enable per-repo via project/local MCP
   registration. terraform needed in harleydev.

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -108,10 +108,13 @@ stack-flavored ones per the layering principle. Grouped by leverage:
 (`dependency-analyzer`/`deps`, `arch-review`/`architecture-reviewer`,
 `tech-debt`, `codebase-explorer`) → the **`arch-review`** skill
 (`diagram`/Mermaid dropped — not used); `modernize` → the **`modernize`**
-skill; `plan-reviewer` → the **`plan-review`** skill. **Remaining:**
-`debug-assistant` (→ a *troubleshooting* category), `deps-update`,
-`write-documentation`/`documentation-architect` (→ a *documentation* category)
-— see the *Skill ideas & future categories* in `SETUP-AUDIT.md`.
+skill; `plan-reviewer` → the **`plan-review`** skill;
+`write-documentation`/`documentation-architect` → the
+**`write-documentation`** skill, which **opens the `documentation`
+category** (the `rules/documentation.md` rule plus the skill).
+**Remaining:** `debug-assistant` (→ a *troubleshooting* category),
+`deps-update` — see the *Skill ideas & future categories* in
+`SETUP-AUDIT.md`.
 
 **Tier 2 — useful generic, some overlap.** **DONE** (built as qa-dimension
 review skills, the arch-review family): `perf-check`/`performance-engineer` →
@@ -120,8 +123,12 @@ review skills, the arch-review family): `perf-check`/`performance-engineer` →
 **`pytest-patterns`** skill (testing depth) and `typing-patterns` →
 **`typing-patterns`** skill (typing depth, paired with `python.md`).
 `security-auditor` → **SKIP** (overlaps `security-scan` + `/security-review`).
-**Remaining (not qa):** `ui-ux-designer`, `handoff`, `standup`,
-`dev-docs-update`, `brainstorm` — workflow/UX items for later categories.
+The documentation-output item `api-documenter` → **ADOPTED** (folded into
+`write-documentation`, above). **Remaining (not qa):** `ui-ux-designer`,
+`handoff`, `standup`, `dev-docs-update`, `brainstorm` — workflow/UX items for
+later categories; `handoff`/`standup`/`dev-docs-update` were **considered for
+`documentation` and deliberately held out** as session-continuity workflow
+(not product docs) — see *Category status*.
 
 **Tier 3 — external libraries/frameworks/tools: global, built on first use.**
 These are all guidance about something *foreign to the repo*, so per ADR-0003
@@ -160,5 +167,17 @@ list above.
   — infra, not a skill).
 - **`gh`/`git`** — covered by rules + skills; open ideas: `resolve-issue`,
   `categorize-issue` (audit backlog).
-- **`documentation`, `troubleshooting`** — **not yet opened**; homes for
-  `write-documentation` and `debug-assistant` (the remaining Tier-1 items).
+- **`documentation`** — **opened.** `documentation.md` (the doc bar + the
+  "right form per audience" stance) + the **`write-documentation`** skill
+  (authoring procedure) + `code-style.md` (writing mechanics) +
+  `markdownlint.md` (lint) + the `adr` skill (decisions) + `qa.md` dim 13 (the
+  pre-merge gate, which points here). Mined doc-output items folded in:
+  `documentation-architect`, `api-documenter` → `write-documentation`. **Held
+  as adjacent — not documentation:** `handoff`/`standup`/`dev-docs-update`
+  (session-continuity workflow) and `dev-docs`/`read-specs`/
+  `feature-specification` (spec → plan) belong to a future *workflow*/planning
+  category, not product docs — folding them in would force unrelated concerns
+  together ("don't force it").
+- **`troubleshooting`** — **not yet opened**; home for a `debug-assistant`
+  skill (the remaining Tier-1 item; distinct from qa — diagnosing a failure
+  vs assessing quality).

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -21,7 +21,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | task-init | generic | CANDIDATE | multi-phase task orchestration (overlaps Plan) |
 | tech-debt | generic | CANDIDATE | catalog debt/TODOs/complexity, prioritize by ROI |
 | test-suite | generic | SKIP | runner + coverage = `qa-check` (Tests dim); missing-test gaps = `test-review` |
-| write-documentation | generic | CANDIDATE | multi-format doc generation (API/arch/DB) |
+| write-documentation | generic | ADOPTED | built as the **`write-documentation`** skill — opens the documentation category |
 | deploy | stack | CANDIDATE | deployment orchestration — infra/repo-specific |
 | rollback | stack | CANDIDATE | recovery/rollback orchestration — infra-specific |
 | commit | generic | SKIP | overlaps git/gh rules + ship-pr; msg-gen fights the staging rules |
@@ -43,8 +43,8 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | performance-engineer | generic | CANDIDATE | profiling/load/Core-Web-Vitals (broader than database-optimizer) |
 | accessibility-specialist | generic | CANDIDATE | WCAG/ARIA/keyboard — novel a11y lens |
 | security-auditor | generic | SKIP | overlaps `security-scan` skill + `/security-review`; deeper-audit lens not worth a separate skill now |
-| documentation-architect | generic | CANDIDATE | comprehensive docs across stacks |
-| api-documenter | generic | CANDIDATE | OpenAPI/SDK — layering: FastAPI auto-OpenAPI covers Python; generic remainder thin |
+| documentation-architect | generic | ADOPTED | folded into the **`write-documentation`** skill (comprehensive-docs facet) |
+| api-documenter | generic | ADOPTED | folded into `write-documentation` as the API-doc mode; FastAPI auto-OpenAPI layered to `fastapi-patterns` |
 | backend-architect | generic | CANDIDATE | API/schema/caching design patterns |
 | refactor-planner | generic | SKIP | refactoring plans + risk — now covered by `modernize` (large) + `/simplify` (small) + `arch-review`/`plan-review` |
 | legacy-modernizer | generic | CANDIDATE | framework migration / monolith→services |

--- a/config/claude/rules/documentation.md
+++ b/config/claude/rules/documentation.md
@@ -1,0 +1,75 @@
+---
+# No paths — the documentation bar applies whenever behaviour changes,
+# which is triggered by code edits, not by editing a `.md` file.
+---
+
+# Documentation Rules
+
+**Version:** v1.0.0
+
+What a change must satisfy for documentation, and the stance on what *form*
+a doc should take. Deliberately **non-prescriptive** about writing mechanics
+and tooling — those live elsewhere (see *Where the specifics live*).
+`code-style.md` owns how docs are *written*; `qa.md` owns the Documentation
+*pipeline* stage that gates them.
+
+## The bar
+
+A change that alters behaviour but not its documentation is **incomplete**.
+When behaviour changes, update every documentation layer it touches, in the
+**same change**:
+
+- **User-facing** — README / usage / API reference, and the **changelog**.
+- **In-repo planning** — the `TODO` / roadmap the change advances or closes.
+- **Governing rules / skills** — the rules, skills, or `.claude/` docs the
+  change makes stale, **global *and* local**.
+- **Inline** — comments and docstrings at the code itself; public APIs MUST
+  carry one (`code-style.md`).
+
+Docs must be **current** and **accurate**: they describe the code as it is
+*now*, with no stale or broken references. Currency beats completeness — a
+short true doc beats a thorough stale one.
+
+## Form — be idiomatic to the audience
+
+Pick the **right kind** of doc for who reads it and why, the way `testing.md`
+picks the idiomatic test layout per language:
+
+- **The "why" behind a decision** → an ADR (the `adr` skill), not a buried
+  code comment.
+- **How to *use* a thing** → README / usage / API reference.
+- **Why a line of code is the way it is** → an inline comment that explains
+  *why*, never one that restates *what* well-named code already says
+  (`code-style.md`).
+- **What changed** → the changelog.
+
+Prefer **inline documentation over separate doc files**; add a separate file
+only when asked (`CLAUDE.md`). And follow the Rule of Three for docs: a
+repeated *fact* lives in **one** canonical place and is linked, but
+*explanatory* prose rightly overlaps where its job is to explain in its own
+context — dedupe the source of a fact, not understanding (`code-style.md`).
+
+## Where the specifics live
+
+| Layer | Holds |
+|-------|-------|
+| This rule (`documentation.md`) | the doc bar + the "right form per audience" stance |
+| `code-style.md` | writing mechanics — 78-col wrap, 72-col comments, reference links, public-API docstrings, dedupe-the-fact |
+| `markdownlint.md` (+ prose linters) | the linter that gates Markdown |
+| `qa.md` | the Documentation pipeline stage that gates docs pre-merge (dim 13), incl. generated-changelog prep |
+| `adr` skill | decision records (the "why") |
+| `write-documentation` skill | the procedure that authors / refreshes a doc |
+| repo `.claude/` | that repo's concrete doc set, changelog command, and any local doc conventions |
+
+## Agent Behavior
+
+- When a change alters behaviour, update the docs in the **same change**,
+  across **every** affected layer above. A behaviour change with no doc
+  change is incomplete — say so rather than ship it silently.
+- Choose the idiomatic **form** for the audience; prefer inline over separate
+  files; never duplicate a reference fact (link the canonical source).
+- Reach for the **`write-documentation`** skill to author or refresh a
+  substantial doc, and the **`adr`** skill to record a decision.
+- Lint Markdown (`markdownlint.md`) and let the **qa** Documentation stage
+  gate it; get the repo's concrete doc set + changelog command from its
+  `.claude/`.

--- a/config/claude/rules/qa.md
+++ b/config/claude/rules/qa.md
@@ -69,14 +69,16 @@ skip silently.
     acknowledge it (status it) rather than pretend it's covered.
 12. **Build** — the artifact actually compiles/bundles, and images build
     (the **containerize** skill) when containers change. Note size deltas.
-13. **Documentation** — the change's docs are **current** and **accurate**:
-    user-facing docs (README/usage/API, **changelog**), in-repo planning (a
-    `TODO` / roadmap), and the governing rules/skills it affects (global
-    *and* local) are updated; prose is linted (e.g. a Markdown linter) with
-    no stale or broken references. A change that alters behaviour but not its
-    docs is incomplete. When a repo's **changelog is generated** (from git
-    history or commit metadata), regenerating it **mutates the tree**, so it
-    is a **prep step in the same class as Format** (dimension 1) — run it
+13. **Documentation** — runs the **documentation bar** (`documentation.md`,
+    which owns it): the docs are **current** and **accurate** across every
+    layer that rule names (user-facing incl. the **changelog**, in-repo
+    planning, the governing rules/skills it affects — global *and* local, and
+    inline); prose is linted (e.g. a Markdown linter) with no stale or broken
+    references; a change that alters behaviour but not its docs is incomplete.
+    The **`write-documentation`** skill authors/refreshes a doc; the `adr`
+    skill records decisions. When a repo's **changelog is generated** (from
+    git history or commit metadata), regenerating it **mutates the tree**, so
+    it is a **prep step in the same class as Format** (dimension 1) — run it
     once just before opening the PR and **commit the result**; never in CI,
     which gates and must not commit. The concrete command lives in the
     repo's QA doc.

--- a/config/claude/skills/write-documentation/SKILL.md
+++ b/config/claude/skills/write-documentation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: write-documentation
+description: Author or refresh a piece of product/codebase documentation — pick the right form for the audience, derive it from the real code (not from memory), draft it to the documentation bar, wire it into the canonical index + changelog, and lint it. Use for "document this", "write documentation", "write the docs", "update the README", "API docs for X", "the docs are stale". Subject-agnostic; layers stack specifics (e.g. FastAPI auto-OpenAPI) onto generic structure. Composes documentation.md (the bar) and the adr skill (for decisions). documentation.
+---
+
+# write-documentation
+
+**Version:** v1.0.0
+
+The procedure that turns "this needs docs" into an accurate, current doc in
+the **right form**, derived from the code rather than from memory. The policy
+it serves — the bar and the "right form per audience" stance — lives in
+`documentation.md`; this skill is the *how*.
+
+## When to reach for it
+
+A behaviour change left its docs stale, a feature shipped without a doc, an
+API needs a reference, or a README has drifted from the code. Any time you're
+about to **author or refresh a substantial doc** rather than tweak a line.
+
+## Type / composition
+
+A **skill** (an authoring procedure you invoke and watch). It serves
+`documentation.md` (the bar + form stance) and takes writing mechanics from
+`code-style.md` (78-col wrap, reference links, public-API docstrings). For
+**decisions** (the "why") it defers to the **`adr`** skill — don't write an
+ADR here. For a large surface, fan the source-reading out to a read-only
+agent so accuracy doesn't cost the main context.
+
+## Boundaries — what this is *not*
+
+- **Not ADRs.** A decision record (the "why") → the `adr` skill.
+- **Not session/workflow notes.** Handoff, standup, "where I left off" docs
+  are session continuity, a different concern — not product documentation.
+- **Not spec → plan.** Turning a spec into an implementation plan is the
+  built-in Plan / `plan-review`, not a doc deliverable.
+
+## Procedure
+
+1. **Audience + form.** Name who reads it and why, then pick the idiomatic
+   form (`documentation.md`): README / usage, API reference, inline
+   comment/docstring, or changelog. Prefer **inline over a separate file**;
+   add a new file only when the content genuinely needs one (`CLAUDE.md`).
+2. **Find the canonical home.** Refresh an existing doc **in place** before
+   creating a new one. If the fact already lives somewhere, **link** it —
+   don't restate it (Rule of Three for docs, `code-style.md`).
+3. **Derive from the source of truth.** Read the actual code/behaviour the
+   doc describes — real signatures, schemas, flags, defaults — so the doc is
+   *derived*, not inferred. **Layering:** where the stack generates docs (a
+   FastAPI app's auto-OpenAPI), point at the generated artifact and the
+   stack's patterns (`fastapi-patterns`) instead of hand-writing what the
+   framework already produces.
+4. **Draft to the bar.** Current and accurate, right form, mechanics from
+   `code-style.md`. Every example must actually run/resolve — no invented
+   flags or endpoints.
+5. **Wire it in.** Link the new/updated doc from its index (README / docs
+   index), add a **changelog** entry, and flag any governing rule/skill the
+   change makes stale (global *and* local) so it's fixed in the same change.
+6. **Lint + verify.** Run `markdownlint` (`markdownlint.md`); confirm every
+   reference resolves and every code sample matches the source.
+
+## Output
+
+The documentation itself — inline at the code, or a file in its canonical
+home — plus a short note of **what was authored/refreshed**, **what it was
+linked from**, and **what else changed** (changelog, a stale rule). If a
+decision surfaced that belongs in an ADR, say so and point at the `adr`
+skill rather than burying it in prose.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools`
+`write-documentation` (multi-format doc generation) and the
+`documentation-architect` / `api-documenter` agents (comprehensive,
+derive-from-code docs; API-doc mode). No upstream code reused. See
+`SOURCE.md`.

--- a/config/claude/skills/write-documentation/SOURCE.md
+++ b/config/claude/skills/write-documentation/SOURCE.md
@@ -1,0 +1,29 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+derive-from-source procedure, the documentation.md composition).
+
+## Idea sources (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `write-documentation` — multi-format doc
+  generation (API / architecture / DB). MIT.
+- `rafaelkamimura/claude-tools` `documentation-architect` agent —
+  comprehensive docs across stacks. MIT.
+- `rafaelkamimura/claude-tools` `api-documenter` agent — OpenAPI/SDK docs;
+  folded in as the API-doc **mode**, not a separate skill. MIT.
+
+## Local design decisions
+
+- **Consolidated** three mined items (a command + two agents) into one skill
+  — they are facets of one job, authoring docs (Rule of Three).
+- **Serves `documentation.md`** (the bar + form stance) rather than restating
+  policy — the skill is the *how*, the rule is the *what/why* (DRY).
+- **Derive-from-source, not from memory** — read the real signatures/schemas
+  so docs are accurate; for stacks that generate docs (FastAPI auto-OpenAPI)
+  point at the generated artifact + `fastapi-patterns` (layering principle).
+- **Boundaries drawn** — ADRs go to the `adr` skill; session/handoff/standup
+  notes and spec→plan are explicitly *not* this skill (different concerns).
+- Positioned as the Tier-1 build that **opens the `documentation` category**.


### PR DESCRIPTION
## Summary
- Opens a **documentation** top-level category. Adds an always-on
  `rules/documentation.md` (the doc **bar** + the "right form per audience"
  **stance**), modeled on `testing.md`, as the canonical home for doc policy
  previously scattered across `code-style.md` (mechanics), `markdownlint.md`
  (linter), and `qa.md` dim 13 (pipeline gate). `qa.md` dim 13 now **points
  to** it instead of restating the audience list — qa wired last, per the
  umbrella rule.
- Builds the Tier-1 **`write-documentation`** skill (the authoring *how*),
  consolidating three mined items — `write-documentation` +
  `documentation-architect` + `api-documenter` (folded as the API-doc mode;
  FastAPI auto-OpenAPI layered to `fastapi-patterns`).
- **Held out as adjacent** (not product docs, "don't force the fold"):
  `handoff`/`standup`/`dev-docs-update` (session continuity) and
  `dev-docs`/`read-specs`/`feature-specification` (spec→plan) — a future
  workflow/planning category.
- Updates the mining census, the `claude-tools` matrix, and `SETUP-AUDIT`
  (category opened + decisions-log entry).

## Test plan
- [ ] `pre-commit run markdownlint` passes on all changed files (verified locally)
- [ ] New prose wraps at 78 cols (verified on added lines)
- [ ] CI green (markdownlint, bats, perl, python, CodeFactor, snyk)