### PR TITLE
feat(claude/troubleshooting): open the troubleshooting category

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -205,8 +205,9 @@ decisions are also summarized in the *Decisions log*.
 ### Skill ideas & future categories (not from mining)
 
 - [ ] **`resolve-issue` skill** — orchestrate `gh` issue resolution: fetch
-  issue → **agent** investigates it against the codebase (root cause, "simple
-  or not", proposed fix or a question) → decide → fix → open PR with
+  issue → **agent** investigates it against the codebase via the
+  `debug-assistant` skill (root cause, "simple or not", proposed fix or a
+  question) → decide → fix → open PR with
   `Closes #X` → merge. The investigation is an agent; **PR-open and merge stay
   gated** per `gh.md` ("no PR create/merge without explicit approval") unless a
   deliberately opted-in autonomous variant with guardrails (trivial-only, after
@@ -219,12 +220,30 @@ decisions are also summarized in the *Decisions log*.
   - [x] **`documentation`** — **opened** 2026-06-11: `rules/documentation.md`
     (the doc bar + form stance) + the `write-documentation` skill. Doc tooling
     (`markdownlint.md`) and the `adr` skill compose in. See *Decisions log*.
-  - [ ] **`troubleshooting`** — home for a `debug-assistant` skill (the
-    remaining Tier-1 debugging item; distinct from qa — assessing quality vs
-    diagnosing a failure).
+  - [x] **`troubleshooting`** — **opened** 2026-06-11: a *thin* always-on
+    `rules/troubleshooting.md` (the debugging bar) + the `debug-assistant`
+    skill (the procedure). Not a qa dimension — a peer category. See
+    *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-11 — **Opened the `troubleshooting` category (thin always-on).**
+  Added a **deliberately thin** always-on `rules/troubleshooting.md` carrying
+  only the debugging *bar* (reproduce-first, root-cause-not-symptom,
+  regression-test-per-fix) plus a pointer — kept always-on, unlike a
+  path-scoped rule, because a failure can surface on **any** turn (a bug
+  report, a red test, surprising behaviour mid-build), so the guardrail must
+  be present whenever it's needed; kept thin (the depth is in the skill) to
+  respect the always-on-tier anti-bloat guardrail. Built the Tier-1
+  **`debug-assistant`** skill (the scientific-method session: reproduce →
+  capture evidence → isolate by bisection → one hypothesis at a time → fix the
+  root cause → regression-test → verify with `qa-check`). **Not wired into
+  `qa.md`** — troubleshooting is the diagnostic activity triggered *when* a
+  check or behaviour fails, a peer category, not a qa gate dimension. The
+  **ops facet** (`devops-troubleshooter`) stays build-on-first-use (ADR-0003);
+  the planned `resolve-issue` skill will compose `debug-assistant`. This
+  **completes the Tier-1 cluster** (only `deps-update` remains). Idea-level
+  adaptation (ADR-0002). Landed via dotfiles PR.
 - 2026-06-11 — **Opened the `documentation` category.** Added an always-on
   `rules/documentation.md` (the doc **bar** + the "right form per audience"
   **stance**), modeled on `testing.md`, as the canonical home for what had

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -111,10 +111,11 @@ stack-flavored ones per the layering principle. Grouped by leverage:
 skill; `plan-reviewer` → the **`plan-review`** skill;
 `write-documentation`/`documentation-architect` → the
 **`write-documentation`** skill, which **opens the `documentation`
-category** (the `rules/documentation.md` rule plus the skill).
-**Remaining:** `debug-assistant` (→ a *troubleshooting* category),
-`deps-update` — see the *Skill ideas & future categories* in
-`SETUP-AUDIT.md`.
+category** (the `rules/documentation.md` rule plus the skill);
+`debug-assistant` → the **`debug-assistant`** skill, which **opens the
+`troubleshooting` category** (a thin always-on `rules/troubleshooting.md`
+plus the skill). **Remaining:** `deps-update` — see the *Skill ideas &
+future categories* in `SETUP-AUDIT.md`.
 
 **Tier 2 — useful generic, some overlap.** **DONE** (built as qa-dimension
 review skills, the arch-review family): `perf-check`/`performance-engineer` →
@@ -178,6 +179,15 @@ list above.
   `feature-specification` (spec → plan) belong to a future *workflow*/planning
   category, not product docs — folding them in would force unrelated concerns
   together ("don't force it").
-- **`troubleshooting`** — **not yet opened**; home for a `debug-assistant`
-  skill (the remaining Tier-1 item; distinct from qa — diagnosing a failure
-  vs assessing quality).
+- **`troubleshooting`** — **opened.** A **thin** always-on
+  `rules/troubleshooting.md` (the debugging bar — reproduce-first,
+  root-cause, regression-test — present every turn because a failure can
+  surface on any turn) + the **`debug-assistant`** skill (the full
+  scientific-method session, where the depth lives). Deliberately lighter
+  than `testing.md`/`documentation.md`: the bar is always-on, the procedure
+  is on-demand. **Not a qa dimension** — troubleshooting is the *diagnostic
+  activity triggered when any check or behaviour fails*, a peer category, not
+  a qa gate (so `qa.md` is unchanged). The **ops facet**
+  (`devops-troubleshooter` — incident response on running infra) is held as
+  build-on-first-use (ADR-0003). The planned `resolve-issue` skill composes
+  `debug-assistant` as its investigation step.

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -9,7 +9,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 |------|-------|-------|--------|
 | brainstorm | generic | CANDIDATE | deep requirements ideation; pairs with built-in Plan |
 | bslist | generic | CANDIDATE | list/resume past brainstorm sessions |
-| debug-assistant | generic | CANDIDATE | structured debugging harness (stack-trace → repro → fix) |
+| debug-assistant | generic | ADOPTED | built as the **`debug-assistant`** skill — opens the troubleshooting category |
 | deps-update | generic | CANDIDATE | dependency auditor w/ compat testing + changelog |
 | dev-docs | generic | CANDIDATE | spec → implementation plan + checklist |
 | dev-docs-update | generic | CANDIDATE | capture session state before context-limit reset |
@@ -51,7 +51,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | test-automator | generic | SKIP | test strategy/pyramid = `testing.md` bar + `plan-review` + `test-review` |
 | frontend-qa-tester | generic | SKIP-until browser-UI/e2e | the tool for qa.md's End-to-end dimension (no tool yet); Playwright/browser-specific — build on first browser-UI/e2e need (watch list) |
 | ui-ux-designer | generic | CANDIDATE | design methodology (vs frontend-design's implementation) |
-| devops-troubleshooter | generic | CANDIDATE | incident response / log analysis |
+| devops-troubleshooter | generic | CANDIDATE | the **ops facet** of troubleshooting (incident response / log analysis on running infra) — distinct from `debug-assistant` (code-level); build on first ops-incident need (ADR-0003) |
 | web-research-specialist | generic | CANDIDATE | overlaps `/deep-research`; lower priority |
 | ai-engineer | generic | CANDIDATE | LLM/RAG/agent patterns — relevant if building AI features |
 | deployment-engineer, cloud-architect, data-engineer, ml-engineer | stack | CANDIDATE | infra/data/ML — build when first used (ADR-0003) |

--- a/config/claude/rules/troubleshooting.md
+++ b/config/claude/rules/troubleshooting.md
@@ -1,0 +1,48 @@
+---
+# No paths — a failure can surface on ANY turn (a bug report, a failing
+# test, unexpected behaviour mid-development), so the debugging discipline
+# must be present whenever it's needed, not gated to a file type. Kept
+# deliberately THIN: the bar lives here; the full procedure is the
+# debug-assistant skill.
+---
+
+# Troubleshooting Rules
+
+**Version:** v1.0.0
+
+The discipline for diagnosing a failure — present on every turn because a bug
+can surface at any moment (resolving a bug report, a red test, surprising
+behaviour while building). This rule is the **thin guardrail**; the full
+step-by-step procedure is the **`debug-assistant`** skill.
+
+## The bar
+
+When something is broken, the fix is not done until:
+
+- **Reproduced first.** A bug you can't reproduce isn't fixed, it's hidden.
+  Get a reliable (ideally minimal) repro before changing code.
+- **Root cause, not symptom.** Fix *why* it broke, not the surface that
+  showed it — and check whether the same cause hides elsewhere.
+- **Regression-tested.** Land a test that **fails before the fix and passes
+  after** (`testing.md`). That test is the proof, and the guard against
+  recurrence.
+
+And the method that gets you there: **read the actual error/stack/logs**
+(don't guess), **change one thing at a time**, and reverting a failed
+hypothesis is progress, not waste.
+
+## Where the depth lives
+
+- **`debug-assistant`** skill — the full session: reproduce → capture the
+  evidence → isolate (bisect) → hypothesize-and-test → fix the root cause →
+  regression-test → verify with `qa-check`.
+- **`testing.md`** — the regression-test-per-bug bar (the fix's safety net).
+- repo `.claude/` — how to run / reproduce / attach a debugger locally.
+
+## Agent Behavior
+
+- Reproduce before fixing; fix the root cause; land a regression test that
+  failed before the fix. State it plainly if a bug can't be reproduced rather
+  than guessing at a fix.
+- Reach for the **`debug-assistant`** skill for a structured session, then
+  re-run **`qa-check`** to confirm the fix broke nothing else.

--- a/config/claude/skills/debug-assistant/SKILL.md
+++ b/config/claude/skills/debug-assistant/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: debug-assistant
+description: Run a structured debugging session on a specific failure — reproduce it, capture the real evidence (stack/logs), isolate the cause by bisection, test one hypothesis at a time, fix the root cause, and lock it with a regression test. Use for "debug this", "why is this failing", "this test is flaky", "track down this bug", "this error", "it crashes when", "find the root cause", or resolving a bug report. Subject-agnostic scientific method. Serves troubleshooting.md (the bar); composes testing.md (regression test) and qa-check (verify). troubleshooting.
+---
+
+# debug-assistant
+
+**Version:** v1.0.0
+
+The procedure that turns "it's broken" into a root-cause fix locked by a
+regression test — by **scientific method**, not by guessing-and-patching. The
+discipline it serves (reproduce-first, root-cause, regression-test) lives in
+`troubleshooting.md`; this skill is the *how*.
+
+## When to reach for it
+
+A specific failure to diagnose: a failing or flaky test, a crash or
+exception, a bug report, or surprising behaviour you need to track to its
+cause. This is the **investigation** step inside a bug-report resolution (the
+planned `resolve-issue` skill composes it).
+
+## Type / composition
+
+A **skill** (a diagnostic procedure you invoke and watch). It serves
+`troubleshooting.md` (the bar) and composes `testing.md` (the regression-test
+bar) and `qa-check` (post-fix verification). For a large or unfamiliar
+codebase, fan the investigation read-out to a **read-only agent** (isolation,
+generic-in-subject) so tracing doesn't consume the main context. If the bug
+exposes a structural problem, hand off to `arch-review` / `modernize`.
+
+## Boundaries — what this is *not*
+
+- **Not whole-codebase health.** "Is this codebase healthy / where's the
+  rot" → `arch-review`.
+- **Not "it's slow."** A performance problem → `perf-review` (measure-first).
+  This skill is for **incorrect behaviour**.
+- **Not ops/incident response** on running infrastructure (log fleets, deploy
+  rollbacks) → a future `devops-troubleshooter`, built on first need.
+
+## Procedure (scientific method)
+
+1. **Reproduce.** Get a reliable repro — the **smallest** input/steps that
+   trigger it. Can't reproduce? Gather signal first (exact version, env,
+   inputs, full logs); **do not fix what you can't reproduce** — say so and
+   ask for what's missing.
+2. **Capture the evidence.** Read the **actual** error, stack trace, and logs
+   — never infer the failure from the description. Pin the exact failure point
+   and the expected-vs-actual.
+3. **Isolate.** Narrow to the smallest failing surface by **bisection** —
+   `git bisect` across history, or binary-search the input / comment-out
+   regions — not scattershot edits. Separate the **trigger** from the **root
+   cause**.
+4. **Hypothesize, one at a time.** State a **falsifiable** hypothesis about
+   the cause, test it with a **single** change, and revert it if wrong before
+   trying the next. One variable per step.
+5. **Fix the root cause.** Address *why* it broke, not the symptom, and grep
+   for the **same cause elsewhere** (sibling bugs from one root).
+6. **Regression-test.** Add a test that **fails before the fix, passes
+   after** (`testing.md`). That test is the proof the cause is understood.
+7. **Verify + record.** Re-run **`qa-check`** to confirm nothing else broke;
+   note the root cause and fix in the commit/changelog, and an `adr` if it
+   changed a decision.
+
+## Output
+
+The root-cause fix plus its regression test, and a short **root-cause note**:
+what failed, why (the actual cause, not the symptom), how it's fixed, and what
+the regression test pins. If the cause can't be found or reproduced, report
+the dead end and the evidence gathered rather than shipping a guess.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools` `debug-assistant`
+(structured stack-trace → repro → fix harness). No upstream code reused. See
+`SOURCE.md`.

--- a/config/claude/skills/debug-assistant/SOURCE.md
+++ b/config/claude/skills/debug-assistant/SOURCE.md
@@ -1,0 +1,27 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+scientific-method procedure, the troubleshooting.md composition).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `debug-assistant` — structured debugging
+  harness (stack-trace → reproduce → fix). MIT.
+
+## Local design decisions
+
+- **Serves `troubleshooting.md`** (the thin always-on bar) rather than
+  restating policy — the skill is the *how*, the rule is the *what/why* (DRY).
+- **Scientific method, reproduce-first** — no fix without a reliable repro;
+  isolate by bisection; one falsifiable hypothesis at a time; root cause over
+  symptom, with a grep for sibling occurrences.
+- **Locks the fix with a regression test** (`testing.md`) and **verifies with
+  `qa-check`** — the fix isn't done until the bar holds.
+- **Boundaries drawn** — whole-codebase health → `arch-review`; "it's slow" →
+  `perf-review`; ops/incident response → a future `devops-troubleshooter`.
+- **Composed by the planned `resolve-issue` skill** as its investigation step
+  (the `gh` issue-resolution flow).
+- The Tier-1 build that **opens the `troubleshooting` category**.


### PR DESCRIPTION
## Summary
- Opens a **troubleshooting** top-level category. Adds a **deliberately thin**
  always-on `rules/troubleshooting.md` carrying only the debugging **bar**
  (reproduce-first, root-cause-not-symptom, regression-test-per-fix) + a
  pointer. Always-on (not path-scoped) because a failure can surface on **any**
  turn — a bug report, a red test, surprising behaviour mid-build — so the
  guardrail must be present whenever needed; kept thin (depth in the skill) to
  respect the always-on-tier anti-bloat guardrail.
- Builds the Tier-1 **`debug-assistant`** skill: the scientific-method session
  (reproduce → capture evidence → isolate by bisection → one hypothesis at a
  time → fix the root cause → regression-test → verify with `qa-check`).
  Composes `testing.md` + `qa-check`; the planned `resolve-issue` skill will
  compose it as its investigation step.
- **Not wired into `qa.md`** — troubleshooting is the diagnostic activity
  triggered *when* a check/behaviour fails, a peer category, not a qa gate. The
  ops facet (`devops-troubleshooter`) stays build-on-first-use (ADR-0003).
- Completes the **Tier-1 cluster** (only `deps-update` remains). Updates the
  census, the `claude-tools` matrix, and `SETUP-AUDIT`.

## Test plan
- [ ] `pre-commit run markdownlint` passes on changed files (verified locally)
- [ ] New prose wraps at 78 cols (verified on added lines)
- [ ] CI green (markdownlint, bats, perl, python, CodeFactor, snyk)