### PR TITLE
feat(hooks): block edits on a protected branch (PreToolUse)

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Repository Workflow
 
-**Version:** v1.1.0
+**Version:** v1.2.0
 
 ## Purpose
 
@@ -150,6 +150,11 @@ advisory — the remote enforces it:
 * A local `no-commit-to-branch` pre-commit hook also blocks a direct commit
   to `master` at commit time (early guard; the server ruleset is what
   actually enforces it). See `config/claude/rules/git.md`.
+* The global `branch-protection.py` `PreToolUse` hook blocks an agent
+  `Edit`/`Write`/`MultiEdit` while `master` is checked out — the earliest
+  guard, at edit time. It derives the protected branch from the
+  `no-commit-to-branch` args above, so this repo activates it automatically.
+  See `config/claude/rules/git.md` *Protecting the Default Branch*.
 
 To change the ruleset, edit the JSON and re-apply with the OAuth token (the
 narrow PAT lacks admin):
@@ -263,7 +268,7 @@ See individual tool configurations for additional variables.
 ### Versioning
 
 * `CLAUDE.md` - Versioned (see that file)
-* `WORKFLOW.md` - Versioned (this file, v1.1.0)
+* `WORKFLOW.md` - Versioned (this file, v1.2.0)
 * `TESTS.md` - Versioned (see that file)
 * `.claude/rules/*.md` - Individual versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ goes green (see the merge-time finalization in
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 
+## 2026-06-18
+
+### Added
+
+- **`config/claude/hooks/branch-protection.py`** — a `PreToolUse` hook on
+  `Edit`/`Write`/`MultiEdit` that blocks an agent edit while a protected
+  branch is checked out, enforcing git.md's "Never Work Directly on a
+  Protected Branch" at edit time (the earliest of three layers, below the
+  commit-time `no-commit-to-branch` hook and the push-time server ruleset).
+  It reads the protected set from the repo's `no-commit-to-branch` args, so
+  it activates only where that hook is configured (silent in repos without
+  it, e.g. cloned upstreams/forks); plan-mode edits are whitelisted and any
+  error fails safe. Wired into `settings.json`, covered by
+  `tests/python/test_branch_protection.py` (the first python test, which
+  self-activates the python CI job). (PR #108)
+
+### Changed
+
+- **Documented the edit-time protection layer** — `config/claude/rules/git.md`
+  now describes **three** protection layers (v1.6.0) and `.claude/WORKFLOW.md`
+  notes the hook for `master` (v1.2.0). (PR #108)
+
 ## 2026-06-17
 
 ### Security

--- a/config/claude/hooks/branch-protection.py
+++ b/config/claude/hooks/branch-protection.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+"""PreToolUse hook: block file edits while a protected branch is checked out.
+
+Fires on `Edit` / `Write` / `MultiEdit`. Enforces git.md's "Never Work
+Directly on a Protected Branch" at *edit time* — the earliest of the three
+layers, below the commit-time `no-commit-to-branch` pre-commit hook and the
+push-time server ruleset. It stops the slip before the first character is
+written: branch first, then edit.
+
+**Detection is the repo's own declaration, not a guess.** A repo is treated as
+protecting a branch only when its `.pre-commit-config.yaml` configures the
+`no-commit-to-branch` hook; the protected set is read straight from that
+hook's `--branch` args (single source of truth, matching git.md's "a local
+`no-commit-to-branch` hook names it"). Consequences:
+
+  - On a protected branch in such a repo → **block** the edit, naming the
+    branch and suggesting the working-branch command.
+  - On any other branch, or in a repo with no `no-commit-to-branch` hook →
+    **allow** silently.
+
+**Known limitation (foreign / forked repos):** this leans on pre-commit being
+installed and configured. A cloned upstream or third-party repo that has no
+`.pre-commit-config.yaml` (or no `no-commit-to-branch` hook) gets no edit-time
+guard here — the agent's git.md discipline and the server ruleset still apply.
+Revisit if that gap bites in practice.
+
+Edits to a plan file (`.../claude/plans/...`) are always allowed, so plan mode
+is never blocked.
+
+Fail-safe: any error exits 0 silently so a hook bug can never block editing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The pre-commit hook id whose presence declares branch protection, and the
+# id line that marks its entry in `.pre-commit-config.yaml`.
+GUARD_HOOK_ID = "no-commit-to-branch"
+ID_RE = re.compile(r"-\s*id:\s*" + re.escape(GUARD_HOOK_ID) + r"\s*$")
+
+# A line that starts the next hook/repo entry — the boundary of the guard
+# hook's own config block when scanning for its args.
+NEXT_ENTRY_RE = re.compile(r"-\s*(?:id|repo):")
+
+# no-commit-to-branch's default protected branches when invoked with no
+# `--branch` args; union with the repo's derived default branch for safety.
+DEFAULT_PROTECTED = {"master", "main"}
+
+
+def _emit(decision: str | None, message: str) -> None:
+  out: dict = {"hookEventName": "PreToolUse"}
+  if decision:
+    out["permissionDecision"] = decision
+    out["permissionDecisionReason"] = message
+  else:
+    out["additionalContext"] = message
+  print(json.dumps({"hookSpecificOutput": out}))
+
+
+def _git(repo: Path, *args: str) -> str | None:
+  """Run a git command in `repo`; return stripped stdout, or None on error."""
+  try:
+    res = subprocess.run(
+      ["git", "-C", str(repo), *args],
+      capture_output=True,
+      text=True,
+      timeout=5,
+    )
+  except Exception:
+    return None
+  if res.returncode != 0:
+    return None
+  return res.stdout.strip()
+
+
+def _existing_ancestor(path: Path) -> Path | None:
+  """Nearest existing directory at or above `path` (a Write target may not
+  exist yet, but its parent does)."""
+  cur = path if path.is_dir() else path.parent
+  for p in (cur, *cur.parents):
+    if p.is_dir():
+      return p
+  return None
+
+
+def _repo_root(path: Path) -> Path | None:
+  """The git work-tree root containing `path`, or None if not in a repo."""
+  anchor = _existing_ancestor(path)
+  if anchor is None:
+    return None
+  top = _git(anchor, "rev-parse", "--show-toplevel")
+  return Path(top) if top else None
+
+
+def _default_branch(repo: Path) -> str | None:
+  """The repo's default branch from the local symbolic ref (no network)."""
+  ref = _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD")
+  if not ref:
+    return None
+  return ref.rsplit("/", 1)[-1] or None
+
+
+def _protected_branches(repo: Path) -> set[str] | None:
+  """Branches the repo declares protected via no-commit-to-branch, or None
+  when the hook isn't configured (no protection signal → don't enforce)."""
+  cfg = repo / ".pre-commit-config.yaml"
+  try:
+    lines = cfg.read_text(encoding="utf-8").splitlines()
+  except Exception:
+    return None
+
+  # Find the guard hook's `- id: no-commit-to-branch` line, then collect the
+  # tokens of its config block (up to the next hook/repo entry).
+  start = next((i for i, ln in enumerate(lines) if ID_RE.search(ln)), None)
+  if start is None:
+    return None
+
+  block: list[str] = []
+  for ln in lines[start + 1:]:
+    if NEXT_ENTRY_RE.search(ln):
+      break
+    block.append(ln)
+
+  # Tokenize the block, then read the value after each --branch / -b flag.
+  tokens = re.split(r"[\s,\[\]]+", " ".join(block))
+  branches: set[str] = set()
+  i = 0
+  while i < len(tokens):
+    tok = tokens[i]
+    if tok in ("--branch", "-b"):
+      if i + 1 < len(tokens) and tokens[i + 1]:
+        branches.add(tokens[i + 1])
+      i += 2
+      continue
+    if tok.startswith("--branch="):    # `--branch=master` form
+      branches.add(tok.split("=", 1)[1])
+    i += 1
+
+  if branches:
+    return branches
+
+  # Hook present but no explicit branches: mirror its defaults, plus the
+  # repo's actual default branch.
+  protected = set(DEFAULT_PROTECTED)
+  default = _default_branch(repo)
+  if default:
+    protected.add(default)
+  return protected
+
+
+def main() -> int:
+  try:
+    event = json.load(sys.stdin)
+  except Exception:
+    return 0
+
+  if event.get("tool_name") not in ("Edit", "Write", "MultiEdit"):
+    return 0
+
+  file_path = (event.get("tool_input") or {}).get("file_path")
+  if not file_path:
+    return 0
+
+  # Plan-mode edits land in a claude plans dir — never block those.
+  if "/claude/plans/" in file_path.replace("\\", "/"):
+    return 0
+
+  project_dir = (
+    os.environ.get("CLAUDE_PROJECT_DIR") or event.get("cwd") or os.getcwd()
+  )
+  target = Path(file_path)
+  if not target.is_absolute():
+    target = Path(project_dir) / target
+
+  repo = _repo_root(target)
+  if repo is None:
+    return 0  # not in a git repo → nothing to protect
+
+  protected = _protected_branches(repo)
+  if not protected:
+    return 0  # repo declares no protected branch (e.g. foreign/forked repo)
+
+  branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+  if not branch or branch == "HEAD":
+    return 0  # detached HEAD or unreadable → don't enforce
+
+  if branch in protected:
+    default = _default_branch(repo) or branch
+    _emit(
+      "deny",
+      f"Edit blocked — you're on protected branch '{branch}' in "
+      f"{repo.name}. This repo protects it (no-commit-to-branch in "
+      ".pre-commit-config.yaml), and git.md's \"Never Work Directly on a "
+      "Protected Branch\" forbids authoring here. Branch FIRST, then edit:\n\n"
+      f"  git switch -c <type>/<name> origin/{default}   "
+      "# feature/ | bugfix/ | docs/\n\n"
+      "Uncommitted changes carry across the switch, so create the branch and "
+      "retry the edit. This hook fails safe.",
+    )
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.5.0
+**Version:** v1.6.0
 
 ## Commit Messages
 
@@ -57,15 +57,16 @@ and then `git remote set-head origin <branch>` to cache it.
 
 ## Protecting the Default Branch
 
-When a repo's default branch should be PR-only, protect it in **two layers**
-— the server enforces it, the local hook catches mistakes earlier:
+When a repo's default branch should be PR-only, protect it in **three layers**
+— the server enforces it; two local guards catch mistakes earlier, at commit
+time and edit time:
 
 1. **Server-side ruleset / branch protection** (authoritative): require PRs,
    required status checks, and block deletion + force-push. This is what
    actually rejects a direct push. Apply it via the host's API (GitHub
    rulesets need an admin/OAuth token, not a narrow PAT).
-2. **Local `no-commit-to-branch` pre-commit hook** (early guard): add the
-   `no-commit-to-branch` hook (from `pre-commit/pre-commit-hooks`) to the
+2. **Local `no-commit-to-branch` pre-commit hook** (commit-time guard): add
+   the `no-commit-to-branch` hook (from `pre-commit/pre-commit-hooks`) to the
    check config so a direct commit on the protected branch fails *before* the
    push is even attempted:
 
@@ -74,8 +75,18 @@ When a repo's default branch should be PR-only, protect it in **two layers**
      args: [--branch, <default-branch>]
    ```
 
-The local hook is a convenience, not a substitute — without the server-side
-ruleset, anyone (or any tool) without the hook installed can still push. The
+3. **Edit-time Claude Code hook** (earliest, agent-only): the global
+   `branch-protection.py` `PreToolUse` hook blocks an `Edit`/`Write`/
+   `MultiEdit` while a protected branch is checked out, so the agent is told
+   to branch *before* writing the first character. It reads the protected set
+   straight from the repo's `no-commit-to-branch` args (layer 2), so it
+   activates **only where that hook is configured** — a repo without it (a
+   cloned upstream/fork) gets no edit-time guard. It is a backstop for the
+   agent, not a constraint on a human editor, and fails safe (any error
+   allows the edit).
+
+The local guards are conveniences, not substitutes — without the server-side
+ruleset, anyone (or any tool) without the hooks installed can still push. The
 repo's concrete ruleset/config lives in its `.claude/` docs.
 
 ## Never Work Directly on a Protected Branch
@@ -97,7 +108,9 @@ the change is committed where it must never land).
 To tell whether a branch is protected: a server-side ruleset / branch
 protection, a local `no-commit-to-branch` hook (above), or the repo's
 `.claude/` docs name it. When in doubt, treat the default branch as
-protected.
+protected. In a repo that configures `no-commit-to-branch`, the edit-time
+`branch-protection.py` hook enforces this rule for the agent automatically
+(see *Protecting the Default Branch*).
 
 ## Worktrees
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -11,6 +11,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/branch-protection.py",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/python/test_branch_protection.py
+++ b/tests/python/test_branch_protection.py
@@ -1,0 +1,137 @@
+"""Tests for the branch-protection PreToolUse hook.
+
+Runs the hook as a subprocess (the way Claude Code invokes it) against
+throwaway git repos, asserting it blocks edits on a declared-protected branch
+and stays silent everywhere else. See the hook under config/claude/hooks/.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "config" / "claude" / "hooks" / "branch-protection.py"
+
+# A .pre-commit-config.yaml that protects `master` via no-commit-to-branch.
+PROTECT_MASTER = (
+  "repos:\n"
+  "  - repo: https://github.com/pre-commit/pre-commit-hooks\n"
+  "    rev: v6.0.0\n"
+  "    hooks:\n"
+  "      - id: no-commit-to-branch\n"
+  "        args: [--branch, master]\n"
+  "      - id: check-yaml\n"
+)
+
+# Same hook but with no args — exercises the default-protected fallback.
+PROTECT_DEFAULTS = (
+  "repos:\n"
+  "  - repo: https://github.com/pre-commit/pre-commit-hooks\n"
+  "    rev: v6.0.0\n"
+  "    hooks:\n"
+  "      - id: no-commit-to-branch\n"
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+  subprocess.run(
+    ["git", "-C", str(repo), *args],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+
+
+def _make_repo(tmp_path: Path, branch: str, config: str | None) -> Path:
+  """A git repo on `branch` with one commit, optionally carrying a
+  pre-commit config."""
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  _git(repo, "init", "-q", "-b", branch)
+  _git(
+    repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+    "--allow-empty", "-m", "init"
+  )
+  if config is not None:
+    (repo / ".pre-commit-config.yaml").write_text(config, encoding="utf-8")
+  return repo
+
+
+def _run(tool_input_path: str, cwd: str, tool: str = "Write") -> dict:
+  """Invoke the hook with a crafted event; return parsed JSON (or {} when the
+  hook emits nothing, i.e. allows)."""
+  event = {
+    "tool_name": tool,
+    "tool_input": {
+      "file_path": tool_input_path
+    },
+    "cwd": cwd,
+  }
+  res = subprocess.run(
+    ["python3", str(HOOK)],
+    input=json.dumps(event),
+    capture_output=True,
+    text=True,
+  )
+  assert res.returncode == 0, res.stderr    # always fail-safe exit 0
+  out = res.stdout.strip()
+  return json.loads(out) if out else {}
+
+
+def _is_deny(out: dict) -> bool:
+  return out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+
+def test_blocks_edit_on_protected_master(tmp_path):
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  out = _run(str(repo / "foo.txt"), str(repo))
+  assert _is_deny(out)
+  assert "master" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_blocks_edit_for_not_yet_created_file(tmp_path):
+  # A Write to a new path (nonexistent file/dir) must still resolve the repo.
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  out = _run(str(repo / "newdir" / "new.txt"), str(repo))
+  assert _is_deny(out)
+
+
+def test_blocks_on_default_branch_when_hook_has_no_args(tmp_path):
+  repo = _make_repo(tmp_path, "main", PROTECT_DEFAULTS)
+  out = _run(str(repo / "foo.txt"), str(repo))
+  assert _is_deny(out)
+
+
+def test_allows_edit_on_working_branch(tmp_path):
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  _git(repo, "switch", "-q", "-c", "docs/x")
+  out = _run(str(repo / "foo.txt"), str(repo))
+  assert out == {}
+
+
+def test_allows_when_repo_declares_no_protection(tmp_path):
+  # Foreign / forked repo with no no-commit-to-branch hook → no signal.
+  repo = _make_repo(tmp_path, "master", config=None)
+  out = _run(str(repo / "foo.txt"), str(repo))
+  assert out == {}
+
+
+def test_allows_plan_files_even_on_protected_branch(tmp_path):
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  plan = repo / "config" / "claude" / "plans" / "p.md"
+  out = _run(str(plan), str(repo))
+  assert out == {}
+
+
+def test_allows_outside_any_git_repo(tmp_path):
+  out = _run(str(tmp_path / "loose.txt"), str(tmp_path))
+  assert out == {}
+
+
+@pytest.mark.parametrize("tool", ["Bash", "Read", "Grep"])
+def test_ignores_non_edit_tools(tmp_path, tool):
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  out = _run(str(repo / "foo.txt"), str(repo), tool=tool)
+  assert out == {}


### PR DESCRIPTION
## Summary
- Add `config/claude/hooks/branch-protection.py`, a `PreToolUse` hook on
  `Edit`/`Write`/`MultiEdit` that **denies** an edit while a protected branch
  is checked out — enforcing git.md's "Never Work Directly on a Protected
  Branch" at edit time. This is the earliest of three layers, below the
  commit-time `no-commit-to-branch` hook and the push-time server ruleset.
- **Detection is the repo's own declaration**: the protected set is read from
  the `no-commit-to-branch` args in `.pre-commit-config.yaml`, so the hook
  activates only where that hook is configured and stays silent elsewhere
  (e.g. cloned upstreams/forks — a noted limitation). Plan-mode edits under
  `.../claude/plans/` are whitelisted; any error fails safe (allows the edit).
- Wire it into `settings.json`; add a pytest suite (first
  `tests/python/test_*.py`, which self-activates the non-required python CI
  job); update the protection docs (`git.md` → three layers, v1.6.0;
  `WORKFLOW.md`, v1.2.0).

## Test plan
- [ ] `pytest tests/python/test_branch_protection.py` — 10 tests: deny on
  protected master/main (existing + not-yet-created file paths, no-args
  defaults), allow on a working branch, allow in a repo with no
  `no-commit-to-branch`, allow for plan files, allow outside a repo, ignore
  non-edit tools.
- [ ] `pre-commit run --files <changed>` — check-only hooks pass
  (isort/yapf/flake8/markdownlint/check-json).
- [ ] Note: the hook only goes live after merge + redeploy to `~/.claude/`.