### PR TITLE
feat(claude): add spotify-patterns skill (completes the Spotify category)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,27 +106,23 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
 
-## 🎵 Build a `spotify-patterns` skill (LOW PRIORITY)
+## ✅ Build a `spotify-patterns` skill (DONE 2026-06-12)
 
-Companion to `rules/spotify.md` + the `spotify-audit` skill (added 2026-06-12).
-The audit/rule cover *policy and alignment*; this would carry the concrete
-*recipes* — mirroring how `fastapi-patterns` / `sqlalchemy-patterns` back their
-rules. Mined as a CANDIDATE from `fabioc-aloha/spotify-skill` (see
-`config/claude/audit/mining/spotify-skill.md`). Lower priority, but genuinely
-useful — having these recipes earlier would have pre-empted the relinking and
-token-refresh bugs that motivated the Spotify category.
+Done — the recipe companion to `rules/spotify.md` + `spotify-audit`, mirroring
+`fastapi-patterns` / `sqlalchemy-patterns`. All recipes shipped:
 
-- [ ] **Token refresh + relinking recipes** — proactive refresh-before-expiry,
-  and the `linked_from`-for-Library-ops pattern (the two bugs we hit).
-- [ ] **Pagination + set-based dedup** — always loop list reads (per-endpoint
-  page size); collect ids into a set before populating a playlist.
-- [ ] **Rate-limit handling** — a 429 / `Retry-After` + exponential-backoff
-  wrapper for the HTTP layer.
-- [ ] **Playlist-creation strategies** — by-artist / theme / song-list (drop
-  the recommendation-seeded one — it depends on a deprecated endpoint).
-- [ ] **Cover-art generation** — SVG→PNG with a11y contrast + `ugc-image-upload`.
-- [ ] Wire it into `rules/spotify.md` ("for recipes, invoke spotify-patterns")
-  and record in `SETUP-AUDIT.md`.
+- [x] **Token refresh + relinking recipes** — proactive refresh-before-expiry
+  and `linked_from`-for-Library-ops (written first-hand from the pigify fixes).
+- [x] **Pagination + set-based dedup**.
+- [x] **Rate-limit handling** — 429 / `Retry-After` + exponential-backoff wrapper.
+- [x] **Playlist-creation strategies** — by-artist / theme / song-list
+  (recommendation-seeded dropped — deprecated endpoint).
+- [x] **Cover-art generation** — SVG→PNG, a11y contrast, `ugc-image-upload`.
+- [x] Wired into `rules/spotify.md`; recorded in `SETUP-AUDIT.md` + the census.
+
+Follow-up (also logged in the mining census): re-mine Spotify's official
+**Concepts / Tutorials / How-Tos** sections for more material for the rule
+and skills.
 
 ## 🔗 docker_wrapper Symlink Automation (MEDIUM PRIORITY)
 

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,19 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-12 — **Built `spotify-patterns` skill (completes the Spotify
+  category).** The recipe half deferred from the Spotify category, mirroring
+  `fastapi-patterns` / `sqlalchemy-patterns`: concrete recipes for proactive
+  token refresh, relinking-aware Library ops (the two bugs pigify hit, written
+  first-hand from those fixes), pagination + set-based dedup, a 429/Retry-After
+  backoff wrapper, playlist-creation strategies (by-artist / theme /
+  song-list — the recommendation-seeded one dropped as deprecated-dependent),
+  and cover-art (SVG→PNG, a11y contrast, `ugc-image-upload`). Wired into
+  `rules/spotify.md` ("for recipes, invoke spotify-patterns"); SOURCE.md cites
+  `fabioc-aloha/spotify-skill` (Apache-2.0, ideas-only). The mining census's
+  ADOPT set is now fully shipped. **Follow-up logged** (census + TODO): re-mine
+  Spotify's official Concepts / Tutorials / How-Tos sections for more material.
+  Landed via dotfiles PR.
 - 2026-06-12 — **Spotify category: `rules/spotify.md` + `spotify-audit`
   skill (audit run from pigify).** pigify (the first Spotify repo) surfaced a
   cluster of hard-won, non-obvious Spotify Web API quirks — track relinking

