### PR TITLE
chore: resolve cryptography alert #6, add Dependabot + QA docs

### DIFF
--- a/.claude/CONVENTIONS.md
+++ b/.claude/CONVENTIONS.md
@@ -37,3 +37,9 @@ The principles below are a working subset relevant to this repository.
 - Keep the subject line under 72 characters.
 - Wrap body at 72 columns.
 - Reference issues where applicable: `Fixes #123`, `Relates to #456`.
+
+## Quality Assurance
+
+This repo's QA map — the concrete tools, commands, and a per-dimension
+status for every dimension in the global `config/claude/rules/qa.md`
+pipeline — lives in [`QA.md`](QA.md). The **qa-check** skill reads it.

--- a/.claude/QA.md
+++ b/.claude/QA.md
@@ -1,0 +1,79 @@
+# Quality Assurance
+
+**Version:** v1.0.0
+
+## Purpose
+
+This is the **repo-specific** QA doc for the dotfiles repository: the concrete
+tools, commands, and a **per-dimension status** for every dimension in the
+global `config/claude/rules/qa.md` pipeline. `qa.md` owns the dimensions,
+their ordering, and the fix/check discipline (generic); this file records what
+each dimension *is* here. The **qa-check** skill reads this doc for the
+commands.
+
+**Precedence:** `WORKFLOW.md` > `TESTS.md` > this file. Testing specifics live
+in `TESTS.md`; pre-commit policy in `config/claude/rules/pre-commit.md`; this
+file is the QA map that ties them to the global dimensions.
+
+## How QA runs here
+
+Two pre-commit configs (see `config/claude/rules/pre-commit.md`):
+
+- **Fix** — `.pre-commit-config-fix.yaml` (auto-fixers; run once as prep):
+
+  ```bash
+  pre-commit run --all-files --config .pre-commit-config-fix.yaml
+  ```
+
+- **Check** — `.pre-commit-config.yaml` (read-only gate; commit + CI):
+
+  ```bash
+  pre-commit run --all-files
+  ```
+
+CI (`.github/workflows/tests.yml`) runs on push to `master`, on PRs, and on
+manual dispatch: jobs **bats**, **perl**, **python**, **pre-commit**. The
+`master` ruleset requires **bats + perl + pre-commit** green to merge
+(squash-only).
+
+## Dimension status
+
+Every dimension from `qa.md`, with its status (**Active** / **Planned** +link
+/ **Off** +reason / **N/A**):
+
+| # | Dimension | Status | This repo |
+|---|-----------|--------|-----------|
+| 1 | Format | **Active** | `shfmt`, `yapf`, `isort`, `prettier`, `markdownlint-fix`, trailing-whitespace, end-of-file-fixer (fix config) |
+| 2 | Lint | **Active** | `shellcheck`, `yamllint`, `markdownlint`, `flake8` (check config) |
+| 3 | Type-check | **Off** | No typed source under active dev; Python `mypy`/`pyright` deferred to on-demand (`rules/python.md`). See TODO *pre-commit Phase 3*. |
+| 4 | Code smell / complexity | **Off** | `shellcheck` catches some; no dedicated bash complexity tool. Acknowledged gap, no tracked owner yet. |
+| 5 | Security | **Active (partial)** | Secrets: `gitleaks` + `detect-private-key` (check). SCA / supply-chain: Dependabot alerts + version updates (`.github/dependabot.yml`). SAST: **Planned** — TODO *trufflehog & Checkmarx*, *CodeFactor & Snyk*. DAST: **N/A** (no running service). Deeper triage → `security-scan` skill. |
+| 6 | Tests | **Active** | `bats tests/shell/test_*.bats` (gate), `prove tests/perl/`, `pytest tests/python` (self-activating). Layout/policy in `TESTS.md`. |
+| 7 | UI/UX & accessibility | **N/A** | Headless dotfiles / CLI — no UI. |
+| 8 | End-to-end | **N/A** | No application. Docker integration tests that bring up a real login shell / pwsh profile live under Tests (`TESTS.md`). |
+| 9 | Compatibility | **N/A** | No external API / data-format contracts. Cross-shell (bash + PowerShell) and the docker context matrix are exercised under Tests. |
+| 10 | Performance & load | **Off** | Not a service. Login-shell startup perf is handled ad hoc, measure-first (resolved — see `CHANGELOG.md`). |
+| 11 | Reliability & observability | **N/A** | Not a deployed service. |
+| 12 | Build | **N/A** | Nothing compiles / bundles. The test docker harness image is test infra, not a product artifact. |
+| 13 | Documentation | **Active** | `markdownlint` (prose); inline-first doc philosophy (`WORKFLOW.md`); changelog is **hand-written** (`CHANGELOG.md`). `proselint` / link-validation **Planned** — TODO *Pre-commit Phase 4*. |
+| 14 | Code review | **Active (solo)** | `master` ruleset requires a PR (no bypass) with review-thread resolution; **0 required approvals** (solo repo) — review is self-review. |
+| 15 | CI | **Active** | `tests.yml` jobs bats / perl / python / pre-commit; required checks bats + perl + pre-commit gate merges. Watch via the `ship-pr` skill's `ci-watch`. |
+
+## Optimization stance
+
+Measure first (`qa.md`): no optimization without a baseline; premature
+optimization is itself a smell. The login-shell perf work is the worked
+example — each suspect module was profiled directly (non-DEBUG) before any
+code changed (see `CHANGELOG.md`).
+
+## Notes
+
+- **Generated changelog: N/A.** `CHANGELOG.md` is maintained by hand at the
+  merge-time finalization step (`WORKFLOW.md`; ship-pr Step 4.5), not
+  generated from git history — so there is no regenerate-and-commit prep
+  action in the QA pipeline.
+- Deferred Perl QA (`perlcritic` / `perltidy`, commented in both pre-commit
+  configs) is tracked under TODO *Perl quality tooling*.
+- This doc must give **every** dimension a status; when a new dimension
+  becomes relevant (e.g. a UI is added), update its row rather than leaving
+  it silent.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+---
+# Dependabot version updates.
+#
+# Security (alert-driven) updates are enabled separately in the repo's
+# security settings; this file configures scheduled *version*-update PRs.
+# No auto-merge — Dependabot PRs land through the normal protected-master
+# flow (squash-only + required checks), reviewed/merged via the ship-pr
+# skill like any other PR.
+version: 2
+
+updates:
+  # Python tooling environment (Poetry manifest). cryptography is pinned
+  # directly in the manifest for alert #6; committing a poetry.lock so
+  # transitive deps are covered too is a tracked follow-up (see TODO.md).
+  # Dependabot's pip ecosystem updates the direct deps listed in
+  # pyproject.toml even without a committed lockfile.
+  - package-ecosystem: pip
+    directory: /config/pypoetry
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # GitHub Actions in .github/workflows — keeps actions off deprecated
+  # runtimes automatically (cf. the manual Node 20 bump in PR #101).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,3 +155,26 @@ real costs (xtrace artifacts).
 - **`tests.yml`** runs on push to `master` and on pull requests, executing
   BATS tests and running shellcheck/yamllint/markdownlint via the
   `pre-commit` job.
