### PR TITLE
docs(todo): plugins to rules/skills; context7 via mymcp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,47 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
+## 🔌 Convert marketplace plugins to in-repo rules/skills (MEDIUM PRIORITY)
+
+Replace these installed plugins with rules/skills that live in our own
+`config/claude/` and fit our environment (XDG paths, `mymcp`, our QA/git
+workflow), so we own and version the behaviour instead of depending on
+external marketplace plugins:
+
+- [ ] **claude-code-setup** (`claude-automation-recommender` skill).
+- [ ] **claude-md-management** (`claude-md-improver` + `revise-claude-md`
+  skills) — overlaps our existing CLAUDE.md/rules discipline; reconcile.
+- [ ] **hookify** (skills + `conversation-analyzer` agent + the hook
+  machinery) — our hooks live under `~/.claude/hooks/`; decide what carries
+  over.
+- [ ] **ralph-loop** (`ralph-loop` / `cancel-ralph` / `help` skills).
+- [ ] **skill-creator** (`skill-creator` skill).
+
+For each: extract the useful behaviour into a `config/claude/rules/<name>.md`
+or `config/claude/skills/<name>/` per the three-tier model in `CLAUDE.md`,
+drop anything redundant with what we already have, then disable/remove the
+plugin in `settings.json` + `installed_plugins.json`. Record the outcome in
+`SETUP-AUDIT.md`.
+
+## 🔁 Point the context7 plugin at `mymcp` (MEDIUM PRIORITY)
+
+**Investigation done:** the `context7` plugin contains **nothing besides the
+MCP server** — just `.mcp.json` (`npx -y @upstash/context7-mcp`) and a
+`plugin.json` manifest. No skills, commands, rules, agents, or hooks. So there
+is nothing to convert to a rule/skill; it only needs to run through our own
+MCP launcher.
+
+- [ ] Add a `context7` case to `bin/mymcp`:
+  `context7() { npx_run '@upstash/context7-mcp'; }` + `known_cmd['context7']=1`
+  (`npx_run` already prepends `-y`, so pass only the package).
+- [ ] Register context7 as an `mcpServers` entry running `mymcp context7`
+  (stdio) the way `github`/`snyk` are, instead of the marketplace plugin.
+- [ ] Disable the plugin: drop `"context7@claude-plugins-official": true` from
+  both `config/claude/settings.json` and `~/.claude/settings.json` (they
+  mirror).
+- [ ] Verify the context7 MCP tools still resolve after the switch; record in
+  `SETUP-AUDIT.md`.
+
 ## 🐙 `/github-tasks` skill — recurring GitHub housekeeping (MEDIUM PRIORITY)
 
 Create a `/github-tasks` skill that sweeps the repo's GitHub state and drives


### PR DESCRIPTION
## Summary
- Add a TODO to convert the `claude-code-setup`, `claude-md-management`,
  `hookify`, `ralph-loop`, and `skill-creator` marketplace plugins into
  in-repo `config/claude/` rules/skills that fit our environment.
- Add a TODO to run `context7` through `bin/mymcp` instead of the marketplace
  plugin. Investigation noted in the entry: the context7 plugin contains
  nothing besides its MCP server, so only the launcher switch is needed.

## Test plan
- [ ] `pre-commit run --files TODO.md` passes (markdownlint clean)
- [ ] No code changed; documentation-only edit