### PR TITLE
feat(git): versioning & tagging rule + release-tag skill

### DIFF
--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.4.0
+**Version:** v1.5.0
 
 ## Commit Messages
 
@@ -217,6 +217,72 @@ git branch -ra
 
 The deleted branch should no longer appear in the output.
 
+## Versioning & tags
+
+Two separate things: **what a version *is*** (the `vX.Y.Z` format — universal)
+versus **how it's *applied*** (the tagging *method* — per-repo).
+
+### What `vX.Y.Z` is
+
+`vMAJOR.MINOR.PATCH`. How strict the parts are depends on whether the major
+(`X`) has reached 1:
+
+- **`X = 0` (`v0.y.z`) — alpha / pre-stable.** **Breakage is expected**, and
+  the `y.z` split is **loose** — don't agonize over minor-vs-patch, and a
+  breaking change needs no ceremony. Roughly: bump `y` for a meaningful
+  addition, `z` for a smaller change.
+- **`X ≥ 1` (`v1.y.z`+) — stable.** The version is now a compatibility
+  promise, so `y.z` get **strict**: a **breaking change requires bumping
+  `X`** (a major bump); `y` is a backward-compatible feature; `z` is a
+  backward-compatible fix.
+
+The `0 → 1` jump — declaring the project stable — is a **major decision in
+its own right**: give it as much thought and care as any later major bump
+(`1 → 2`, …). Cross it on purpose, never by accident.
+
+### Tag hygiene (independent of method)
+
+- **Annotated** tags only — `git tag -a <tag> -m "<msg>"`, never lightweight.
+- Tag the **merge commit** the release ships from, not a side branch.
+- A pushed tag is **immutable history**: never move, delete, or re-point it.
+  A mistake gets a **new** tag, not a rewrite.
+- Push tags **explicitly** (`git push origin <tag>`); a plain `git push`
+  does not push them. Pushing usually **triggers the release/publish
+  workflow**, so it is outward-facing — **confirm before pushing**.
+
+### How it's applied — tagging methods
+
+The *scope* a tag versions is per-repo. A repo uses **one** method and
+**declares it** in its `.claude/CONVENTIONS.md` ("Versioning & tagging") — the
+method, the tag pattern(s), the bump policy, and what pushing a tag triggers.
+
+| Method | Tag pattern | Versions | Fits |
+|--------|-------------|----------|------|
+| **`repo`** | `vX.Y.Z` | the whole repo as one unit | a single deployable / one artifact |
+| **`subdir`** | `<component>/vX.Y.Z` (e.g. `backend/v*`, `frontend/v*`) | each deployable subtree independently | a monorepo with separate components/images |
+
+The catalog is **open**. If a repo needs a method not listed (e.g.
+package-name-prefixed tags in a multi-package monorepo, or date-based
+versions), that is a **config change, not an ad-hoc choice**: add the method
+to this table and teach the **release-tag** skill to derive it *before* using
+it — the same discipline as a new tool getting a `rules/<tool>.md` (see
+`CLAUDE.md` *Missing or Conflicting Tool Rules*).
+
+### Foreign / forked repos — follow theirs
+
+The catalog + declaration model is for repos **you control**. On a repo you
+do **not** own (contributing upstream, or a fork's upstream), **do not impose
+this catalog** — detect and follow **that repo's** existing convention (its
+tag history, release docs, CI triggers). Match what they do; our methods are
+for our own repos.
+
+### Cutting a tag
+
+The procedure — read the declared method, pick the changed stream(s) (only
+when a *shipped artifact* changed), decide the bump, cut the annotated tag at
+the merge commit, push, and watch the release — is the **release-tag** skill;
+`ship-pr` Step 6 delegates to it.
+
 ## Agent Rules
 
 - NEVER hardcode `main` or `master` — always derive the default branch.
@@ -243,3 +309,11 @@ The deleted branch should no longer appear in the output.
 - Scan `git config --get-regexp '^alias\.'` at the start of non-trivial
   git work; prefer formatting/complex aliases over equivalent raw
   commands. See *Aliases and Configuration* above.
+- `vX.Y.Z` is semver — `X = 0` is alpha (breakage expected, loose `y.z`);
+  once `X ≥ 1`, breaking changes require a major bump. Tags are **annotated**,
+  at the **merge commit**, and **never moved** once pushed. See *Versioning &
+  tags*.
+- Apply tags per the repo's **declared method** (`.claude/CONVENTIONS.md`
+  "Versioning & tagging" — `repo` vs `subdir`); use the **release-tag** skill.
+  A new method is a config change (add it to the catalog first), not an
+  ad-hoc choice. For a repo you don't own, follow ITS convention.