+
+## Planning-doc history (TODO.md)
+
+Revision history of the planning document itself, moved here from
+[`TODO.md`](TODO.md):
+
+- **v1.2.0** (2026-06-17): Merge-finalization opt-in. Pruned all completed
+  `- [x]` items (whole DONE sections: spotify-patterns, gmailctl move,
+  creds-helper fix, perl CI, login-shell perf; plus done sub-items across
+  Testing, pre-commit Phase 1/3, and CI/CD Phase 1), migrating the
+  done-work record to this changelog. Also removed the two duplicate "Bump
+  GitHub Actions off Node.js 20" sections (completed in PR #101 — verified
+  against `tests.yml`). This repo now opts in to the merge-time finalization
+  hook (see `.claude/WORKFLOW.md`), so the planning docs track only open work.
+- **v1.1.0** (2026-06-07): Cleanup pass — removed completed sections (git
+  file-mode normalization, Dependabot alerts, stale-branch cleanup, the
+  container-harness build, shell context detection, and assorted done
+  sub-items), fixed stale/contradictory statuses, deduplicated entries
+  (grok block, bash_prompt venv, parse_params), dropped stale items for
+  archived libs, and refreshed Progress Tracking + Next Actions.
+- **v1.0.0** (2026-01-18): Initial consolidated TODO based on modernization
+  plan. Documented completed tasks, organized remaining work by phase and
+  priority.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ goes green (see the merge-time finalization in
 
 ## 2026-06-17
 
+### Security
+
+- **Resolved Dependabot alert #6** (HIGH — vulnerable OpenSSL in
+  `cryptography` wheels, `< 48.0.1`). `cryptography` is a transitive dep of
+  the Poetry tool-env with no committed lockfile, so it was promoted to a
+  direct constraint `cryptography = ">=48.0.1"` in
+  `config/pypoetry/pyproject.toml`. (PR #103)
+
+### Added
+
+- **`.github/dependabot.yml`** — weekly version-update PRs for the pip
+  (Poetry) and github-actions ecosystems; no auto-merge (PRs land via the
+  normal protected-master flow). (PR #103)
+- **`.claude/QA.md`** — repo QA doc mapping every dimension in the global
+  `rules/qa.md` pipeline to this repo with an explicit status and the
+  concrete commands; pointer added from `.claude/CONVENTIONS.md`. (PR #103)
+
 ### Changed
 
 - **Bumped GitHub Actions off Node.js 20** — `actions/checkout@v4` → `@v5`

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,18 @@ follow-up remains:
 - [ ] Confirm Dependabot / auto-merge interplay once a Dependabot PR appears
   (squash-only + required checks — ensure auto-merge still completes).
 
+## 📦 Commit a poetry.lock for the Poetry tool-env (MEDIUM PRIORITY)
+
+`config/pypoetry/pyproject.toml` has no committed `poetry.lock`, so transitive
+dependencies aren't pinned and Dependabot can't open security-update PRs for
+them. Alert #6 (`cryptography`) was remediated with a **direct** pin in the
+manifest instead; per `rules/poetry.md` the lockfile MUST be committed.
+
+- [ ] Generate and commit `config/pypoetry/poetry.lock` (resolving
+  `cryptography >= 48.0.1`) so transitive deps are pinned and Dependabot
+  security updates can cover them. Larger change than the direct pin — its
+  own fix.
+
 ## 🧭 Explore other GitHub rulesets (LOW PRIORITY)
 
 We use a single branch ruleset (protect master). Survey what else rulesets
@@ -1116,27 +1128,6 @@ in the future.
 - Code improvements and config enhancements are cataloged but can be addressed
   opportunistically
 - Template creation is extensive future work, deferred for now
-
-## Version History
-
-- **v1.2.0** (2026-06-17): Merge-finalization opt-in. Pruned all completed
-  `- [x]` items (whole DONE sections: spotify-patterns, gmailctl move,
-  creds-helper fix, perl CI, login-shell perf; plus done sub-items across
-  Testing, pre-commit Phase 1/3, and CI/CD Phase 1), migrating the
-  done-work record to the new [`CHANGELOG.md`](CHANGELOG.md). Also removed
-  the two duplicate "Bump GitHub Actions off Node.js 20" sections (completed
-  in PR #101 — verified against `tests.yml`). This repo now opts in to the
-  merge-time finalization hook (see `WORKFLOW.md`), so the planning docs
-  track only open work.
-- **v1.1.0** (2026-06-07): Cleanup pass — removed completed sections (git
-  file-mode normalization, Dependabot alerts, stale-branch cleanup, the
-  container-harness build, shell context detection, and assorted done
-  sub-items), fixed stale/contradictory statuses, deduplicated entries
-  (grok block, bash_prompt venv, parse_params), dropped stale items for
-  archived libs, and refreshed Progress Tracking + Next Actions.
-- **v1.0.0** (2026-01-18): Initial consolidated TODO based on modernization
-  plan. Documented completed tasks, organized remaining work by phase and
-  priority.
 
 ## References
 

--- a/TODO.md
+++ b/TODO.md
@@ -209,6 +209,50 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
 
+## 📓 Add a global `rules/dependabot.md` (MEDIUM PRIORITY)
+
+Authoring `.github/dependabot.yml` (the Dependabot setup / *Commit a
+poetry.lock* item) surfaced that Dependabot has no
+`config/claude/rules/<tool>.md`, which `CLAUDE.md` *Missing or Conflicting
+Tool Rules* says to fill. Dependabot is repo-agnostic → a **tier-1 (global)**
+rule.
+
+- [ ] Write `config/claude/rules/dependabot.md` covering: the `dependabot.yml`
+  v2 schema essentials (`package-ecosystem`, `directory` / `directories`,
+  `schedule.interval`, `groups`, `commit-message`,
+  `open-pull-requests-limit`); the pip/Poetry gotcha (transitive-dep security
+  updates need a committed lockfile; direct deps update without one); the
+  no-auto-merge default (PRs land via `ship-pr`); and conventional-commit
+  prefixing. Ecosystems in use here: pip + github-actions.
+- [ ] **Cross-cutting fix to the rule/skill-authoring guidance** — whatever
+  governs creating rules/skills (`config/claude/EXTENDING.md`,
+  `config/claude/CLAUDE.md`, `config/claude/rule-TEMPLATE.md`) should state,
+  among its authoring steps, that a new rule/skill must **consult official
+  documentation first**, and **also** any **man page or other local
+  documentation installed by the package** (`man <tool>`, `<tool> --help`,
+  `/usr/share/doc/<pkg>`, …) — not memory. Add it once to the canonical
+  authoring doc and reference it; don't duplicate.
+
+## 🧰 Extract `config/claude/` into its own generic repo (MEDIUM PRIORITY)
+
+The agent config under `config/claude/` (rules, skills, `CLAUDE.md`,
+`EXTENDING.md`, hooks, …) is language- and repo-agnostic and is consumed by
+every project, not just dotfiles. Move it to a standalone repo so it can be
+shared/versioned independently and carries **no dotfiles-specific references**
+(generic — no mention of "dotfiles").
+
+- [ ] **Check first whether such a repo already exists** before creating one —
+  scan sibling clones under `$PROJECTS_DIR` and `gh repo list` (candidates to
+  rule out: `newdotfiles`, `gollum-config`). As of 2026-06-17 no dedicated
+  agent-config repo was found.
+- [ ] Carve `config/claude/` out into the standalone repo; scrub
+  dotfiles-specific wording so the content reads generically.
+- [ ] Decide how dotfiles (and other repos) consume it — submodule, sibling
+  clone, or symlink into `$CLAUDE_CONFIG_DIR` — and update the deploy/symlink
+  steps and any hardcoded paths.
+- [ ] Reconcile with the "Break tmux config into its own repo" item (same
+  extraction question: submodule vs sibling).
+
 ## 🔗 docker_wrapper Symlink Automation (MEDIUM PRIORITY)
 
 `bin/docker_wrapper` is a multi-call dispatcher: each tool is a `bin/<tool>`

--- a/config/pypoetry/pyproject.toml
+++ b/config/pypoetry/pyproject.toml
@@ -11,3 +11,7 @@ python = "3.12.3"
 poetry = "2.3.4"
 idna = ">=3.15"
 dulwich = ">=1.2.5"
+# Pin to resolve Dependabot alert #6 (GHSA — vulnerable OpenSSL in
+# cryptography wheels, < 48.0.1). Promoted from a transitive dep to a
+# direct constraint so it can be remediated without a committed lockfile.
+cryptography = ">=48.0.1"


### PR DESCRIPTION
## Summary
- **Security:** pin `cryptography >= 48.0.1` to resolve Dependabot alert #6
  (HIGH — vulnerable OpenSSL in cryptography wheels). It's a transitive dep
  of the Poetry tool-env with no committed lockfile, so it's promoted to a
  direct constraint in `config/pypoetry/pyproject.toml`.
- **Dependabot:** add `.github/dependabot.yml` — weekly version updates for
  pip (Poetry) + github-actions, no auto-merge (PRs land via ship-pr).
- **QA doc:** add `.claude/QA.md` mapping every `rules/qa.md` dimension to
  this repo with a status (Active/Planned/Off/N/A) + commands; pointer from
  `CONVENTIONS.md`.
- **Docs housekeeping:** move TODO `Version History` into `CHANGELOG.md`;
  add TODOs for a global `rules/dependabot.md` (with a rule-authoring
  doc-sourcing check) and for extracting `config/claude/` into its own
  generic repo; track committing a `poetry.lock` for transitive-dep coverage.

## Test plan
- [x] `pre-commit run --all-files` (check config) green repo-wide.
- [x] `yamllint` + `check-yaml` validate `.github/dependabot.yml`; schema
  verified against GitHub's dependabot.yml docs.
- [x] 78-col prose audit clean for all authored lines.
- [ ] CI green (bats + perl + python + pre-commit).
- [ ] Alert #6 auto-clears after merge + Dependabot rescan.