### PR TITLE
Add Spotify Web API rule + spotify-audit skill; Context7 currency check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,28 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
 
+## 🎵 Build a `spotify-patterns` skill (LOW PRIORITY)
+
+Companion to `rules/spotify.md` + the `spotify-audit` skill (added 2026-06-12).
+The audit/rule cover *policy and alignment*; this would carry the concrete
+*recipes* — mirroring how `fastapi-patterns` / `sqlalchemy-patterns` back their
+rules. Mined as a CANDIDATE from `fabioc-aloha/spotify-skill` (see
+`config/claude/audit/mining/spotify-skill.md`). Lower priority, but genuinely
+useful — having these recipes earlier would have pre-empted the relinking and
+token-refresh bugs that motivated the Spotify category.
+
+- [ ] **Token refresh + relinking recipes** — proactive refresh-before-expiry,
+  and the `linked_from`-for-Library-ops pattern (the two bugs we hit).
+- [ ] **Pagination + set-based dedup** — always loop list reads (per-endpoint
+  page size); collect ids into a set before populating a playlist.
+- [ ] **Rate-limit handling** — a 429 / `Retry-After` + exponential-backoff
+  wrapper for the HTTP layer.
+- [ ] **Playlist-creation strategies** — by-artist / theme / song-list (drop
+  the recommendation-seeded one — it depends on a deprecated endpoint).
+- [ ] **Cover-art generation** — SVG→PNG with a11y contrast + `ugc-image-upload`.
+- [ ] Wire it into `rules/spotify.md` ("for recipes, invoke spotify-patterns")
+  and record in `SETUP-AUDIT.md`.
+
 ## 🔗 docker_wrapper Symlink Automation (MEDIUM PRIORITY)
 
 `bin/docker_wrapper` is a multi-call dispatcher: each tool is a `bin/<tool>`

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -95,6 +95,7 @@ again. The two are distinct by design:
 | `fastapi/fastapi` (official `.agents/skills`) | FastAPI best-practice concepts (Annotated, return-type serialization, async-vs-sync); maintained with new versions, so re-mine on FastAPI upgrades | MIT | 2026-06-11 | No (concepts only) |
 | `rafaelkamimura/claude-tools` | Layered-architecture ideas; candidate commands (`adr`, `tech-debt`, `debug-assistant`) and agents (`database-optimizer`, `api-documenter`) | MIT | 2026-06-11 | No (ideas only) |
 | `pydantic/skills` (official) | Pydantic AI **agent-framework** + Logfire skills — relevant only if we adopt LLM agents or Logfire observability; not used today | MIT (check) | 2026-06-11 | No |
+| `fabioc-aloha/spotify-skill` | Spotify Web API skill — endpoint/scope/error inventory, auto-refresh pattern, `ugc-image-upload`→401, cover-art + playlist strategies; refs are stale (pre-2024-11-27, no PKCE) so official docs win | Apache-2.0 | 2026-06-12 | Ideas → `spotify-audit` + `rules/spotify.md` (SOURCE.md) |
 
 The **full disposition census** of every item in these repos (every agent /
 command / hook / skill considered, ADOPT/CANDIDATE/SKIP + reason) is in
@@ -227,6 +228,29 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-12 — **Spotify category: `rules/spotify.md` + `spotify-audit`
+  skill (audit run from pigify).** pigify (the first Spotify repo) surfaced a
+  cluster of hard-won, non-obvious Spotify Web API quirks — track relinking
+  (`linked_from` for Library ops), the 1-hour token + proactive refresh, the
+  `127.0.0.1`-only OAuth redirect, and the Web-Playback-SDK / EME / Permissions-
+  Policy requirements — each of which had already caused a bug. Built a global,
+  detection-activated **`rules/spotify.md`** (the policy/reference: auth +
+  PKCE, tokens, scopes, current-vs-deprecated endpoints incl. the 2024-11-27
+  deprecations and the legacy `/me/tracks` save/remove, 429/Retry-After,
+  relinking, SDK/EME, compliance) and a **`spotify-audit`** skill (`/spotify-
+  audit`) that checks a codebase against it and emits a severity-grouped
+  report. Repo-foreign-API guidance → **global, front-loaded** (ADR-0003).
+  Ideas adapted from `fabioc-aloha/spotify-skill` (Apache-2.0, ideas-only —
+  SOURCE.md); policy grounded in Spotify's official docs (its references are
+  stale). `spotify-patterns` (cover-art, playlist strategies, pagination/dedup)
+  deferred to `TODO.md`. Landed via dotfiles PR.
+- 2026-06-12 — **claude-audit: use Context7 (if available) to verify
+  currency.** Added a step to the **claude-audit** skill — when auditing a rule
+  or adopting a pattern, query **Context7** for the tool/library/API's current
+  docs to catch drift without cloning (it caught Spotify's `/me/tracks`
+  deprecation that third-party guides missed). Strictly **second-class**
+  (`mcp.md`): a convenience for the audit *process*, never a dependency of the
+  resulting config; the audit works without it.
 - 2026-06-11 — **Built `deps-update`; Tier-1 cluster done.** The proactive,
   human-driven dependency-currency sweep — inventory outdated → triage by
   risk/security-urgency → read changelogs → apply in safe batches →

