### PR TITLE
feat(claude/qa): add deps-update skill (completes Tier-1)

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -227,6 +227,22 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-11 — **Built `deps-update`; Tier-1 cluster done.** The proactive,
+  human-driven dependency-currency sweep — inventory outdated → triage by
+  risk/security-urgency → read changelogs → apply in safe batches →
+  compat-gate each batch with `qa-check` (red batch → `debug-assistant` to
+  isolate the offending bump). Folded into the **qa /
+  dependency-maintenance orbit** — **no new category, no new rule** — and
+  wired into `qa.md`'s Security/SCA dimension. Deliberately scoped to the gap
+  the existing tools leave:
+  `dependabot.md` (automated, scheduled, one-PR-per-bump bot) and
+  `security-scan` (vuln/CVE-driven) are *reactive*; `deps-update` is the
+  *considered, on-demand* counterpart (majors one at a time, changelog-read,
+  no blindly widened ranges). Generic over ecosystem (commands from
+  `poetry.md`, …). This was the **last Tier-1 mined item** — the cluster
+  (`arch-review`, `modernize`, `plan-review`, `write-documentation`,
+  `debug-assistant`, `deps-update`) is now fully adopted. Idea-level
+  (ADR-0002). Landed via dotfiles PR.
 - 2026-06-11 — **Opened the `troubleshooting` category (thin always-on).**
   Added a **deliberately thin** always-on `rules/troubleshooting.md` carrying
   only the debugging *bar* (reproduce-first, root-cause-not-symptom,

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -114,8 +114,9 @@ skill; `plan-reviewer` → the **`plan-review`** skill;
 category** (the `rules/documentation.md` rule plus the skill);
 `debug-assistant` → the **`debug-assistant`** skill, which **opens the
 `troubleshooting` category** (a thin always-on `rules/troubleshooting.md`
-plus the skill). **Remaining:** `deps-update` — see the *Skill ideas &
-future categories* in `SETUP-AUDIT.md`.
+plus the skill); `deps-update` → the **`deps-update`** skill (qa /
+dependency-maintenance orbit — no new category). **Tier-1 is fully
+adopted** — nothing remaining.
 
 **Tier 2 — useful generic, some overlap.** **DONE** (built as qa-dimension
 review skills, the arch-review family): `perf-check`/`performance-engineer` →
@@ -159,8 +160,9 @@ list above.
   code-refactor-master/code-architecture-reviewer, ruff-patterns,
   refactor-planner) is SKIP — covered. A skill adds nothing over the rule
   (and style is personal preference — a rule's job, not a skill's).
-- **`qa`** — substantially built (the `*-review` family + python depth); the
-  **umbrella, worked last**. Open: nothing required.
+- **`qa`** — substantially built (the `*-review` family + python depth + the
+  **`deps-update`** dependency-maintenance skill, wired into the Security/SCA
+  dimension); the **umbrella, worked last**. Open: nothing required.
 - **`testing`** — covered (`testing.md` + `bats-setup` + `test-review` +
   `pytest-patterns` + `qa-check` runs/coverage). Two deferred: **e2e** (qa dim
   8 has no tool — `frontend-qa-tester` is `SKIP-until` a browser-UI/Playwright

--- a/config/claude/audit/mining/claude-tools.md
+++ b/config/claude/audit/mining/claude-tools.md
@@ -10,7 +10,7 @@ the cross-repo CANDIDATE backlog). MIT. Round 2026-06-11. 93 items.
 | brainstorm | generic | CANDIDATE | deep requirements ideation; pairs with built-in Plan |
 | bslist | generic | CANDIDATE | list/resume past brainstorm sessions |
 | debug-assistant | generic | ADOPTED | built as the **`debug-assistant`** skill — opens the troubleshooting category |
-| deps-update | generic | CANDIDATE | dependency auditor w/ compat testing + changelog |
+| deps-update | generic | ADOPTED | built as the **`deps-update`** skill (qa / dependency-maintenance orbit — no new category) |
 | dev-docs | generic | CANDIDATE | spec → implementation plan + checklist |
 | dev-docs-update | generic | CANDIDATE | capture session state before context-limit reset |
 | env-sync | generic | CANDIDATE | .env sync/validation/secret rotation (security-sensitive) |

