### PR TITLE
Replace marketplace plugins + context7→mymcp; workflow tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,45 @@ goes green (see the merge-time finalization in
   error fails safe. Wired into `settings.json`, covered by
   `tests/python/test_branch_protection.py` (the first python test, which
   self-activates the python CI job). (PR #108)
+- **`config/claude/skills/retrospective/`** — a pre-merge skill (wired as
+  ship-pr Step 4.6) that reflects on friction with the agent's own tooling
+  (rules / skills / hooks / patterns / commands / MCP) and captures each
+  finding as a detailed TODO, routed global vs repo-local. Idea borrowed from
+  the dropped claude-md-management plugin. (PR #109)
+- **Grounding & sourcing authoring rule** — `EXTENDING.md` now requires a new
+  or edited rule/skill to be grounded in official docs / man pages (not
+  memory) and to cite the source; `rule-TEMPLATE.md` gains a **Sources** slot
+  and `CLAUDE.md` a pointer. (PR #109)
+- **`claude-audit` cross-impact + grounding lenses** — when changing / moving
+  / deleting an artifact, grep for referrers and fix/flag the ripple; and flag
+  rules/skills that assert a tool's behaviour with no cited source. (PR #109)
+- **Mark-as-you-go tracking rule** (`git.md` v1.7.0) — mark a `TODO`/`ROADMAP`
+  item `[x]` in the commit that completes it, so merge-time finalization is a
+  mechanical prune. Placed in always-on `git.md` so it is in context at every
+  commit (a skill at PR-end cannot be). (PR #109)
 
 ### Changed
 
 - **Documented the edit-time protection layer** — `config/claude/rules/git.md`
   now describes **three** protection layers (v1.6.0) and `.claude/WORKFLOW.md`
   notes the hook for `master` (v1.2.0). (PR #108)
+- **context7 MCP: marketplace plugin → `mymcp`** — `bin/mymcp` gained a
+  `context7` case that reads the API key from the private store and passes
+  `CONTEXT7_API_KEY`; the global export was removed from `api-keys.cfg`.
+  Registered globally at user scope (`claude mcp add context7 --scope user --
+  mymcp context7`); verified via the MCP `initialize` handshake (Context7
+  v3.2.1). (PR #109)
+- **Kept `skill-creator` and put it to work** — the one non-redundant
+  marketplace plugin; wired into `claude-audit` (the skills dimension) and
+  `EXTENDING.md` (use it when authoring a skill). (PR #109)
+
+### Removed
+
+- **Four redundant marketplace plugins** — `claude-code-setup`,
+  `claude-md-management`, `hookify` (+ ICEBOX: revisit a declarative guard
+  engine only on Rule-of-Three), and `ralph-loop` (+ ICEBOX: extend `/loop`,
+  don't rebuild). `enabledPlugins` 6 → 1; per-plugin rationale in
+  `SETUP-AUDIT.md`. (PR #109)
 
 ## 2026-06-17
 

--- a/TODO.md
+++ b/TODO.md
@@ -233,15 +233,13 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
 `config/claude/rules/dependabot.md` already exists (since 2026-06-03) and now
 carries a doc-consultation instruction (v1.1.0). What remains is cross-cutting:
 
-- [ ] **Rule/skill-authoring must source docs** — whatever governs creating
-  rules/skills (`config/claude/EXTENDING.md`, `config/claude/CLAUDE.md`,
-  `config/claude/rule-TEMPLATE.md`) should state that a new rule/skill must
-  first **check whether the rule already exists**, **consult official
-  documentation**, and refer to any **man page / local package-installed
-  docs** (`man <tool>`, `<tool> --help`, `/usr/share/doc/<pkg>`) — not memory.
-  Motivating incident: a `dependabot.yml` was authored on the false premise
-  that `rules/dependabot.md` didn't exist (it did). Add once to the canonical
-  authoring doc and reference it; don't duplicate.
+- [x] **Rule/skill-authoring must source docs** — codified in `EXTENDING.md`
+  (*Grounding & sourcing*, canonical): check the artifact doesn't already
+  exist, then ground it in official docs / man page / local package docs (not
+  memory) and cite the source (rule *Sources* section — added to
+  `rule-TEMPLATE.md`; skill `SOURCE.md`). Referenced from `CLAUDE.md` (*Missing
+  or Conflicting Tool Rules*); `/claude-audit` gained a grounding lens to
+  catch ungrounded artifacts. Added once + referenced, not duplicated.
 - [ ] **Evaluate a `dependabot` skill** — a forcing function that scans the
   repo for every manifest / Dockerfile / workflow, consults current official
   docs, generates/reconciles `dependabot.yml` to full coverage + conventions

--- a/TODO.md
+++ b/TODO.md
@@ -72,14 +72,17 @@ Replace these installed plugins with rules/skills that live in our own
 workflow), so we own and version the behaviour instead of depending on
 external marketplace plugins:
 
-- [ ] **claude-code-setup** (`claude-automation-recommender` skill).
-- [ ] **claude-md-management** (`claude-md-improver` + `revise-claude-md`
-  skills) — overlaps our existing CLAUDE.md/rules discipline; reconcile.
-- [ ] **hookify** (skills + `conversation-analyzer` agent + the hook
-  machinery) — our hooks live under `~/.claude/hooks/`; decide what carries
-  over.
-- [ ] **ralph-loop** (`ralph-loop` / `cancel-ralph` / `help` skills).
-- [ ] **skill-creator** (`skill-creator` skill).
+- [x] **claude-code-setup** — dropped (redundant; covered by EXTENDING.md /
+  CLAUDE.md proposal triggers / claude-audit).
+- [x] **claude-md-management** — dropped; its useful idea rebuilt as the new
+  `retrospective` skill (memory system + documentation.md + claude-audit
+  cover the rest).
+- [x] **hookify** — dropped + ICEBOX (kept our bespoke-hook model; revisit a
+  declarative guard engine only on Rule-of-Three).
+- [x] **ralph-loop** — dropped + ICEBOX (built-in `/loop` covers it; extend
+  `/loop`, don't rebuild).
+- [x] **skill-creator** — kept (documented exception — the one non-redundant
+  plugin); wired into claude-audit + EXTENDING.md.
 
 For each: extract the useful behaviour into a `config/claude/rules/<name>.md`
 or `config/claude/skills/<name>/` per the three-tier model in `CLAUDE.md`,
@@ -95,16 +98,16 @@ MCP server** — just `.mcp.json` (`npx -y @upstash/context7-mcp`) and a
 is nothing to convert to a rule/skill; it only needs to run through our own
 MCP launcher.
 
-- [ ] Add a `context7` case to `bin/mymcp`:
-  `context7() { npx_run '@upstash/context7-mcp'; }` + `known_cmd['context7']=1`
-  (`npx_run` already prepends `-y`, so pass only the package).
-- [ ] Register context7 as an `mcpServers` entry running `mymcp context7`
-  (stdio) the way `github`/`snyk` are, instead of the marketplace plugin.
-- [ ] Disable the plugin: drop `"context7@claude-plugins-official": true` from
-  both `config/claude/settings.json` and `~/.claude/settings.json` (they
-  mirror).
-- [ ] Verify the context7 MCP tools still resolve after the switch; record in
-  `SETUP-AUDIT.md`.
+- [x] Added a `context7` case to `bin/mymcp` (also reads the API key from the
+  private store and passes `CONTEXT7_API_KEY`; removed the global export from
+  `api-keys.cfg`).
+- [x] Registered context7 — at **user scope** (global), not per-repo:
+  `claude mcp add context7 --scope user -- mymcp context7` (a deploy step;
+  `~/.claude.json` is uncommitted — MCP servers aren't in `settings.json`).
+- [x] Disabled the plugin: dropped `"context7@claude-plugins-official"` from
+  `settings.json` (one file — `~/.claude` is a symlink to `config/claude`).
+- [x] Verified via the MCP `initialize` handshake (Context7 v3.2.1 over
+  stdio); recorded in `SETUP-AUDIT.md`. Full tool-resolution is post-deploy.
 
 ## 🐙 `/github-tasks` skill — recurring GitHub housekeeping (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,50 +65,6 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
-## 🔌 Convert marketplace plugins to in-repo rules/skills (MEDIUM PRIORITY)
-
-Replace these installed plugins with rules/skills that live in our own
-`config/claude/` and fit our environment (XDG paths, `mymcp`, our QA/git
-workflow), so we own and version the behaviour instead of depending on
-external marketplace plugins:
-
-- [x] **claude-code-setup** — dropped (redundant; covered by EXTENDING.md /
-  CLAUDE.md proposal triggers / claude-audit).
-- [x] **claude-md-management** — dropped; its useful idea rebuilt as the new
-  `retrospective` skill (memory system + documentation.md + claude-audit
-  cover the rest).
-- [x] **hookify** — dropped + ICEBOX (kept our bespoke-hook model; revisit a
-  declarative guard engine only on Rule-of-Three).
-- [x] **ralph-loop** — dropped + ICEBOX (built-in `/loop` covers it; extend
-  `/loop`, don't rebuild).
-- [x] **skill-creator** — kept (documented exception — the one non-redundant
-  plugin); wired into claude-audit + EXTENDING.md.
-
-For each: extract the useful behaviour into a `config/claude/rules/<name>.md`
-or `config/claude/skills/<name>/` per the three-tier model in `CLAUDE.md`,
-drop anything redundant with what we already have, then disable/remove the
-plugin in `settings.json` + `installed_plugins.json`. Record the outcome in
-`SETUP-AUDIT.md`.
-
-## 🔁 Point the context7 plugin at `mymcp` (MEDIUM PRIORITY)
-
-**Investigation done:** the `context7` plugin contains **nothing besides the
-MCP server** — just `.mcp.json` (`npx -y @upstash/context7-mcp`) and a
-`plugin.json` manifest. No skills, commands, rules, agents, or hooks. So there
-is nothing to convert to a rule/skill; it only needs to run through our own
-MCP launcher.
-
-- [x] Added a `context7` case to `bin/mymcp` (also reads the API key from the
-  private store and passes `CONTEXT7_API_KEY`; removed the global export from
-  `api-keys.cfg`).
-- [x] Registered context7 — at **user scope** (global), not per-repo:
-  `claude mcp add context7 --scope user -- mymcp context7` (a deploy step;
-  `~/.claude.json` is uncommitted — MCP servers aren't in `settings.json`).
-- [x] Disabled the plugin: dropped `"context7@claude-plugins-official"` from
-  `settings.json` (one file — `~/.claude` is a symlink to `config/claude`).
-- [x] Verified via the MCP `initialize` handshake (Context7 v3.2.1 over
-  stdio); recorded in `SETUP-AUDIT.md`. Full tool-resolution is post-deploy.
-
 ## 🐙 `/github-tasks` skill — recurring GitHub housekeeping (MEDIUM PRIORITY)
 
 Create a `/github-tasks` skill that sweeps the repo's GitHub state and drives
@@ -228,24 +184,29 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
 
-## 📓 Rule/skill-authoring doc-sourcing; evaluate a Dependabot skill (MEDIUM PRIORITY)
+## 📓 Evaluate a Dependabot skill (MEDIUM PRIORITY)
 
-`config/claude/rules/dependabot.md` already exists (since 2026-06-03) and now
-carries a doc-consultation instruction (v1.1.0). What remains is cross-cutting:
+`config/claude/rules/dependabot.md` already exists (since 2026-06-03) and
+carries a doc-consultation instruction (v1.1.0). One follow-up remains
+(the rule/skill-authoring doc-sourcing half is now done — see CHANGELOG):
 
-- [x] **Rule/skill-authoring must source docs** — codified in `EXTENDING.md`
-  (*Grounding & sourcing*, canonical): check the artifact doesn't already
-  exist, then ground it in official docs / man page / local package docs (not
-  memory) and cite the source (rule *Sources* section — added to
-  `rule-TEMPLATE.md`; skill `SOURCE.md`). Referenced from `CLAUDE.md` (*Missing
-  or Conflicting Tool Rules*); `/claude-audit` gained a grounding lens to
-  catch ungrounded artifacts. Added once + referenced, not duplicated.
 - [ ] **Evaluate a `dependabot` skill** — a forcing function that scans the
   repo for every manifest / Dockerfile / workflow, consults current official
   docs, generates/reconciles `dependabot.yml` to full coverage + conventions
   (per `rules/dependabot.md`), and verifies (yamllint). Decide scope vs the
   existing `security-scan` skill (which *triages* Dependabot findings) — setup
   vs triage; avoid duplication (Rule of Three).
+
+## 🧪 Dogfood skill-creator on the retrospective skill (LOW PRIORITY)
+
+Retrospective follow-up (from the PR that added the `retrospective` skill):
+`EXTENDING.md` now says to use **skill-creator** when authoring a skill, but
+`retrospective` predated that rule. Exercising skill-creator on it both
+validates the skill and starts the keep/vendor/borrow/drop learning its
+`SETUP-AUDIT.md` decision calls for.
+
+- [ ] Run skill-creator's eval + description-trigger optimizer on the
+  `retrospective` skill; apply or capture what it surfaces.
 
 ## 🧰 Extract `config/claude/` into its own generic repo (MEDIUM PRIORITY)
 

--- a/api-keys.cfg
+++ b/api-keys.cfg
@@ -9,7 +9,6 @@ XAI_API_KEY=grok
 # deliberately left unset; gh falls through to GH_TOKEN, and MCP servers
 # read their own scoped tokens directly (see bin/mymcp).
 GH_TOKEN=gh
-CONTEXT7_API_KEY=context7
 
 # These need to be set manually on a workstation
 LDAP_PASS=pass.ldap

--- a/bin/mymcp
+++ b/bin/mymcp
@@ -94,6 +94,22 @@ snyk() {
 known_cmd['snyk']=1
 
 #------------------------------------------------------------------------------
+# https://github.com/upstash/context7 (package: @upstash/context7-mcp).
+# Replaces the marketplace context7 plugin so the server is owned and
+# versioned here. context7 is wanted globally, so register it once at
+# user scope (MCP servers are not configured in settings.json):
+#   claude mcp add context7 --scope user -- mymcp context7
+# The API key is read from the private store and passed via the env var
+# the server reads (so it no longer needs exporting into every shell).
+context7() {
+  export CONTEXT7_API_KEY
+  CONTEXT7_API_KEY="$(read_api_key context7)"
+  npx_run '@upstash/context7-mcp'
+}
+
+known_cmd['context7']=1
+
+#------------------------------------------------------------------------------
 # https://github.com/Pimzino/spec-workflow-mcp
 spec_workflow() {
   npx_run "@pimzino/spec-workflow-mcp@latest" "$@"

--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -127,6 +127,8 @@ conflicts with how the repo actually uses the tool, or the rule has
 gone stale relative to current best practice:
 
 - Stop and surface the gap before silently working around it.
+- Ground the new or updated rule in official docs / man pages and cite the
+  source, never memory (see `EXTENDING.md` *Grounding & sourcing*).
 - Propose creating or updating the rule, and decide its scope using the
   three-tier model in *Configuration Migration*:
   - Generally useful across repos → new or updated global

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -23,6 +23,34 @@ Claude Code itself, not any one repo.
 | MCP server | External tools/data over MCP | Active | External process/endpoint | Tools a CLI lacks |
 | Plugin | A bundle of the above | — | — | Packaging / distribution |
 
+## Grounding & sourcing (author from docs, not memory)
+
+Before authoring **any** primitive below — and when editing one — two
+requirements:
+
+1. **Check it doesn't already exist.** Search `config/claude/` (and the
+   built-in skills/commands) for a rule/skill/hook that already covers this.
+   Authoring a duplicate on the false premise that none existed is a real
+   past failure mode.
+2. **Ground the content in authoritative sources where they exist** — the
+   tool/library/API's **official documentation**, its **man page**
+   (`man <tool>`, `<tool> --help`), or **local package docs**
+   (`/usr/share/doc/<pkg>`) — **not memory**, which goes stale. (Context7, if
+   enabled, is a convenience for the currency check — second-class, never
+   required; see `rules/mcp.md`.) Where the artifact encodes a **house
+   convention** with no external source, say so explicitly.
+
+**Cite what you grounded in**, so it is auditable and re-checkable later:
+
+- **Rules** — a brief **Sources** section (the official doc / man page the
+  rule is built on); `rule-TEMPLATE.md` carries the slot.
+- **Skills** — a **`SOURCE.md`** in the skill dir when it adapts or reuses
+  external material (ADR-0002).
+
+`/claude-audit` checks for this grounding and flags artifacts that lack it
+(no source and not a stated house convention) — so a gap here is caught at the
+next audit, not silently carried.
+
 ## Memory / `CLAUDE.md` (the foundation)
 
 **What:** User-written instructions the harness loads every session (user,

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -54,6 +54,11 @@ current context; no separate process.
 decisions or branches) you want done consistently — e.g. `ship-pr`,
 `qa-check`, `bats-setup`. Reach for a skill when you'd write the procedure
 up for a new contributor.
+**Authoring:** when creating or iterating a skill, use the **skill-creator**
+skill — draft it, run its evals/benchmarks on test prompts, and run its
+description-trigger optimizer so the skill fires on the right requests, not
+just whatever wording was first guessed. We are deliberately exercising
+skill-creator on every new skill to learn its worth (`SETUP-AUDIT.md`).
 
 ## Agent (subagent)
 

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,25 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Dropped the `claude-md-management` plugin; built the
+  `retrospective` skill from its idea.** The plugin's `claude-md-improver`
+  (audit/edit CLAUDE.md against a rubric) and `revise-claude-md` (append
+  session learnings to CLAUDE.md) are redundant with, and structurally
+  mismatched to, our setup: it is CLAUDE.md-centric, whereas our repo context
+  is split across `.claude/CLAUDE.md` → WORKFLOW/CONVENTIONS/TESTS/QA (quality
+  + currency governed by `documentation.md`, audited by `claude-audit`), and
+  "capture session learnings" is already the **memory system**'s job (richer:
+  structured frontmatter + index) — appending prose to CLAUDE.md would erode
+  the curated, versioned file. So the plugin was **dropped** (disabled via
+  `enabledPlugins`; cache + `installed_plugins.json` are gitignored local
+  state). The one genuinely useful idea — *reflect after a piece of work and
+  persist what was learned* — was **rebuilt, not converted**, as the global
+  `retrospective` skill, but aimed at the **agent's own tooling** (rules /
+  skills / hooks / patterns / commands / MCP): it runs as **ship-pr Step 4.6**
+  (advisory, never a gate), decides kind + scope per `EXTENDING.md` + the
+  three-tier model, and captures each finding as a detailed open TODO routed
+  global vs repo-local — feeding `claude-audit`'s backlog. Landed via dotfiles
+  PR.
 - 2026-06-18 — **Dropped the `claude-code-setup` plugin (redundant).** Its sole
   content is the read-only `claude-automation-recommender` skill — "analyze a
   repo's stack → suggest 1–2 Claude Code automations per category." The

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,21 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Dropped the `claude-code-setup` plugin (redundant).** Its sole
+  content is the read-only `claude-automation-recommender` skill — "analyze a
+  repo's stack → suggest 1–2 Claude Code automations per category." The
+  capability is already covered, and better fitted to our environment, by
+  `CLAUDE.md` (*When to Propose a Skill* + *Missing or Conflicting Tool Rules*
+  — proactive gap-surfacing as work happens), `EXTENDING.md` (the placement
+  ladder: rule vs skill vs hook vs MCP, global-lazy vs per-repo), the
+  `claude-audit` skill (surfaces gaps from each repo's vantage), and `mcp.md`
+  (the mymcp pattern). Converting it would mean rewriting nearly all of its
+  concrete advice, which actively conflicts with our setup (`claude mcp add
+  context7` vs mymcp, recommending marketplace plugins we're removing, generic
+  `.claude/skills/` patterns vs the three-tier model) — duplication, not
+  value. Disabled via `enabledPlugins` in `config/claude/settings.json`; the
+  cached copy + `installed_plugins.json` entry are gitignored local state
+  (optional cleanup). Landed via dotfiles PR.
 - 2026-06-18 — **context7 MCP: marketplace plugin → `mymcp` (own/version it).**
   The context7 plugin bundled nothing but its MCP server (`npx -y
   @upstash/context7-mcp`) — no skills/commands/rules/agents/hooks — so there

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,27 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Dropped the `hookify` plugin (kept our bespoke-hook model).**
+  hookify is a ~847-LOC vendored Python rule engine + four generic hook entry
+  points that evaluate declarative markdown rules
+  (`.claude/hookify.<name>.local.md`) to warn/block on bash/file/stop/prompt
+  events, plus a `conversation-analyzer` agent and a `writing-rules` skill. It
+  is a different hook model from ours (bespoke, single-purpose Python per hook:
+  `merge-finalization.py`, `rule-coverage.py`, `branch-protection.py`).
+  Dropped because: (a) the "own **and version**" goal cuts against it — its
+  rules are gitignored, per-machine `*.local.md`, whereas our committed hooks
+  are versioned; (b) none of our real hooks fit its pattern model (each needs
+  custom logic — reading `.pre-commit-config.yaml`, scanning TODO, tracking
+  deps); (c) owning 847 LOC that can block every tool event is a real
+  maintenance + **security** surface for trivial guards we have never needed;
+  (d) the conversation-analyzer "mine pain → propose a guard" angle is now
+  covered by the new `retrospective` skill. Disabled via `enabledPlugins`;
+  cache + `installed_plugins.json` are gitignored local state.
+  `ICEBOX:` revisit a **declarative hook / guard-rule engine** — hookify-style
+  pattern-based block/warn guard rules, low-friction declarative hooks without
+  bespoke Python — **only if** we start writing many trivial pattern-guards
+  and the Rule of Three kicks in. Until then, write a bespoke hook (cf.
+  `branch-protection.py`). Landed via dotfiles PR.
 - 2026-06-18 — **Dropped the `claude-md-management` plugin; built the
   `retrospective` skill from its idea.** The plugin's `claude-md-improver`
   (audit/edit CLAUDE.md against a rubric) and `revise-claude-md` (append

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -189,9 +189,10 @@ decisions are also summarized in the *Decisions log*.
 - [x] **`git-worktree-workflow` reconcile-gone-branches** — guarded bulk-remove
   of `[gone]` branches + worktrees (confirm each, skip dirty, no blanket
   `--force` / `fetch --prune`). Done — Operation 7 (skill v1.1.0).
-- [ ] **Trial `ralph-loop`** (autonomous completion loop, distinct from
-  `/loop`). Unbounded — set a max-iteration cap, respect CLAUDE.md autonomy
-  boundaries.
+- [x] **Decided: dropped `ralph-loop`** (2026-06-18) — not trialed; built-in
+  `/loop` covers autonomous iteration. See Decisions log. ICEBOX preserves the
+  exit-blocking technique as a revisit, *via `/loop`* rather than new
+  machinery.
 - [x] **Evaluated `pr-review-toolkit`, `feature-dev`, `security-guidance`** —
   all dropped (redundant with built-ins / `qa.md` / `security-scan`). Vendor
   bits surfaced by the repo that needs them — don't build proactively:
@@ -228,6 +229,23 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Dropped the `ralph-loop` plugin (built-in `/loop` covers
+  it).** ralph-loop implements the "Ralph Wiggum" technique: a **Stop hook**
+  that blocks Claude's exit and re-feeds the same prompt until a completion
+  promise, an autonomous "keep going until DONE" loop, plus `/ralph-loop` /
+  `/cancel-ralph` / `/help` commands. Dropped because the built-in **`/loop`**
+  skill already does self-paced autonomous iteration (omit the interval) plus
+  scheduled re-firing (ScheduleWakeup); ralph-loop's distinctive
+  exit-blocking-until-promise mechanism is also the riskiest part — unbounded
+  by default and in tension with `CLAUDE.md`'s autonomy boundaries — and it
+  was never trialed. Disabled via `enabledPlugins`; cache +
+  `installed_plugins.json` are gitignored local state; the stale "Trial
+  ralph-loop" audit-backlog item is resolved to this decision.
+  `ICEBOX:` if an autonomous **completion loop** / **exit-blocking "until
+  DONE" loop** (ralph / Ralph Wiggum technique) is ever wanted, **extend the
+  existing `/loop` command** (self-pacing + a completion check + a
+  max-iteration cap) rather than build new but similar machinery — incorporate
+  `/loop`, don't reinvent it.
 - 2026-06-18 — **Dropped the `hookify` plugin (kept our bespoke-hook model).**
   hookify is a ~847-LOC vendored Python rule engine + four generic hook entry
   points that evaluate declarative markdown rules

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -206,6 +206,14 @@ decisions are also summarized in the *Decisions log*.
 
 ### Skill ideas & future categories (not from mining)
 
+- [ ] **Rule eval / optimization (analogous to `skill-creator`)** — `skill-
+  creator` measures whether a *skill* triggers on the right prompts and does
+  its job (evals/benchmarks + a description-trigger optimizer). Investigate the
+  same for *rules*: can we measure whether a rule is actually applied at the
+  right moments, and optimize its wording/`paths:` so it fires when it should?
+  Decide only **after** we have exercised skill-creator enough to judge the
+  approach's worth (see the skill-creator decision in the Decisions log). May
+  reuse skill-creator's harness rather than build new.
 - [ ] **`resolve-issue` skill** — orchestrate `gh` issue resolution: fetch
   issue → **agent** investigates it against the codebase via the
   `debug-assistant` skill (root cause, "simple or not", proposed fix or a
@@ -229,6 +237,24 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Kept `skill-creator` (the one plugin worth keeping) and put
+  it to work.** Unlike the four dropped plugins, skill-creator is **not
+  redundant** — it is a skill-authoring + **evaluation** harness (analyzer /
+  comparator / grader agents; `run_eval` / `aggregate_benchmark` /
+  `improve_description` / `package_skill` / `quick_validate` scripts; an
+  eval-viewer) whose quantitative skill evals and **description-trigger
+  optimization** are a capability we otherwise lack. It is Anthropic-official
+  (low supply-chain risk, stays current), so we **keep it enabled** rather than
+  vendor + restyle ~8 third-party Python scripts for a tool not yet exercised.
+  To stop it sitting idle, it is now **wired into our workflow**: the
+  `claude-audit` skill names it as the standing tool for the skills dimension
+  (measure triggering/behaviour, not eyeball the frontmatter), and
+  `EXTENDING.md` instructs using it when **authoring/iterating any skill**
+  (draft → eval → description-optimize). The sooner it is used, the sooner we
+  learn whether to leave it as a plugin, **vendor** it, borrow its ideas, or
+  drop it. **Follow-up logged** (audit backlog): investigate an analogous
+  **rule eval / optimization** capability (possibly reusing skill-creator's
+  harness). Landed via dotfiles PR.
 - 2026-06-18 — **Dropped the `ralph-loop` plugin (built-in `/loop` covers
   it).** ralph-loop implements the "Ralph Wiggum" technique: a **Stop hook**
   that blocks Claude's exit and re-feeds the same prompt until a completion

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -228,6 +228,32 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **context7 MCP: marketplace plugin → `mymcp` (own/version it).**
+  The context7 plugin bundled nothing but its MCP server (`npx -y
+  @upstash/context7-mcp`) — no skills/commands/rules/agents/hooks — so there
+  was nothing to convert to a rule/skill, only the launcher to re-home. Added
+  a `context7()` case to `bin/mymcp` (`npx_run '@upstash/context7-mcp'`) and
+  dropped `context7@claude-plugins-official` from `enabledPlugins` in
+  `config/claude/settings.json` (the same file as `~/.claude/settings.json`
+  via the `~/.claude → config/claude` symlink, so one edit covers both).
+  context7 is wanted **globally**, so it is re-registered at **user scope** —
+  `claude mcp add context7 --scope user -- mymcp context7`, written to the
+  personal, uncommitted `~/.claude.json`. (Verified via claude-code-guide:
+  MCP servers are **not** configured in `settings.json`, and user scope is the
+  only all-projects mechanism short of bundling a plugin — so there is no
+  committed global-MCP file; the launcher is what we own/version, the
+  registration is a per-machine deploy step.) Same global availability as the
+  plugin, but the `mymcp` launcher is now ours instead of a marketplace
+  dependency. The Context7 API key now comes from the private store —
+  `context7()` does `read_api_key context7` and passes it via the
+  `CONTEXT7_API_KEY` env var the server reads — so the key no longer needs
+  exporting into every shell; its line was removed from `api-keys.cfg`.
+  **Deferred:** `config/opencode/config.json`'s remote context7 still reads
+  `{env:CONTEXT7_API_KEY}` and will be broken until reconfigured — left as-is
+  per the user (opencode unused lately; fix on next encounter). Smoke-tested:
+  `mymcp context7` launches Context7 v3.2.1 over stdio and answers the MCP
+  `initialize` handshake; full tool-resolution is a post-deploy check
+  (re-register + reload). Landed via dotfiles PR.
 - 2026-06-16 — **`ICEBOX:` marker + feature-request behaviors (from pigify).**
   Standardized a discoverability convention for *deferred / revisit-on-request*
   decisions, born from a real pigify case (persistent playlist reorder under

--- a/config/claude/rule-TEMPLATE.md
+++ b/config/claude/rule-TEMPLATE.md
@@ -22,6 +22,15 @@ Brief description of what the command does and when to use it.
 
 Where the config lives, how it is resolved, and any Docker wrapper notes.
 
+## Sources
+
+What this rule is grounded in (per `EXTENDING.md` *Grounding & sourcing*) —
+the official docs / man page(s) it is built on, so it can be re-checked when
+the tool changes. State "house convention — no external source" if none
+applies.
+
+- <official doc URL, or `man <tool>` / `<tool> --help` / `/usr/share/doc/<pkg>`>
+
 ## Agent Behavior
 
 - After creating or modifying any file matched by the paths above:

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.6.0
+**Version:** v1.7.0
 
 ## Commit Messages
 
@@ -35,6 +35,26 @@ Stage deliberately — never blanket-add untracked files into a commit.
   stray files land in a commit. Use `-u` plus explicit paths instead.
 - Review `git status` / `git diff --staged` before committing to confirm
   only the intended changes are staged.
+
+## Tracking Progress as You Commit
+
+When a commit completes a tracked item — a `TODO.md` / `ROADMAP.md` entry or an
+issue — **mark it done in that same commit** (`- [x]`, or per the repo's
+convention). Mark it **as you go**, never in a batch at the end.
+
+Why: it makes end-of-PR finalization **mechanical**. At merge you just act on
+the `[x]` items — the repo's merge-time finalization prunes them and migrates
+them to the changelog (see the repo's `WORKFLOW.md`) — instead of re-scanning
+the whole list asking "did we do this?". Marking late forces reconstructing
+what got done, which is exactly the error this rule prevents. Add a
+newly-surfaced follow-up the same way: as an open `- [ ]` in the commit that
+surfaces it.
+
+This is the **mark-as-you-go** half of the loop; the **prune-at-merge** half
+is the repo's merge-time finalization, with the merge-finalization hook as the
+end-state backstop (it blocks a merge that still has unpruned `[x]` items, in
+repos that opt in). This rule is always-on **because committing is**: it has to
+be in front of you at each commit, not only when a PR skill runs at the end.
 
 ## Branch Naming
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -43,8 +43,7 @@
   },
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -42,7 +42,6 @@
     "refreshInterval": 5
   },
   "enabledPlugins": {
-    "ralph-loop@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -42,7 +42,6 @@
     "refreshInterval": 5
   },
   "enabledPlugins": {
-    "context7@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -44,7 +44,6 @@
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
     "hookify@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -45,7 +45,6 @@
     "ralph-loop@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -103,6 +103,25 @@ frontmatter. This is the audit's standing tool for the skills dimension; the
 more it is used, the sooner we learn whether to leave skill-creator enabled,
 vendor it, borrow its ideas, or drop it (`SETUP-AUDIT.md`).
 
+**Check reference consistency (cross-impact).** Artifacts cross-reference each
+other by greppable name — rules by filename (`git.md`), skills by name, hooks
+by path, `[[links]]` in docs. When the audit recommends **changing, moving, or
+deleting** an artifact, `grep config/claude/` for references to it and confirm
+each referrer is still accurate: a renamed flag, moved section, dropped skill,
+or bumped version silently leaves its referrers stale. **Fix or flag the
+ripple — never change the target in isolation.** (Where the repo has a
+structure map — e.g. a `STRUCTURE.md` of rule/skill/hook edges — it charts
+this for humans; the grep is the actual check regardless.)
+
+**Check grounding (author-from-docs).** Each rule/skill should be grounded in,
+and cite, an authoritative source where one exists — official docs / man page
+(a rule's **Sources** section) or an adapted-from `SOURCE.md` (a skill) — per
+`EXTENDING.md` *Grounding & sourcing*. Flag any artifact that asserts a
+tool/library/API's behaviour with **no source and not marked a house
+convention**: its claims may be memory-based and already stale. This pairs
+with the currency check above (Context7) — grounding is *whether* a source
+exists; currency is *whether* it is still current.
+
 ## Mining repos for ideas
 
 An audit improves the **whole** dev environment, not just the current repo —

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -95,6 +95,14 @@ Resolve the library id, then query the specific question. It is **second-class**
 dependency the resulting rules/skills rely on, and the audit must work
 without it. Fall back to official docs or a shallow clone when it's absent.
 
+**Evaluate skills with `skill-creator`.** When the audit questions a skill's
+quality or whether its `description` triggers on the right requests, use the
+**skill-creator** skill — its evals / benchmarks and description-trigger
+optimizer *measure* triggering and behaviour rather than eyeballing the
+frontmatter. This is the audit's standing tool for the skills dimension; the
+more it is used, the sooner we learn whether to leave skill-creator enabled,
+vendor it, borrow its ideas, or drop it (`SETUP-AUDIT.md`).
+
 ## Mining repos for ideas
 
 An audit improves the **whole** dev environment, not just the current repo —

--- a/config/claude/skills/retrospective/SKILL.md
+++ b/config/claude/skills/retrospective/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: retrospective
+description: Run a pre-merge retrospective on the agent's OWN tooling — after a piece of work (typically the last step before merging a PR), evaluate the friction hit with rules, skills, hooks, patterns files, commands, or mymcp/MCP setup, decide whether any need creating or updating, and capture each as a detailed TODO (routed global vs repo-local). Use for "run a retrospective", "retro this", "did any rules/skills/hooks need updating after this", "config retrospective", or as ship-pr's near-final step. It CAPTURES follow-ups; it does not implement them.
+---
+
+# Retrospective
+
+A short, structured reflection on the **agent's own tooling** after a piece of
+work — *not* a retro of the product code. The question it answers: **did
+anything about how I'm configured get in the way, and should a rule, skill,
+hook, patterns file, command, or MCP entry be created or changed because of
+it?** Each answer becomes a **detailed TODO**, not an edit — capturing the
+follow-up keeps the current PR focused (`CLAUDE.md` *Scope Discipline*).
+
+This is the lightweight, in-the-moment, **per-PR** complement to the deeper
+periodic **`claude-audit`** skill: the retrospective *feeds* the audit's
+backlog; the audit is where the accumulated items get worked. Don't duplicate
+the audit here — surface and record.
+
+## When to run
+
+- As **ship-pr Step 4.6** — a near-final step, after CI is green and after the
+  Step 4.5 doc finalization, before the merge. It is **advisory, not a gate**
+  (the only merge gate is the merge-finalization hook).
+- On request: "run a retrospective", "retro this", "any rules/skills/hooks
+  need updating after this work?".
+
+## Step 1 — Reflect: where did the *tooling* create friction?
+
+Look back over the work just done and name concrete pain points with the
+agent's configuration. Useful lenses (skip any that didn't bite):
+
+- **Missing guidance** — worked in a language/tool/framework with **no
+  `rules/<name>.md`**, or added a dependency with no rule (`CLAUDE.md`
+  *Missing or Conflicting Tool Rules*; the `rule-coverage.py` hook may have
+  already flagged it).
+- **Stale or wrong rule** — an existing rule contradicted how the repo
+  actually works, named a file/flag that no longer exists, or fought current
+  best practice.
+- **A repeated multi-step procedure** — the same 3+ step sequence with
+  decisions was done more than once (here or in a past session): candidate for
+  a **skill** (`CLAUDE.md` *When to Propose a Skill*).
+- **A rule that should have been enforced** — a rule was easy to forget and a
+  slip was only caught late: candidate for a **hook** (forcing function).
+- **Repeated judgment calls** — the same flag/group/scope decision made 3+
+  times: candidate to encode (Rule of Three, `code-style.md`).
+- **Recipe depth** — a rule kept needing the same concrete how-to: candidate
+  for a **patterns** skill (cf. `*-patterns`).
+- **Friction in an existing skill/command/MCP** — a step was unclear, missing,
+  or wrong; mymcp/MCP setup needed a tweak.
+
+If nothing bit, say so and stop — a clean retrospective is a valid outcome.
+
+## Step 2 — Decide: what artifact, and where?
+
+For each pain point, decide the **kind** and the **scope**:
+
+- **Kind** — update an existing artifact, or create a new one? Choose rule vs
+  skill vs hook vs patterns vs command vs MCP using `EXTENDING.md` *Choosing
+  between them* and its placement ladder. (Reference, don't restate it.)
+- **Scope** — apply the three-tier model (`CLAUDE.md` *Configuration
+  Migration*): language/tool-agnostic or language-specific-but-repo-agnostic →
+  **global** (the dotfiles `config/claude/`); only-meaningful-here →
+  **repo-local** (the current repo's `.claude/`).
+
+Prefer *promotion to global* when in doubt (it helps every repo on that
+stack); keep only genuinely repo-specific items local.
+
+## Step 3 — Capture: a detailed TODO per finding (do not implement)
+
+Write each finding as an **open** `- [ ]` item (never `- [x]` — open items
+don't trip the merge-finalization hook). Make it actionable later without
+re-deriving the context now. Each entry states:
+
+- **The pain** — what happened, concretely, that exposed the gap.
+- **The proposed artifact** — kind (rule / skill / hook / patterns / command /
+  MCP) and a working name.
+- **The scope** — global (dotfiles) or repo-local, with the target path.
+- **A pointer** — the file/commit/line that motivated it.
+
+Route by scope:
+
+- **Repo-local** → the current repo's `TODO.md` (its triage queue / relevant
+  section).
+- **Global agent-config** → the dotfiles backlog: `TODO.md` (the Claude
+  rules/skills/hooks sections) or the `SETUP-AUDIT.md` *Audit backlog*, which
+  `claude-audit` reads. When the retrospective runs **outside** the dotfiles
+  repo, do not silently edit dotfiles inline — capture the item the way
+  `claude-audit` does (scoped dotfiles branch + PR), or hand it to the user to
+  run `/claude-audit`. Surface it either way; never drop it.
+
+## Step 4 — Fold into the merge flow
+
+When run as ship-pr Step 4.6, include any TODO additions in the **same
+doc-only finalization commit** as Step 4.5 (or a quick follow-up doc commit),
+then **re-watch CI** once before merging. The additions are documentation, so
+they belong with the finalization, not with code.
+
+## Output
+
+A short report:
+
+- the pain points found (or "none — clean retrospective"),
+- for each: the decided kind + scope + target,
+- the TODO entries written and where.
+
+Then proceed with the merge (Step 5). This skill never blocks.

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -152,6 +152,20 @@ This separates *progress tracking* (Step 1 marks items done / adds new ones as
 you work) from *finalization* (here, completed items are pruned once the PR is
 proven green).
 
+## Step 4.6 — Retrospective (agent tooling, advisory)
+
+Run the **retrospective** skill: a short reflection on whether the work hit
+friction with the agent's **own tooling** — a missing/stale rule, a procedure
+worth a skill, a rule worth enforcing with a hook, recipe depth worth a
+patterns file, an awkward command or MCP entry. Each finding becomes a
+**detailed, open** `- [ ]` TODO (routed global vs repo-local), **not** an edit
+— capturing it keeps this PR focused; `claude-audit` works the backlog later.
+
+It is **advisory, never a gate**. Fold any TODO additions into the Step 4.5
+doc-only commit (or a quick follow-up) and re-watch CI once before merging. A
+clean retrospective ("nothing to change") is a valid outcome — say so and move
+on.
+
 ## Step 5 — Merge (only with explicit approval)
 
 A `PreToolUse` hook (`~/.claude/hooks/merge-finalization.py`) backstops Step

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -78,9 +78,12 @@ to the change, per the repo's QA doc) and reports each dimension's status.
 (qa-check's CI stage is Step 4 here, not part of this local pass.) This
 includes the **Documentation** dimension — update the docs, `TODO`/roadmap,
 and any rules/skills (global *and* local) this change touches before
-committing. (Here you **mark** progress / add new items; **removing** the
-completed `TODO`/`ROADMAP` items is deferred to the merge-time finalization,
-Step 4.5, so they're pruned only once the PR is proven green.)
+committing. **Mark each completed `TODO`/`ROADMAP` item `[x]` in the commit
+that completes it** (the *mark-as-you-go* rule in `git.md`; this skill runs
+once at the end, so the rule lives there to be in context at every commit) and
+add newly-surfaced follow-ups as open `- [ ]`. *Removing* the `[x]` items is
+deferred to the merge-time finalization (Step 4.5), so they're pruned only
+once the PR is proven green.
 
 qa-check's format/lint/test stages are the pre-commit sequence — run it ONCE
 (per `rules/pre-commit.md`): the fix config, then the check config.


### PR DESCRIPTION
## Summary
- **context7**: marketplace plugin → `mymcp` launcher (owned/versioned;
  registered globally at user scope; API key now read from the private store
  and passed via `CONTEXT7_API_KEY`, so the global export is removed from
  `api-keys.cfg`).
- **Dropped 4 redundant plugins** — claude-code-setup, claude-md-management,
  hookify, ralph-loop (each covered by existing config; hookify + ralph-loop
  carry ICEBOX notes). **Kept skill-creator** (the one non-redundant tool) and
  wired it into `claude-audit` + `EXTENDING.md`. `enabledPlugins` 6 → 1.
- **New `retrospective` skill** (wired as ship-pr Step 4.6) — built from
  claude-md-management's idea, aimed at the agent's own tooling.
- **Workflow tooling**: `claude-audit` gained cross-impact + grounding lenses;
  codified "ground rules/skills in official docs" (`EXTENDING.md` + a
  `rule-TEMPLATE.md` Sources slot + `CLAUDE.md` pointer) and "mark `TODO` `[x]`
  as you commit" (`git.md` v1.7.0).
- Decisions recorded in `SETUP-AUDIT.md`.

## Test plan
- [ ] `pre-commit run --all-files` — clean.
- [ ] `bats tests/shell/test_*.bats` — 159 pass.
- [ ] `mymcp context7` launches Context7 v3.2.1 and answers the MCP
  `initialize` handshake.