--- a/config/claude/skills/release-tag/SKILL.md
+++ b/config/claude/skills/release-tag/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: release-tag
+description: Cut a release version tag (vX.Y.Z) at a merge commit, following the repo's declared tagging method, then watch the release workflow. Use when the user wants to tag/cut/ship a release — "tag the release", "cut a release", "cut frontend/v0.2.0", "release-tag this", "bump the version and tag", "tag v1.2.0". Reads the repo's `.claude/CONVENTIONS.md` "Versioning & tagging" to determine the method (repo-level `vX.Y.Z` vs per-subdir `<component>/vX.Y.Z`), decides the bump (alpha-loose under v0, strict once v1+), creates the annotated tag(s) at the merge commit, pushes (with confirmation, since it publishes), and watches the build/publish. For a repo you don't own, follows ITS convention. This is ship-pr's Step 6 as a standalone skill.
+---
+
+# Release tag
+
+**Version:** v1.0.0
+
+Cut a **release version tag** that follows the repo's declared tagging method.
+The *format* (`vX.Y.Z` = semver) and *tag hygiene* (annotated, at the merge
+commit, never moved) live in **`rules/git.md` › Versioning & tags** — this
+skill is the **procedure** that applies them.
+
+Pushing a release tag usually **triggers the build/publish workflow**, so it
+is **outward-facing**: confirm before pushing, and never move a published tag.
+
+## When to use
+
+The user wants to tag/release a finished, **merged** change — "cut a release",
+"tag `frontend/v0.2.0`", "bump and tag". Commonly invoked as `ship-pr` Step 6,
+but works standalone for an already-merged commit.
+
+**Skip entirely** when the change ships **no artifact** (docs / CI / compose /
+meta-only) or the repo doesn't tag releases.
+
+## Procedure
+
+### 1. Determine the method
+
+Read the repo's `.claude/CONVENTIONS.md` "Versioning & tagging" for the
+declared method (catalog in `rules/git.md`):
+
+- **`repo`** → one `vX.Y.Z` stream for the whole repo.
+- **`subdir`** → `<component>/vX.Y.Z` per deployable subtree
+  (e.g. `backend/v*`, `frontend/v*`).
+
+If the repo **declares no method**, infer from existing tags (`git tag -l`)
+and **confirm with the user** before tagging. If the needed method isn't in
+the `rules/git.md` catalog, that's a config gap — surface it and **add the
+method there first** (don't invent a one-off).
+
+**Foreign / forked repo you don't own:** ignore our catalog — follow **its**
+convention (tag history, release docs, CI triggers). Match what they do.
+
+### 2. Choose the stream(s)
+
+Tag **only a stream whose shipped artifact changed**:
+
+- `repo` → the single `v*` stream (if anything shipped).
+- `subdir` → only the component(s) whose subtree changed — a frontend-only
+  change tags `frontend/v*`, not `backend/v*`; a change to both tags each.
+
+Skip docs / CI / compose / meta-only changes — they ship nothing.
+
+### 3. Decide the bump
+
+Find the latest tag on each chosen stream, then bump per `rules/git.md`
+semver — remembering the **alpha vs stable** distinction:
+
+```bash
+git describe --tags --match '<prefix>v*' --abbrev=0   # latest on the stream
+```
+
+- **No tag yet** → seed the first release (commonly `v0.1.0`).
+- **`v0.y.z` (alpha)** → loose: `y` for a meaningful addition, `z` otherwise;
+  breaking changes need no major bump.
+- **`v1.y.z`+ (stable)** → strict: a **breaking change bumps the major**; `y`
+  = backward-compatible feature; `z` = backward-compatible fix.
+- The **`0 → 1`** jump is a major decision (as weighty as `1 → 2`) — only on
+  the user's explicit say-so.
+- **Confirm the bump with the user** whenever it's beyond an obvious patch.
+
+### 4. Cut the tag(s)
+
+On the default branch at the **merge commit** (the squash-merge HEAD), cut an
+**annotated** tag per the method's pattern:
+
+```bash
+git checkout "$DEFAULT" && git pull --ff-only
+git tag -a "<prefix>vX.Y.Z" -m "<component> vX.Y.Z — <summary>" "$(git rev-parse HEAD)"
+```
+
+- `repo` → `vX.Y.Z`.
+- `subdir` → `<component>/vX.Y.Z` (e.g. `frontend/v0.2.0`).
+
+### 5. Push and watch
+
+**Confirm with the user, then** push the tag(s) explicitly:
+
+```bash
+git push origin <tag> [<tag2> ...]
+```
+
+Pushing is the release trigger. Watch the release workflow to green
+(`rules/github-actions.md`) and verify the artifact published (e.g. the image
+tags via the registry). Report what released.
+
+A GitHub **Release object** (release notes) is a separate, optional step
+(`gh release create <tag> ...`) — do it only if the repo's convention wants
+release notes; the tag alone is what builds/deploys.
+
+## Guardrails
+
+- **Outward-facing:** pushing a tag publishes/deploys — confirm before push.
+- **Immutable tags:** never move / delete / re-point a pushed tag; a mistake
+  gets a **new** tag.
+- **Annotated, at the merge commit** (`rules/git.md` tag hygiene).
+- **Only artifact-shipping changes** get a tag — skip docs/CI/meta-only.
+- **`0 → 1`** is a deliberate, user-approved decision, not a default.
+- **Foreign repos:** follow their convention, not ours.

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commit a finished feature branch and push it, then — each only wi
 
 # Ship PR
 
-**Version:** v1.7.1
+**Version:** v1.8.0
 
 Take a finished branch through the standard landing sequence: **QA check** →
 commit → push → (approval) open PR → watch CI → (approval) merge →
@@ -196,23 +196,16 @@ Read the rejection, if any:
 
 ## Step 6 — Tag the release (if the repo tags releases)
 
-If the repo's versioning convention ties a release/deploy to a **tag at the
-merge commit** (not to every merge), create and push it now — but **only for
-a change that ships an artifact**; skip docs/CI/meta-only merges. Defer to the
-repo for the scheme, the bump type (patch/minor/major), and per-component
-streams (its `CONVENTIONS.md` "Versioning & tagging"; `rules/git.md` for tag
-hygiene). **Skip entirely** if the repo doesn't tag, or the change ships
-nothing.
+If the change **ships an artifact** and the repo ties a release to a **tag at
+the merge commit**, cut it now with the **release-tag** skill — it reads the
+repo's declared tagging method (`rules/git.md` › *Versioning & tags*, plus the
+repo's `CONVENTIONS.md` "Versioning & tagging"), decides the bump (alpha-loose
+under `v0`, strict once `v1`+, the `0 → 1` jump a deliberate call), cuts the
+annotated tag(s) at the merge commit, pushes (with confirmation — it
+publishes), and watches the release.
 