--- a/config/claude/audit/mining/spotify-skill.md
+++ b/config/claude/audit/mining/spotify-skill.md
@@ -9,27 +9,33 @@ We **adapt ideas only, never vendor code**. Authoritative policy comes from
 Spotify's official docs — the repo's `references/` are stale (predate the
 2024-11-27 deprecations; omit PKCE / the implicit-grant ban).
 
-Disposition column: **ADOPTED** = folded into this round's
-`rules/spotify.md` and `spotify-audit`; **CANDIDATE** = deferred to the
-`spotify-patterns` backlog; a split row landed its cross-cutting *pattern*
-and deferred its *recipe*. Each reason leads with **Done →** (what landed
-where) or **Deferred →**.
+Disposition column: **ADOPTED** = folded into `rules/spotify.md`,
+`spotify-audit`, or `spotify-patterns`; **SKIP** = not used. Each reason leads
+with **Done →**, naming where it landed. All ADOPT-idea recipes have now
+shipped — `spotify-patterns` was built 2026-06-12, so nothing remains deferred.
 
 | item | type | disp. | reason |
 |------|------|-------|--------|
 | `spotify-api/SKILL.md` | skill | ADOPTED | **Done →** `rules/spotify.md` (Endpoints, Scopes) + `spotify-audit`: endpoint/scope inventory + patterns |
 | `references/api_reference.md` | reference | ADOPTED | **Done →** rule (Endpoints, Rate limiting): endpoint/error/rate-limit tables. **Stale** — cross-checked vs official docs |
 | `references/authentication_guide.md` | reference | ADOPTED | **Done →** rule (Auth, Tokens): token lifecycle; we **added** the PKCE / implicit-ban it omitted |