--- a/config/claude/audit/mining/spotify-skill.md
+++ b/config/claude/audit/mining/spotify-skill.md
@@ -1,0 +1,29 @@
+# Mining matrix — `fabioc-aloha/spotify-skill`
+
+Part of the mining census (`../mining-census.md` has the disposition key and
+the cross-repo CANDIDATE backlog). Apache-2.0. Round 2026-06-12. v0.9.0.
+Third-party (13★, 0 open issues, 56 commits). Mined because pigify is the
+first Spotify repo and the *Idea sources* registry had no Spotify coverage.
+
+We **adapt ideas only, never vendor code**. Authoritative policy comes from
+Spotify's official docs — the repo's `references/` are stale (predate the
+2024-11-27 deprecations; omit PKCE / the implicit-grant ban).
+
+| item | type | disp. | reason |
+|------|------|-------|--------|
+| `spotify-api/SKILL.md` | skill | ADOPT-idea | endpoint/scope inventory + patterns → `rules/spotify.md`, `spotify-audit` |
+| `references/api_reference.md` | reference | ADOPT-idea | endpoint/error/rate-limit tables — **stale**, cross-check vs official |
+| `references/authentication_guide.md` | reference | ADOPT-idea | token lifecycle; **gap:** no PKCE / implicit warning (we add) |
+| `references/COVER_ART_LLM_GUIDE.md` | reference | CANDIDATE | cover-art (SVG→PNG, a11y contrast) → future `spotify-patterns` |
+| `spotify-api/scripts/*.py` | code | SKIP code / ADOPT-idea | 40+ methods, 5 playlist strategies, auto-refresh pattern (ideas only) |
+| `get_refresh_token.py` | script | ADOPT-idea | Auth-Code flow on `127.0.0.1`, manual refresh-token capture (concept) |
+| `agent_skills_spec.md` | spec | SKIP | Agent Skills spec — informs skill *shape*, not Spotify policy |
+| `tools/{init,validate,package}_skill.py` | tooling | SKIP | generic skill scaffolding, unrelated to Spotify |
+| `examples/`, `Guide/` | examples/docs | SKIP | generic skill-authoring tutorials |
+| housekeeping (`CHANGELOG`, `RELEASE_NOTES`, `*.backup`, `CustomGPT/`, …) | misc | SKIP | packaging artifacts |
+
+**Adopted →** `rules/spotify.md` + `spotify-audit` skill (this round).
+**CANDIDATE backlog →** `spotify-patterns` skill (cover-art generation,
+playlist-creation strategies, pagination/dedup, error-code mapping) — tracked
+in `TODO.md`; lower priority but genuinely useful (would have pre-empted the
+relinking / token-refresh bugs that motivated this round).