-```bash
-git checkout "$DEF" && git pull --ff-only          # get the squash-merge commit
-git tag -a "<tag>" -m "<message>" "$(git rev-parse HEAD)"
-git push origin "<tag>"
-```
-
-Pushing the tag is usually what triggers the release/publish workflow — watch
-it (see Notes). Confirm the tag is what the user wants if the bump type or
-stream is ambiguous.
+**Skip entirely** for docs / CI / meta-only merges, or if the repo doesn't
+tag.
 
 ## Step 7 — Post-merge cleanup
 


### PR DESCRIPTION
## Summary
Versioning had no real home — `git.md` said nothing despite `ship-pr` Step 6
pointing at it "for tag hygiene", and the scheme was deferred entirely to each
repo. Codify it, separating the two concerns:

- **`rules/git.md` › new "Versioning & tags"** — **what `vX.Y.Z` is**: `X = 0`
  is alpha (breakage expected, loose `y.z`); once `X ≥ 1`, breaking changes
  require a major bump; the `0 → 1` jump is as weighty as `1 → 2`. Plus tag
  hygiene (annotated, at the merge commit, never moved once pushed) and **how
  it's applied** — a catalog of tagging *methods* (`repo` vs `subdir`) a repo
  **declares** in its `CONVENTIONS.md`, open to new methods (added to the
  catalog, not ad-hoc), with foreign/forked repos following their own.
- **New `release-tag` skill** — the procedure (read the declared method, pick
  the changed stream(s), decide the bump, cut the annotated tag at the merge
  commit, push with confirmation, watch the release).
- **`ship-pr` Step 6 → delegates to `release-tag`**, fixing the dangling
  `rules/git.md` pointer. Bumps: git.md v1.4.0→v1.5.0, ship-pr v1.7.1→v1.8.0.

## Test plan
- [x] pre-commit (markdownlint, secrets) clean on all three files
- [x] 78-col prose wrap verified on the new content
- [x] `release-tag` skill registers and is discoverable