### PR TITLE
fix(deps): full dependabot coverage (docker, groups); rule v1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@
 # security settings; this file configures scheduled *version*-update PRs.
 # No auto-merge — Dependabot PRs land through the normal protected-master
 # flow (squash-only + required checks), reviewed/merged via the ship-pr
-# skill like any other PR.
+# skill like any other PR. Conventions per config/claude/rules/dependabot.md:
+# cover every shipped manifest (incl. docker + github-actions), schedule
+# weekly, group minor/patch (majors stay individual), conventional commits.
 version: 2
 
 updates:
@@ -21,11 +23,40 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   # GitHub Actions in .github/workflows — keeps actions off deprecated
   # runtimes automatically (cf. the manual Node 20 bump in PR #101).
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Docker base-image (FROM) pins in the repo's own Dockerfiles. The
+  # vendored Dockerfiles under config/coc/.../node_modules and the plugin
+  # marketplace are third-party and are not covered here.
+  - package-ecosystem: docker
+    directory: /tests/docker
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: docker
+    directory: /config/nvm
     schedule:
       interval: weekly
     commit-message:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ goes green (see the merge-time finalization in
 
 ### Changed
 
+- **Conformed `.github/dependabot.yml` to its rule** — added `docker`
+  entries for the repo's own Dockerfiles (`/tests/docker`, `/config/nvm`)
+  and grouped minor/patch updates per ecosystem for pip + github-actions
+  (majors stay individual). Updated `config/claude/rules/dependabot.md` to
+  v1.1.0 with a doc-consultation authoring instruction (check the rule
+  exists, consult official docs, verify ecosystem constraints — not memory).
+  (PR #106)
 - **Bumped GitHub Actions off Node.js 20** — `actions/checkout@v4` → `@v5`
   (×4) and `actions/setup-python@v5` → `@v6` (×2) in
   `.github/workflows/tests.yml`, clearing the Node 20 deprecation warnings

--- a/TODO.md
+++ b/TODO.md
@@ -209,29 +209,26 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
 
-## 📓 Add a global `rules/dependabot.md` (MEDIUM PRIORITY)
+## 📓 Rule/skill-authoring doc-sourcing; evaluate a Dependabot skill (MEDIUM PRIORITY)
 
-Authoring `.github/dependabot.yml` (the Dependabot setup / *Commit a
-poetry.lock* item) surfaced that Dependabot has no
-`config/claude/rules/<tool>.md`, which `CLAUDE.md` *Missing or Conflicting
-Tool Rules* says to fill. Dependabot is repo-agnostic → a **tier-1 (global)**
-rule.
+`config/claude/rules/dependabot.md` already exists (since 2026-06-03) and now
+carries a doc-consultation instruction (v1.1.0). What remains is cross-cutting:
 
-- [ ] Write `config/claude/rules/dependabot.md` covering: the `dependabot.yml`
-  v2 schema essentials (`package-ecosystem`, `directory` / `directories`,
-  `schedule.interval`, `groups`, `commit-message`,
-  `open-pull-requests-limit`); the pip/Poetry gotcha (transitive-dep security
-  updates need a committed lockfile; direct deps update without one); the
-  no-auto-merge default (PRs land via `ship-pr`); and conventional-commit
-  prefixing. Ecosystems in use here: pip + github-actions.
-- [ ] **Cross-cutting fix to the rule/skill-authoring guidance** — whatever
-  governs creating rules/skills (`config/claude/EXTENDING.md`,
-  `config/claude/CLAUDE.md`, `config/claude/rule-TEMPLATE.md`) should state,
-  among its authoring steps, that a new rule/skill must **consult official
-  documentation first**, and **also** any **man page or other local
-  documentation installed by the package** (`man <tool>`, `<tool> --help`,
-  `/usr/share/doc/<pkg>`, …) — not memory. Add it once to the canonical
+- [ ] **Rule/skill-authoring must source docs** — whatever governs creating
+  rules/skills (`config/claude/EXTENDING.md`, `config/claude/CLAUDE.md`,
+  `config/claude/rule-TEMPLATE.md`) should state that a new rule/skill must
+  first **check whether the rule already exists**, **consult official
+  documentation**, and refer to any **man page / local package-installed
+  docs** (`man <tool>`, `<tool> --help`, `/usr/share/doc/<pkg>`) — not memory.
+  Motivating incident: a `dependabot.yml` was authored on the false premise
+  that `rules/dependabot.md` didn't exist (it did). Add once to the canonical
   authoring doc and reference it; don't duplicate.
+- [ ] **Evaluate a `dependabot` skill** — a forcing function that scans the
+  repo for every manifest / Dockerfile / workflow, consults current official
+  docs, generates/reconciles `dependabot.yml` to full coverage + conventions
+  (per `rules/dependabot.md`), and verifies (yamllint). Decide scope vs the
+  existing `security-scan` skill (which *triages* Dependabot findings) — setup
+  vs triage; avoid duplication (Rule of Three).
 
 ## 🧰 Extract `config/claude/` into its own generic repo (MEDIUM PRIORITY)
 

--- a/config/claude/rules/dependabot.md
+++ b/config/claude/rules/dependabot.md
@@ -6,7 +6,7 @@ paths:
 
 # Dependabot Rules
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 Dependabot (native GitHub) opens PRs for dependency and version updates. It
 is the **durable** counterpart to scanning: scanners (trivy, semgrep) find
@@ -48,6 +48,13 @@ the language deps — gaps are where drift hides:
 
 ## Agent Behavior
 
+- **Before** authoring or editing `dependabot.yml`, confirm whether this rule
+  and config already exist, then **consult the current official Dependabot
+  documentation** (configuration options + ecosystem support) and verify
+  ecosystem-specific constraints — do not rely on memory; schema keys and
+  supported ecosystems change. Concrete gotcha: Poetry **security** updates
+  for *transitive* deps need a committed `poetry.lock`; without one, promote
+  the dep to a **direct** constraint as the workaround.
 - When adding or editing `dependabot.yml`, ensure **all** manifests are
   covered, including `docker` and `github-actions`.
 - Reviewing Dependabot PRs: a green grouped minor/patch PR is normally safe


### PR DESCRIPTION
## Summary
- Reconcile `.github/dependabot.yml` with `config/claude/rules/dependabot.md`
  (which already existed) — the initial config under-covered:
  - add `docker` entries for the repo's own Dockerfiles (`/tests/docker`,
    `/config/nvm`); vendored/third-party Dockerfiles excluded;
  - group minor/patch updates per ecosystem for pip + github-actions
    (majors stay individual).
- `config/claude/rules/dependabot.md` → **v1.1.0**: add an Agent-Behavior
  instruction to check whether the rule already exists, consult current
  official Dependabot docs, and verify ecosystem constraints (e.g. Poetry
  transitive-dep security updates need a committed lockfile) before
  authoring/editing the config — not memory.
- `TODO.md`: drop the stale "write rules/dependabot.md" item (it exists),
  keep the cross-cutting rule-authoring doc-sourcing item, and add a
  "evaluate a dependabot skill" item (scope vs `security-scan`).

## Test plan
- [x] `pre-commit` fix + check green on changed files.
- [x] `yamllint` validates `.github/dependabot.yml`; structure verified
  (pip + github-actions grouped; docker x2).
- [ ] CI green (bats + perl + python + pre-commit).