### PR TITLE
docs(audit): make Spotify mining-census dispositions self-evident

### DIFF
--- a/config/claude/audit/mining/spotify-skill.md
+++ b/config/claude/audit/mining/spotify-skill.md
@@ -9,14 +9,20 @@ We **adapt ideas only, never vendor code**. Authoritative policy comes from
 Spotify's official docs — the repo's `references/` are stale (predate the
 2024-11-27 deprecations; omit PKCE / the implicit-grant ban).
 
+Disposition column: **ADOPTED** = folded into this round's
+`rules/spotify.md` and `spotify-audit`; **CANDIDATE** = deferred to the
+`spotify-patterns` backlog; a split row landed its cross-cutting *pattern*
+and deferred its *recipe*. Each reason leads with **Done →** (what landed
+where) or **Deferred →**.
+
 | item | type | disp. | reason |
 |------|------|-------|--------|
-| `spotify-api/SKILL.md` | skill | ADOPT-idea | endpoint/scope inventory + patterns → `rules/spotify.md`, `spotify-audit` |
-| `references/api_reference.md` | reference | ADOPT-idea | endpoint/error/rate-limit tables — **stale**, cross-check vs official |
-| `references/authentication_guide.md` | reference | ADOPT-idea | token lifecycle; **gap:** no PKCE / implicit warning (we add) |
-| `references/COVER_ART_LLM_GUIDE.md` | reference | CANDIDATE | cover-art (SVG→PNG, a11y contrast) → future `spotify-patterns` |
-| `spotify-api/scripts/*.py` | code | SKIP code / ADOPT-idea | 40+ methods, 5 playlist strategies, auto-refresh pattern (ideas only) |
-| `get_refresh_token.py` | script | ADOPT-idea | Auth-Code flow on `127.0.0.1`, manual refresh-token capture (concept) |
+| `spotify-api/SKILL.md` | skill | ADOPTED | **Done →** `rules/spotify.md` (Endpoints, Scopes) + `spotify-audit`: endpoint/scope inventory + patterns |
+| `references/api_reference.md` | reference | ADOPTED | **Done →** rule (Endpoints, Rate limiting): endpoint/error/rate-limit tables. **Stale** — cross-checked vs official docs |
+| `references/authentication_guide.md` | reference | ADOPTED | **Done →** rule (Auth, Tokens): token lifecycle; we **added** the PKCE / implicit-ban it omitted |
+| `references/COVER_ART_LLM_GUIDE.md` | reference | CANDIDATE | **Deferred →** `spotify-patterns`: cover-art (SVG→PNG, a11y contrast) |
+| `spotify-api/scripts/*.py` | code | ADOPTED (pattern) + CANDIDATE (recipes) | **Done →** rule (Tokens): auto-refresh pattern. **Deferred →** `spotify-patterns`: 5 playlist strategies, 40+ method inventory. No code copied. |
+| `get_refresh_token.py` | script | ADOPTED (rule) + CANDIDATE (helper) | **Done →** rule (Auth): Auth-Code on `127.0.0.1`. **Deferred →** `spotify-patterns`: the manual refresh-token-capture helper |
 | `agent_skills_spec.md` | spec | SKIP | Agent Skills spec — informs skill *shape*, not Spotify policy |
 | `tools/{init,validate,package}_skill.py` | tooling | SKIP | generic skill scaffolding, unrelated to Spotify |
 | `examples/`, `Guide/` | examples/docs | SKIP | generic skill-authoring tutorials |


### PR DESCRIPTION
## Summary
- Tighten `config/claude/audit/mining/spotify-skill.md` so each row's
  disposition is unambiguous: **ADOPTED** (folded into `rules/spotify.md` +
  `spotify-audit` this round) vs **CANDIDATE** (deferred to `spotify-patterns`),
  with the two *split* rows (scripts, `get_refresh_token.py`) marked as both —
  pattern adopted, recipe deferred. Reasons now lead with **Done →** /
  **Deferred →**, and a key sits above the table.
- **No substance change** — the ideas were already incorporated (verified:
  PKCE, 127.0.0.1, refresh, ugc-image-upload, Retry-After, linked_from,
  deprecated all present in the rule + skill; playlist-strategy / cover-art
  correctly absent, i.e. deferred). This only fixes the record's clarity.

## Test plan
- [ ] `pre-commit run --files config/claude/audit/mining/spotify-skill.md` (markdownlint) green
- [ ] Each table row reads as self-evidently done or deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)