--- a/config/claude/rules/spotify.md
+++ b/config/claude/rules/spotify.md
@@ -1,0 +1,145 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+
+# Spotify Web API Rules
+
+**Version:** v1.0.0
+
+Conventions for integrating the **Spotify Web API** and **Web Playback SDK**.
+This rule is the policy/reference; to audit an existing codebase against it,
+run the **spotify-audit** skill. Concrete recipes (cover-art generation,
+playlist-building strategies, pagination/dedup helpers) are planned for a
+**spotify-patterns** skill (tracked in the dotfiles `TODO.md`).
+
+## Detection
+
+Active **only** when the codebase actually integrates Spotify — a `spotipy`
+(or other Spotify client) dependency, the Web Playback SDK
+(`@spotify/web-playback-sdk` or the `sdk.scdn.co` script), or direct calls to
+`api.spotify.com` / `accounts.spotify.com`. The path globs above are a coarse
+gate (any JS/TS/Python file); this section is the real one — the rule is
+dormant in a repo that does not touch Spotify.
+
+## Authentication
+
+- **User data → Authorization Code with PKCE.** A confidential server-side
+  backend may use plain Authorization Code; SPAs, native, and mobile clients
+  use PKCE (`response_type=code`, `code_challenge_method=S256`, a stored
+  `code_verifier`).
+- **Public catalogue only → Client Credentials** (no user context, and it
+  returns no refresh token).
+- **Never the Implicit Grant** (`response_type=token`) — deprecated; it leaks
+  the access token in the URL fragment. Migrate legacy implicit flows to PKCE.
+- **The client secret is server-side only** — never in client-side code or a
+  committed `.env`. Prefer file/secret-manager sourcing (`*_FILE`, Vault, a
+  cloud secrets manager) over plain environment variables in production.
+- **Redirect URIs must be HTTPS**, the sole exception being
+  `http://127.0.0.1` for local development. Do **not** use `http://localhost`
+  or wildcard URIs — Spotify rejects them.
+
+## Tokens
+
+- Access tokens expire after **3600s (one hour)**; the refresh token does not
+  expire unless the user revokes it. Client Credentials issues no refresh
+  token.
+- **Refresh proactively** — renew from the stored refresh token at/just
+  before expiry rather than waiting for the first 401, so a session survives
+  the one-hour boundary. Persist a rotated refresh token if the response
+  carries one (the Authorization Code flow usually does not rotate it).
+- Store tokens securely (a server-side session or an encrypted store), never
+  on the client.
+
+## Scopes
+
+- **Request only the scopes the features actually use** — never ask for broad
+  scopes preemptively; it weakens both consent and least-privilege.
+- Common scopes: `user-read-private`, `user-read-email`, `user-library-read`,
+  `user-library-modify`, `playlist-read-private`, `playlist-modify-private`,
+  `playlist-modify-public`, `user-read-playback-state`,
+  `user-modify-playback-state`, `streaming` (Web Playback SDK),
+  `user-top-read`, `user-read-recently-played`.
+- `ugc-image-upload` is **required** to upload a playlist cover image —
+  without it the upload returns 401.
+
+## Endpoints
+
+- **Prefer the current endpoint over its legacy sibling:**
+  `/playlists/{id}/items` over `/playlists/{id}/tracks`, and the unified
+  *Save/Remove Items to Library* endpoints over the deprecated per-type
+  `PUT`/`DELETE /me/tracks` (Save/Remove Tracks).
+- **Deprecated for new apps (announced 2024-11-27)** — do not build on these;
+  new apps receive 404 and there is **no official replacement**: **Audio
+  Features** (`/audio-features`), **Audio Analysis**, **Recommendations**
+  (`/recommendations`) and available-genre-seeds, **Related Artists**
+  (`/artists/{id}/related-artists`), 30-second preview URLs in multi-get
+  responses, and algorithmic / editorial-playlist access. Treat a *new*
+  dependency on these as a defect — flag it; do **not** auto-rewrite, since no
+  drop-in replacement exists.
+- **Batch and paginate.** Per-request id caps **vary by endpoint** (e.g.
+  `/tracks` and `/me/tracks*` cap at 20; some library endpoints at 50; a
+  playlist add/remove at 100) — check each endpoint's documented maximum
+  rather than assuming one number. Always paginate list reads (commonly
+  50/page); never assume a collection fits in a single page.
+
+## Rate limiting
+
+- On **HTTP 429**, read the **`Retry-After`** header (seconds) and wait that
+  long before retrying; then apply **exponential backoff** (1→2→4→8s). Never
+  retry immediately or in a tight loop.
+
+## Track relinking
+
+- Spotify serves the same recording under different track ids per market.
+  Pass a `market` parameter (an ISO-3166-1 alpha-2 code, or `from_token` for
+  the user's country) so reads return a playable track; a relinked response
+  carries `is_playable` and a **`linked_from`** object describing the
+  **original** track.
+- **Library and playlist write/membership operations MUST use the original id
+  from `linked_from`** — saving/removing in *Your Music* and the saved-tracks
+  membership check, and removing a track from a playlist. Using the relinked
+  top-level id "will likely return an error or unexpected result." This is a
+  *silent* correctness bug: a track the user has saved reads back as not
+  saved.
+
+## Web Playback SDK (in-browser playback)
+
+- Requires **Spotify Premium**, the **`streaming`** scope, and a **secure
+  context (HTTPS)**; it relies on EME/Widevine DRM.
+- The SDK runs in a **cross-origin iframe** (`sdk.scdn.co`); the embedding
+  page must **delegate `encrypted-media` and `autoplay`** to it via
+  `Permissions-Policy` (the default `self` is not enough), or `connect()`
+  fails.
+- Audio needs a **user gesture**; after a device transfer some browsers (iOS)
+  will not autoplay. Commercial use requires Spotify's written approval.
+
+## Compliance (Developer Terms)
+
+- **Attribute** Spotify content in the UI.
+- **Do not cache** Spotify content beyond immediate use.
+- **Do not train** machine-learning / AI models on Spotify data.
+
+## Verifying against current docs
+
+Spotify's surface shifts (the 2024-11-27 deprecations; the move to unified
+library endpoints), and third-party guides lag it. Treat **Spotify's official
+documentation as authoritative**. Context7's `/websites/developer_spotify_web-api`
+is a convenient live source when available — but it is an optional aid, not a
+dependency: this rule and the **spotify-audit** skill stand on their own
+without it.
+
+## Agent Behavior
+
+- When adding or changing Spotify integration code, follow the auth, token,
+  scope, endpoint, and relinking rules above — in particular proactive token
+  refresh and `linked_from`-for-library-operations.
+- To audit an existing Spotify codebase for alignment, run the
+  **spotify-audit** skill.
+- Treat Spotify's official docs as authoritative; older tutorials and
+  third-party guides predate the 2024-11-27 deprecations and the PKCE
+  guidance.

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -83,6 +83,18 @@ log) — the canonical methodology and living record. In short:
    findings. Convert "evaluate later" items into `TODO.md` follow-ups,
    surfaced by the repo that needs them.
 
