### PR TITLE
feat(claude): ICEBOX marker + feature-request / API-limits behaviors

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -26,6 +26,26 @@ directory and override anything stated here.
 - If a simpler approach exists, say so before implementing the requested one.
 - If the task is unclear, stop and name what is confusing before proceeding.
 
+## Handling Feature Requests
+
+Before implementing a requested feature or resolving an issue:
+
+- **Scan for prior deferred decisions first.** Run `grep -rn "ICEBOX:"`
+  across the codebase — an `ICEBOX:` marker (see `rules/code-style.md`)
+  records a considered "not now" with the context for revisiting. Surface a
+  relevant hit instead of silently re-deciding.
+- **When the feature depends on an external API / service / library, verify
+  it is actually supported** against *current* official docs before committing
+  to build it (Context7 if available, otherwise the official reference).
+  Capabilities and limits change — do not assume from memory.
+- **If it is unsupported, say so with evidence** (what the API does expose
+  versus what is missing) and offer the nearest feasible alternative.
+- **Record the limitation so it is not re-attempted:** an `ICEBOX:` note at
+  the nearest relevant code (dated, keyword-dense) **and** an entry in that
+  dependency's *Limitations* list — its `rules/<tool>.md` when the limit is a
+  generic fact about the dependency, or the repo's `.claude/` when it is a
+  repo-specific constraint.
+
 ## Scope Discipline
 
 - No features beyond what was asked.

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,19 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-16 — **`ICEBOX:` marker + feature-request behaviors (from pigify).**
+  Standardized a discoverability convention for *deferred / revisit-on-request*
+  decisions, born from a real pigify case (persistent playlist reorder under
+  review). Global: `rules/code-style.md` defines the `ICEBOX:` marker (vs
+  `TODO`/`FIXME`/`XXX`) and the keyword-dense rule so a grep on a future
+  request's wording lands on the note; `CLAUDE.md` gains a **Handling Feature
+  Requests** section — scan `ICEBOX:` first, and (the *generic* form of) verify
+  external-API support against current docs before building, surfacing +
+  recording any limitation (an `ICEBOX:` note plus the dependency's
+  `rules/<tool>.md` *or* the repo's `.claude/`). The *specific* Spotify limits
+  (no queue reorder, no playlist-library reorder) live in pigify's local
+  `.claude/CONVENTIONS.md`, per the generic-global / specific-local split.
+  Landed via dotfiles PR.
 - 2026-06-12 — **Added `rules/nginx.md` (rule-coverage gap from pigify).**
   pigify configures nginx (TLS termination, the `/api` reverse proxy, and a
   CSP / `Permissions-Policy` tuned for a cross-origin SDK iframe) but there was

--- a/config/claude/rules/code-style.md
+++ b/config/claude/rules/code-style.md
@@ -35,6 +35,21 @@ at the bottom).
   restate what well-named code already says.
 - Public APIs in any language MUST have a docstring / equivalent.
 
+### Marker comments
+
+Tag in-code notes with a consistent uppercase marker so they are greppable:
+
+- **`TODO:`** — work that will be done.
+- **`FIXME:`** — something broken to fix.
+- **`XXX:`** — a wart or risky spot needing attention.
+- **`ICEBOX:`** — a *deferred / maybe-someday* decision to **revisit only on
+  request** (a considered "not now", not a "will do"). Make the note
+  **keyword-dense** — include the synonyms a future request might use — so a
+  grep on that wording lands on the comment, not just the surrounding code.
+
+Acting on `ICEBOX:` notes (scanning the codebase for them when a feature
+request arrives) is an agent behaviour — see `CLAUDE.md`.
+
 ### Error Handling Posture
 
 - **Executables:** fail fast. A binary or CLI may call `exit` / `panic`


### PR DESCRIPTION
## Summary
Two standardized agent conventions, born from a real pigify case (persistent
playlist reorder, under review; a queue-reorder request the Spotify API can't
satisfy).

- **`rules/code-style.md`** — defines the **`ICEBOX:`** marker (a deferred /
  revisit-on-request decision, distinct from `TODO`/`FIXME`/`XXX`) and the
  **keyword-dense** rule so a grep on a future request's wording lands on the
  note, not just the code.
- **`CLAUDE.md`** — new **Handling Feature Requests** section: (1) scan
  `grep -rn "ICEBOX:"` first to surface prior deferred decisions; (2) for a
  feature that depends on an external API/service, **verify support against
  current docs before building** (Context7 if available); (3) if unsupported,
  surface with evidence + alternative and **record it** (an `ICEBOX:` note +
  the dependency's `rules/<tool>.md` *or* the repo's `.claude/`).

Generic-global / specific-local split: the **Spotify-specific** limits (no
playback-queue reorder, no playlist-library reorder) live in pigify's local
`.claude/CONVENTIONS.md`, not here.

## Test plan
- [ ] `pre-commit run --all-files` (markdownlint) green
- [ ] `grep -rn "ICEBOX:"` is the documented scan; marker glossary reads clearly
- [ ] Changeset is `config/claude/**` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)