-| `references/COVER_ART_LLM_GUIDE.md` | reference | CANDIDATE | **Deferred →** `spotify-patterns`: cover-art (SVG→PNG, a11y contrast) |
-| `spotify-api/scripts/*.py` | code | ADOPTED (pattern) + CANDIDATE (recipes) | **Done →** rule (Tokens): auto-refresh pattern. **Deferred →** `spotify-patterns`: 5 playlist strategies, 40+ method inventory. No code copied. |
-| `get_refresh_token.py` | script | ADOPTED (rule) + CANDIDATE (helper) | **Done →** rule (Auth): Auth-Code on `127.0.0.1`. **Deferred →** `spotify-patterns`: the manual refresh-token-capture helper |
+| `references/COVER_ART_LLM_GUIDE.md` | reference | ADOPTED | **Done →** `spotify-patterns`: cover-art (SVG→PNG, a11y contrast, `ugc-image-upload`) |
+| `spotify-api/scripts/*.py` | code | ADOPTED | **Done →** rule (Tokens): auto-refresh; `spotify-patterns`: playlist strategies, pagination/dedup. (40+ method inventory not enumerated wholesale.) No code copied. |
+| `get_refresh_token.py` | script | ADOPTED | **Done →** rule (Auth): Auth-Code on `127.0.0.1`; `spotify-patterns`: the token-refresh recipe. (A standalone interactive capture CLI wasn't built — low value.) |
 | `agent_skills_spec.md` | spec | SKIP | Agent Skills spec — informs skill *shape*, not Spotify policy |
 | `tools/{init,validate,package}_skill.py` | tooling | SKIP | generic skill scaffolding, unrelated to Spotify |
 | `examples/`, `Guide/` | examples/docs | SKIP | generic skill-authoring tutorials |
 | housekeeping (`CHANGELOG`, `RELEASE_NOTES`, `*.backup`, `CustomGPT/`, …) | misc | SKIP | packaging artifacts |
 
-**Adopted →** `rules/spotify.md` + `spotify-audit` skill (this round).
-**CANDIDATE backlog →** `spotify-patterns` skill (cover-art generation,
-playlist-creation strategies, pagination/dedup, error-code mapping) — tracked
-in `TODO.md`; lower priority but genuinely useful (would have pre-empted the
-relinking / token-refresh bugs that motivated this round).
+**Adopted →** `rules/spotify.md` + `spotify-audit` (2026-06-12), and
+`spotify-patterns` (token refresh, relinking, pagination/dedup, 429 wrapper,
+playlist strategies, cover-art). The full ADOPT set has shipped — having these
+recipes earlier would have pre-empted the relinking / token-refresh bugs that
+motivated the Spotify category.
+
+**Follow-up (TODO).** Re-mine **Spotify's own official documentation** — the
+**Concepts**, **Tutorials**, and **How-Tos** sections — end to end for further
+material to fold into `rules/spotify.md` and the skills. This round mined the
+third-party repo plus the *building-with-AI* page and targeted official pages
+(track relinking, scopes, Web Playback SDK, the Nov-2024 changes), not those
+sections in full.

--- a/config/claude/rules/spotify.md
+++ b/config/claude/rules/spotify.md
@@ -13,9 +13,10 @@ paths:
 
 Conventions for integrating the **Spotify Web API** and **Web Playback SDK**.
 This rule is the policy/reference; to audit an existing codebase against it,
-run the **spotify-audit** skill. Concrete recipes (cover-art generation,
-playlist-building strategies, pagination/dedup helpers) are planned for a
-**spotify-patterns** skill (tracked in the dotfiles `TODO.md`).
+run the **spotify-audit** skill. For concrete recipes — proactive token
+refresh, relinking-aware Library ops, pagination/dedup, a 429 wrapper,
+playlist-creation strategies, and cover-art generation — invoke the
+**spotify-patterns** skill.
 
 ## Detection
 
@@ -138,6 +139,9 @@ without it.
 - When adding or changing Spotify integration code, follow the auth, token,
   scope, endpoint, and relinking rules above — in particular proactive token
   refresh and `linked_from`-for-library-operations.
+- For the concrete *how* (a token-refresh helper, relinking-aware id
+  selection, pagination/dedup, a 429 backoff wrapper, playlist-creation
+  strategies, cover-art generation), invoke the **spotify-patterns** skill.
 - To audit an existing Spotify codebase for alignment, run the
   **spotify-audit** skill.
 - Treat Spotify's official docs as authoritative; older tutorials and

--- a/config/claude/skills/spotify-patterns/SKILL.md
+++ b/config/claude/skills/spotify-patterns/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: spotify-patterns
+description: Concrete Spotify Web API implementation recipes — proactive token refresh (survive the 1-hour expiry), track-relinking-aware Library operations (use linked_from for saved/contains/remove), pagination + set-based dedup, a 429/Retry-After + exponential-backoff wrapper, playlist-creation strategies (by-artist / by-theme / from-song-list), and playlist cover-art generation (SVG→PNG, a11y contrast, ugc-image-upload). Use when writing or refactoring Spotify integration code and you want the deeper how beyond the conventions in rules/spotify.md. Triggers: "refresh the Spotify token", "why does a saved track show as unsaved", "track relinking", "build a playlist from a list", "handle Spotify rate limits / 429", "generate a playlist cover".
+---
+
+# Spotify Patterns
+
+**Version:** v1.0.0
+
+Concrete, adaptable recipes for the Spotify Web API. **`rules/spotify.md` is
+the source of truth for the policy** (auth + PKCE, scopes, deprecated
+endpoints, relinking, SDK/EME, compliance) — read it first; this skill only
+adds the deeper *how*. To audit existing Spotify code against the policy, use
+the **spotify-audit** skill.
+
+Examples are Python-leaning (the dominant Spotify-app language), but the
+patterns are language-agnostic — the relinking and token-refresh recipes apply
+equally to a TypeScript frontend.
+
+## When to reach for this
+
+Implementing auth/token handling, library or playlist operations,
+search-driven playlist building, rate-limit handling, or cover-art upload —
+and the one-liners in `rules/spotify.md` aren't enough detail.
+
+## Proactive token refresh
+
+A session must outlive the **one-hour** access token. Store the expiry as an
+**absolute** deadline and refresh from the stored refresh token *before* a call
+when it is near expiry — don't wait for the 401.
+
+```python
+import time
+
+# Refresh when within this many seconds of expiry.
+_SKEW = 60
+
+async def fresh_access_token(session) -> str:
+    token = session["access_token"]
+    expires_at = session.get("token_expires_at")
+    if expires_at is None or time.time() < expires_at - _SKEW:
+        return token
+
+    refresh = session.get("refresh_token")
+    if not refresh:
+        return token  # can't refresh; let a downstream 401 handle it
+
+    data = await spotify_refresh(refresh)  # grant_type=refresh_token
+    new = data.get("access_token")
+    if not new:
+        return token  # refresh failed; fall back, do not raise
+
+    session["access_token"] = new
+    # Spotify usually does NOT rotate the refresh token; keep a new one if sent.
+    if data.get("refresh_token"):
+        session["refresh_token"] = data["refresh_token"]
+    session["token_expires_at"] = time.time() + data.get("expires_in", 3600)
+    return new
+```
+
+Store `token_expires_at` as an absolute epoch (not the raw `expires_in`). A
+refresh *failure* returns the stale token rather than raising, so the helper
+keeps the same failure profile as a plain "get token" and the existing 401 path
+still handles a truly-dead session.
+
+## Relinking-aware Library operations
+
+Spotify serves a recording under different track ids per market. The id from
+playback / a relinked read is the **playable** one; the id the track is
+**saved** under is the original, in `linked_from`. For *every* Library or
+playlist write/membership op — saved-tracks `contains`, save, remove, and
+playlist-track removal — use the original id, or a saved track reads back as
+unsaved.
+
+```python
+def library_id(track: dict) -> str:
+    # Original id for Library ops; falls back to the id when not relinked.
+    return (track.get("linked_from") or {}).get("id") or track["id"]
+
+# saved-state check uses the ORIGINAL id, not track["id"]
+saved = await get("/me/tracks/contains", ids=library_id(track))
+```
+
+## Pagination + order-preserving dedup
+
+Never assume a list fits one page; loop until `next` is null. When merging
+several searches into a playlist, dedup ids while preserving order.
+
+```python
+async def all_items(url: str) -> list[dict]:
+    items = []
+    while url:
+        page = await get(url)
+        items.extend(page["items"])
+        url = page.get("next")  # absolute next-page url, or None
+    return items
+
+unique_uris = list(dict.fromkeys(uris))  # dedup, insertion order kept
+```
+
+## 429 / Retry-After + backoff
+
+On HTTP 429, wait the `Retry-After` seconds, then exponential backoff. Never
+retry in a tight loop.
+
+```python
+async def with_retry(call, *, attempts=5):
+    delay = 1
+    resp = None
+    for _ in range(attempts):
+        resp = await call()
+        if resp.status_code != 429:
+            return resp
+        wait = int(resp.headers.get("Retry-After", delay))
+        await sleep(wait)
+        delay *= 2  # 1 → 2 → 4 → 8 …
+    return resp  # caller handles the final 429
+```
+
+## Playlist-creation strategies
+
+Build the uri list, dedup, then add (≤100 uris per request — paginate).
+
+- **By artist** — the artist's top tracks (`/artists/{id}/top-tracks`).
+- **By theme / mood** — several search queries, merged and deduped.
+- **From a song list** — search `"title artist"` per row, take the top hit.
+
+There is no **recommendation-seeded** strategy here: `/recommendations` is
+deprecated for new apps (see `rules/spotify.md`).
+
+```python
+async def from_song_list(rows: list[tuple[str, str]]) -> list[str]:
+    uris = []
+    for title, artist in rows:
+        r = await get("/search", q=f"{title} {artist}", type="track", limit=1)
+        hits = r["tracks"]["items"]
+        if hits:
+            uris.append(hits[0]["uri"])
+    return list(dict.fromkeys(uris))
+```
+
+## Cover-art generation + upload
+
+Render a themed SVG (mind a11y contrast), rasterize, then upload — requires the
+**`ugc-image-upload`** scope.
+
+```python
+import cairosvg
+
+png = cairosvg.svg2png(
+    bytestring=svg.encode(), output_width=640, output_height=640
+)
+jpeg_b64 = to_jpeg_base64(png)  # Spotify wants base64 JPEG, ≤ 256 KB
+await put(
+    f"/playlists/{pid}/images",
+    body=jpeg_b64,
+    headers={"Content-Type": "image/jpeg"},
+)
+```
+
+Pick text/background colors with a legible contrast ratio (WCAG AA on the cover
+text). Without `ugc-image-upload` the upload returns 401 — fall back to a "set
+this image manually" prompt rather than failing silently.

--- a/config/claude/skills/spotify-patterns/SOURCE.md
+++ b/config/claude/skills/spotify-patterns/SOURCE.md
@@ -1,0 +1,31 @@
+# Source
+
+The **spotify-patterns** skill adapts **ideas only — no code** — from one repo,
+with the highest-value recipes (proactive token refresh, relinking-aware
+Library ops) written from first-hand implementation in the pigify project.
+
+## Adapted (ideas/structure)
+
+- **`fabioc-aloha/spotify-skill`** — <https://github.com/fabioc-aloha/spotify-skill>
+  - License: **Apache-2.0**. Author: Fabio C. (`fabioc-aloha`).
+  - Mined: 2026-06-12 (v0.9.0), in the same audit round as `rules/spotify.md`
+    and the `spotify-audit` skill (see those artifacts' SOURCE / the mining
+    census `audit/mining/spotify-skill.md`).
+  - What we took (concepts only, our own code): the playlist-creation
+    *strategies* (by-artist / by-theme / from-song-list), the cover-art
+    SVG→PNG → `ugc-image-upload` pipeline, set-based dedup, and the
+    pagination-loop pattern.
+  - **Not taken:** its recommendation-seeded playlist strategy — it depends on
+    the now-deprecated `/recommendations` endpoint (see `rules/spotify.md`).
+
+## First-hand
+
+- The **proactive token refresh** and **relinking-aware Library ops** recipes
+  were written from the implementations done in the pigify project (where both
+  had already caused bugs), not adapted from the source repo.
+
+## Authoritative factual sources (policy, no code)
+
+- See `rules/spotify.md` and `skills/spotify-audit/SOURCE.md` for the Spotify
+  official-docs references (track relinking, rate limiting, the 2024-11-27
+  deprecations, Web Playback SDK).


### PR DESCRIPTION
## Summary
- **`spotify-patterns` skill** (new) — the recipe companion to `rules/spotify.md`
  + `spotify-audit`, mirroring `fastapi-patterns` / `sqlalchemy-patterns`.
  Recipes: proactive token refresh, relinking-aware Library ops
  (`linked_from`), pagination + set-based dedup, a 429/Retry-After backoff
  wrapper, playlist-creation strategies (by-artist / theme / song-list — the
  deprecated recommendation-seeded one dropped), and cover-art (SVG→PNG, a11y
  contrast, `ugc-image-upload`).
- The two highest-value recipes (token refresh, relinking) are written
  **first-hand** from the pigify fixes that motivated the category. `SOURCE.md`
  cites `fabioc-aloha/spotify-skill` (Apache-2.0, ideas-only).
- **Wired in**: `rules/spotify.md` now points to the skill for recipes; the
  mining census's recipe rows flip to **ADOPTED** (the ADOPT set is fully
  shipped); `SETUP-AUDIT.md` decision entry added; the `TODO.md` section marked
  done.
- **Follow-up logged** (census + TODO): re-mine Spotify's official Concepts /
  Tutorials / How-Tos sections for more rule/skill material.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint) green
- [ ] `spotify-patterns` is discoverable as a skill; `rules/spotify.md` links to it
- [ ] Changeset is `config/claude/**` + `TODO.md` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)