+**Verify currency with live docs (Context7, if available).** Rules and skills
+go stale as tools change — deprecations, renamed flags, shifted best practice.
+When auditing an existing rule or adopting a new pattern, use **Context7** (the
+`context7` MCP, *if it is enabled in this session*) to check the tool /
+library / API's **current** documentation before trusting what's written — it
+catches drift without cloning a repo (e.g. it surfaced Spotify's now-deprecated
+`PUT/DELETE /me/tracks` that older third-party guides still listed as current).
+Resolve the library id, then query the specific question. It is **second-class**
+(`rules/mcp.md`): a convenience for the audit *process* only — never a
+dependency the resulting rules/skills rely on, and the audit must work
+without it. Fall back to official docs or a shallow clone when it's absent.
+
 ## Mining repos for ideas
 
 An audit improves the **whole** dev environment, not just the current repo —

--- a/config/claude/skills/spotify-audit/SKILL.md
+++ b/config/claude/skills/spotify-audit/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: spotify-audit
+description: Audit a Spotify Web API / Web Playback SDK codebase for alignment with current Spotify best practices and Developer Terms. Checks auth (Authorization Code + PKCE, no implicit grant, secret handling, redirect URIs), proactive token refresh, scope minimization, deprecated endpoints (post-2024-11-27 + legacy library/playlist paths), rate-limit/429 handling, track relinking (use linked_from for Library ops), and Web Playback SDK/EME prerequisites. Use for "/spotify-audit", "audit our Spotify code", "is our Spotify integration aligned/compliant", "check Spotify API usage", "find deprecated Spotify endpoints", or before shipping Spotify-facing changes.
+---
+
+# Spotify Audit
+
+**Version:** v1.0.0
+
+Audit a codebase that integrates the Spotify Web API and/or Web Playback SDK
+for alignment with current Spotify practice and the Developer Terms. This
+skill is the **checker**; the policy it enforces lives in **`rules/spotify.md`**
+(the source of truth — every finding cites a clause there). It produces a
+severity-grouped findings report and does **not** auto-rewrite: some
+deprecations have no drop-in replacement and need a human decision.
+
+## Read first
+
+- **`rules/spotify.md`** — the authoritative policy (auth, tokens, scopes,
+  endpoints, rate limiting, relinking, SDK/EME, compliance).
+
+## Scope to the repo
+
+Detect the Spotify surface first, then audit only what exists:
+
+- The auth / OAuth flow — login, callback, and token storage/refresh.
+- The HTTP client / service layer that calls `api.spotify.com`.
+- The requested **scope list** (in the authorize URL or login config).
+- Any Web Playback SDK usage (`sdk.scdn.co`, the `streaming` scope, and the
+  embedding page's `Permissions-Policy` / CSP headers).
+
+## Checklist — signal → why → fix
+
+Record each hit with `file:line`. Spotify's API shifts, so verify
+endpoint/deprecation status against the official docs (Context7's
+`/websites/developer_spotify_web-api` is a convenient live source if
+available — optional, not required).
+
+### Auth
+
+- `response_type=token` / implicit-grant flow → deprecated; token leaks in
+  the URL → migrate to Authorization Code + PKCE.
+- Client Credentials used for `/me/*` (user-scoped) data → 401/403, no user
+  context → use Authorization Code (+ PKCE).
+- Client secret in client-side code, the frontend bundle, or a committed
+  `.env` → secret leak → server-side only; `*_FILE`/secrets manager; `.env`
+  gitignored.
+- Redirect URI on `http://` other than exactly `http://127.0.0.1`, or
+  `http://localhost`, or a wildcard → rejected/insecure → HTTPS, or
+  `http://127.0.0.1` for dev only.
+
+### Tokens
+
+- No token-refresh path, or no expiry check before calls → the session breaks
+  at the one-hour mark → refresh proactively from the stored refresh token.
+
+### Scopes
+
+- Scope list broader than the features in use (e.g. `*-modify-*` with no
+  write calls) → least-privilege violation → request only what is used.
+- Cover-image upload without `ugc-image-upload` → 401 → add the scope.
+
+### Endpoints
+
+- Calls to `/audio-features`, `/audio-analysis`, `/recommendations`,
+  `available-genre-seeds`, `/artists/{id}/related-artists` → deprecated
+  2024-11-27, 404 for new apps, no replacement → remove (flag; do not
+  auto-fix).
+- `/playlists/{id}/tracks` instead of `/playlists/{id}/items`, or the
+  deprecated per-type `PUT`/`DELETE /me/tracks` instead of the unified
+  *Save/Remove Items to Library* endpoints → legacy path → use the current
+  one.
+- Multi-get / add / remove that ignores the per-endpoint id cap (varies —
+  often 20, sometimes 50, 100 for a playlist add/remove), or list reads that
+  do not paginate → truncated or rejected requests → batch to the endpoint's
+  cap and paginate.
+
+### Rate limiting
+
+- HTTP layer with no 429 / `Retry-After` branch, or a retry loop with no
+  delay → throttling / ban risk → honor `Retry-After`, then exponential
+  backoff.
+
+### Track relinking
+
+- The saved-tracks membership check, *Your Music* save/remove, or a
+  playlist-track removal using the **root** track id when relinking is in play
+  (a `linked_from` is present, or a `market` is passed) → wrong or
+  not-found track; saved tracks read back as unsaved → use `linked_from.id`
+  (the original).
+- Catalogue/library reads with no `market` (or `from_token`) where
+  playability matters → unplayable tracks surfaced → pass `market`.
+
+### Web Playback SDK / EME
+
+- SDK used without the `streaming` scope, without Premium gating, with the
+  iframe host page not delegating `encrypted-media` / `autoplay` via
+  `Permissions-Policy`, or served over non-HTTPS → `connect()` fails silently
+  → add the scope, gate on Premium, delegate EME/autoplay, serve over HTTPS.
+
+### Compliance
+
+- Long-term caching/persistence of Spotify metadata, missing Spotify
+  attribution in the UI, or feeding Spotify data into model training →
+  Developer-Terms violation → cache only for immediate use, attribute, never
+  train.
+
+## Report
+
+Group findings by severity and cite `file:line` + the `rules/spotify.md`
+clause each violates:
+
+- **Critical** — secret leak, implicit grant, a compliance violation.
+- **High** — new dependency on a deprecated endpoint, missing token refresh,
+  relinking misuse (a silent data bug), missing 429 handling.
+- **Medium** — over-broad scopes, a legacy `/tracks` or `/me/tracks` path, a
+  missing `market`, un-paginated reads.
+- **Info** — SDK/EME prerequisites to verify manually (Premium, HTTPS).
+
+State what was checked and what is clean — never imply coverage you did not
+run. Recommend fixes; do **not** auto-rewrite deprecated calls that have no
+replacement (flag those for a human decision).

--- a/config/claude/skills/spotify-audit/SOURCE.md
+++ b/config/claude/skills/spotify-audit/SOURCE.md
@@ -1,0 +1,29 @@
+# Source
+
+The **spotify-audit** skill and its companion `rules/spotify.md` adapt
+**ideas and structure only — no code** — from one repo, with all factual
+policy grounded in Spotify's official documentation.
+
+## Adapted (ideas/structure)
+
+- **`fabioc-aloha/spotify-skill`** — <https://github.com/fabioc-aloha/spotify-skill>
+  - License: **Apache-2.0**. Author: Fabio C. (`fabioc-aloha`).
+  - Mined: shallow clone, 2026-06-12 (v0.9.0).
+  - What we took: the *concept* of a packaged Spotify skill; its
+    endpoint / scope / error-handling inventory; the auto-refresh-before-call
+    pattern; the `ugc-image-upload`→401 insight; and the cover-art /
+    playlist-strategy capabilities (noted as future `spotify-patterns` work).
+    We wrote our own policy text and audit checklist from scratch.
+  - Lineage: that repo in turn builds on **Anthropic PBC**'s Agent Skills
+    system (Apache-2.0).
+  - **Caveat:** its `spotify-api/references/` predate Spotify's 2024-11-27 API
+    deprecations and omit PKCE / the implicit-grant ban, so we treat Spotify's
+    official docs as authoritative wherever they conflict.
+
+## Authoritative factual sources (policy, no code)
+
+- Building with AI — <https://developer.spotify.com/documentation/web-api/tutorials/building-with-ai>
+- Track relinking — <https://developer.spotify.com/documentation/web-api/concepts/track-relinking>
+- Web Playback SDK — <https://developer.spotify.com/documentation/web-playback-sdk>
+- Nov 2024 Web API changes — <https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api>
+- Live reference (optional): Context7 `/websites/developer_spotify_web-api`


### PR DESCRIPTION
## Summary
- **`rules/spotify.md`** (new, global, detection-activated) — the Spotify Web
  API policy/reference: auth (Authorization Code + PKCE, never implicit, secret
  handling, `127.0.0.1` redirect), token lifecycle + **proactive refresh**,
  scope minimization, **current-vs-deprecated endpoints** (the 2024-11-27
  deprecations + the legacy `/me/tracks` save/remove), 429/Retry-After +
  backoff, **track relinking** (`linked_from` for Library ops), **Web Playback
  SDK/EME**, and Developer-Terms compliance.
- **`spotify-audit` skill** (new) — `/spotify-audit` checks a Spotify codebase
  against the rule and emits a severity-grouped findings report; `SOURCE.md`
  records the ideas-only adaptation of `fabioc-aloha/spotify-skill` (Apache-2.0).
- **claude-audit skill** — adds an optional **Context7 currency check** (query
  live docs to catch drift without cloning; second-class per `mcp.md`).
- **Records** — mining census, `SETUP-AUDIT.md` idea-source + two decision-log
  entries, and a `spotify-patterns` follow-up in `TODO.md`.

Motivated by an audit run from pigify (first Spotify repo): every quirk the
rule encodes had already caused a bug there (relinking, token refresh, OAuth
`127.0.0.1`, EME). Policy grounded in Spotify's official docs — the source
repo's references are stale (pre-2024-11-27, no PKCE).

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint + secrets/large-file/etc.) green
- [ ] `rules/spotify.md` activates only for Spotify repos (Detection prose;
      coarse `**/*.{py,ts,tsx,js,jsx}` path gate)
- [ ] `/spotify-audit` and `rules/spotify.md` deploy to `~/.claude/` and are
      discoverable
- [ ] No unrelated dotfiles touched (changeset is `config/claude/**` + `TODO.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)