--- a/config/claude/rules/qa.md
+++ b/config/claude/rules/qa.md
@@ -40,7 +40,9 @@ skip silently.
 5. **Security** — the layered set: **SAST** (static), **SCA** (dependencies/
    supply-chain — vulns *and* licenses), **DAST** (runtime scan of the
    running app, for services/web apps), IaC/image scanning, and secrets.
-   Delegate to the **security-scan** skill.
+   Delegate to the **security-scan** skill. Keeping dependencies *current* —
+   proactive, considered upgrades beyond vuln-patching — is the
+   **deps-update** skill (which compat-gates each batch with `qa-check`).
 6. **Tests** — unit/integration; cover success **and** failure paths; track
    coverage. Test-suite structure/conventions live in `testing.md`; the
    concrete layout and policy in the repo's `TESTS.md`.

--- a/config/claude/skills/deps-update/SKILL.md
+++ b/config/claude/skills/deps-update/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: deps-update
+description: Run a deliberate dependency-update sweep — inventory what's outdated, triage by risk and security-urgency, read the changelogs, apply updates in safe batches, and compat-gate each batch with qa-check. The proactive, considered counterpart to Dependabot's automated PRs. Use for "update the dependencies", "are my deps outdated", "upgrade the packages", "bump dependencies", "get the deps current", "update the lockfile". Subject-/ecosystem-agnostic; takes concrete commands from the ecosystem's rule. Composes security-scan (vuln urgency) and qa-check (compat gate). qa / dependency maintenance.
+---
+
+# deps-update
+
+**Version:** v1.0.0
+
+The **on-demand, human-driven** dependency-currency sweep: audit what's
+behind, decide what to move, read what changed, and prove compatibility with
+the test/type/build pipeline — in safe batches. It keeps dependencies from
+drifting into a forced big-bang upgrade.
+
+## When to reach for it
+
+You want to **proactively** get dependencies current — a deliberate sweep, a
+batch of bumps, or a careful major-version upgrade — rather than react to a
+stream of bot PRs. Also the home for "are we behind, and what would it take to
+catch up?"
+
+## Type / composition
+
+A **skill** (a maintenance procedure you invoke and watch), in the qa /
+dependency-maintenance orbit — **no new category, no rule**. It composes
+`security-scan` (which updates are *security*-urgent — don't re-derive vuln
+data), `qa-check` (the compatibility gate), and `debug-assistant` (when a
+batch goes red, to find which bump broke it). Concrete per-ecosystem commands
+come from that ecosystem's rule (`poetry.md`, …) — generic procedure,
+specific tooling (the layering principle).
+
+## Boundaries — what this is *not*
+
+- **Not vuln scanning.** Finding/gating *vulnerable* deps (CVEs, SCA) →
+  `security-scan`. This skill consults it for urgency but is about
+  **currency**, not vulns.
+- **Not Dependabot config.** The automated, scheduled, one-PR-per-bump bot →
+  `dependabot.md`. This is its **proactive, considered counterpart** — they
+  complement each other; a repo can use both.
+
+## Procedure
+
+1. **Inventory the outdated.** For each ecosystem in the repo, list the
+   outdated **direct** dependencies with current → latest and the jump type
+   (patch / minor / major), using that ecosystem's own command (e.g. `poetry
+   show --outdated`, `npm outdated`, `cargo outdated`). Get the exact command
+   from the ecosystem rule.
+2. **Triage by risk × urgency.** **Security-urgent first** — consult
+   `security-scan` for which bumps close a known vuln. Then split the rest:
+   patch/minor (low-risk) vs **major** (potentially breaking) — pin each major
+   for individual handling.
+3. **Read the changelog.** For every non-patch bump, read the release
+   notes/changelog and flag breaking changes, deprecations, and required
+   migrations. Never bump a major blind.
+4. **Apply in safe batches.** Patch + minor together; **each major alone**.
+   Update the lockfile, and keep direct-dependency version constraints
+   intentional — don't silently widen ranges.
+5. **Compat-gate with `qa-check`.** Run the full pipeline (tests, type-check,
+   build) **after each batch** — green is the compatibility proof. A red batch
+   → use `debug-assistant` to isolate which bump broke it, then fix or hold
+   that one.
+6. **Record.** Add a changelog entry; note any code changed to accommodate a
+   major; if a bump changes how a library is *used*, update that library's
+   `rules/<name>.md` (the governing-docs layer, `documentation.md`). **Surface
+   what was held back** (and why — a transitive constraint, a costly
+   migration) rather than silently skipping it.
+
+## Output
+
+A sweep summary: **updated** (by batch), **held** (with the reason),
+**code changed** for any major, and the `qa-check` result per batch. Call out
+anything needing a human decision — a major whose migration is non-trivial —
+rather than forcing or skipping it.
+
+## Provenance
+
+Adapted (idea-level) from the mining census — `claude-tools` `deps-update`
+(dependency auditor with compatibility testing + changelog review). No
+upstream code reused. See `SOURCE.md`.

--- a/config/claude/skills/deps-update/SOURCE.md
+++ b/config/claude/skills/deps-update/SOURCE.md
@@ -1,0 +1,29 @@
+# Source / provenance
+
+**Adapted, idea-level — no upstream code reused.** Per ADR-0002 there is no
+tracked per-artifact source; the implementation is our own (house style, the
+batch-and-compat-gate procedure, the security-scan/qa-check composition).
+
+## Idea source (NOT tracked)
+
+Recorded in `../../audit/mining/claude-tools.md`:
+
+- `rafaelkamimura/claude-tools` `deps-update` — dependency auditor with
+  compatibility testing + changelog review. MIT.
+
+## Local design decisions
+
+- **Complements Dependabot, doesn't replace it** — `dependabot.md` is the
+  automated, scheduled, one-PR-per-bump bot; this skill is the proactive,
+  considered, human-driven sweep. A repo can use both.
+- **Currency, not vulns** — defers vuln urgency to `security-scan` (don't
+  re-derive SCA data); this skill owns "are we behind, and what breaks if we
+  catch up?"
+- **Compat is proven, not assumed** — every batch is gated by `qa-check`; a
+  red batch routes to `debug-assistant` to isolate the offending bump.
+- **Majors handled one at a time, changelog-read** — no blind major bumps; no
+  silently widened version ranges.
+- **Generic over ecosystem** — concrete `outdated`/upgrade commands come from
+  the ecosystem rule (`poetry.md`, …), per the layering principle.
+- **Folds into the qa / dependency-maintenance orbit** — no new category, no
+  new always-on rule; the last Tier-1 mined item.


### PR DESCRIPTION
## Summary
- Adds the **`deps-update`** skill: the proactive, human-driven dependency-
  currency sweep — inventory outdated → triage by risk/security-urgency → read
  changelogs → apply in safe batches → compat-gate each batch with `qa-check`
  (a red batch routes to `debug-assistant` to isolate the offending bump).
- **Folds into the qa / dependency-maintenance orbit** — no new category, no
  new rule — and wires into `qa.md`'s Security/SCA dimension.
- **Scoped to the genuine gap:** `dependabot.md` (automated, scheduled bot) and
  `security-scan` (vuln/CVE-driven) are *reactive*; `deps-update` is the
  *considered, on-demand* counterpart (majors one at a time, changelog-read, no
  blindly widened ranges). Generic over ecosystem (commands from `poetry.md`, …).
- **Last Tier-1 mined item** — the cluster (`arch-review`, `modernize`,
  `plan-review`, `write-documentation`, `debug-assistant`, `deps-update`) is now
  fully adopted. Updates the census, `claude-tools` matrix, and `SETUP-AUDIT`.

## Test plan
- [ ] `pre-commit run markdownlint` passes on changed files (verified locally)
- [ ] New prose wraps at 78 cols (verified character-accurate on added lines)
- [ ] CI green (markdownlint, bats, perl, python, CodeFactor, snyk)