### PR TITLE
ci: bump checkout@v5 + setup-python@v6 (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # bats + helper libs come from Debian/Ubuntu packages. bats_load_library
       # resolves bats-support/assert/file from /usr/lib/bats by default; the
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # perl is preinstalled on the runner. Non-core deps: Test::Cmd (used by
       # the tests) and Perl::Tidy (loaded by the script under test); both come
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
## Summary
- `tests.yml` used `actions/checkout@v4` and `actions/setup-python@v5`, both on
  the deprecated Node 20 runtime (GitHub forces them to Node 24 with a warning
  on every run). Bump to `checkout@v5` (matches `opencode.yml`) and
  `setup-python@v6`, both Node-24 native.

## Test plan
- [x] yamllint clean
- [ ] CI green (the four jobs run with the new action versions, no Node 20 warning)