### PR TITLE
fix(auth): stop exporting ANTHROPIC_API_KEY globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ goes green (see the merge-time finalization in
   don't rebuild). `enabledPlugins` 6 → 1; per-plugin rationale in
   `SETUP-AUDIT.md`. (PR #109)
 
+### Fixed
+
+- **Stopped exporting `ANTHROPIC_API_KEY` globally** (`api-keys.cfg`). Per
+  Claude Code's auth precedence it overrode the Max subscription *and* the
+  long-lived `CLAUDE_CODE_OAUTH_TOKEN`, forcing a re-login every ~12h (the
+  OAuth access-token lifetime, which Claude Code doesn't auto-refresh). Tools
+  that need the key now read it from `private_dotfiles/api-key/anthropic`
+  directly (the `mymcp` pattern). (PR #110)
+
 ## 2026-06-17
 
 ### Security

--- a/TODO.md
+++ b/TODO.md
@@ -661,6 +661,22 @@ shim), `show-unicode` (static table), `bash-colors` (color-var defs),
   (mostly covered by the integration tests) and any scripts elsewhere.
 - [ ] Regenerate the meta suite after adding scripts; keep Phase 3 in sync.
 
+## 🔐 Document the Claude Code auth setup (MEDIUM PRIORITY)
+
+Retrospective follow-up (PR #110): `gh.md` documents this user's dual `gh`
+credential scheme, but nothing documents the **Claude Code** auth setup —
+which cost real time (forced re-login every ~12h).
+
+- [ ] Capture the rule: **never export `ANTHROPIC_API_KEY` globally** — Claude
+  Code's auth precedence makes it override the Max subscription *and* the
+  long-lived `CLAUDE_CODE_OAUTH_TOKEN`. Prefer the long-lived `claude
+  setup-token`; Claude Code's OAuth access token is ~12h and isn't
+  auto-refreshed. Likely a short section in `mcp.md` or a new auth note.
+- [ ] Investigate why `CLAUDE_CODE_OAUTH_TOKEN` was unset in this session
+  despite the `api-keys.cfg` mapping (loader / child-session env), so the
+  long-lived token actually takes effect — ties into the `~/.claude →
+  config/claude` symlink realpath issues (CC 2.1.181).
+
 ## 🧠 Claude Rules Files (MEDIUM PRIORITY)
 
 Rules files in `config/claude/rules/` (global, `~/.claude/rules/`) tell the

--- a/api-keys.cfg
+++ b/api-keys.cfg
@@ -1,5 +1,10 @@
 AZURE_DEVOPS_EXT_PAT=azure
-ANTHROPIC_API_KEY=anthropic
+# ANTHROPIC_API_KEY is intentionally NOT exported globally: per Claude
+# Code's auth precedence it overrides the Max subscription AND the
+# long-lived CLAUDE_CODE_OAUTH_TOKEN below, which forced a re-login every
+# ~12h. Tools that need it read private_dotfiles/api-key/anthropic
+# directly (the mymcp pattern). CLAUDE_CODE_OAUTH_TOKEN is the long-lived
+# `claude setup-token` for the Max subscription.
 CLAUDE_CODE_OAUTH_TOKEN=claude-code
 LINODE_TOKEN=linode
 OPENAI_API_KEY=openai


### PR DESCRIPTION
## Summary
- A globally-exported `ANTHROPIC_API_KEY` overrode the Max subscription **and**
  the long-lived `CLAUDE_CODE_OAUTH_TOKEN` (per Claude Code's auth precedence),
  forcing a re-login every ~12h — the OAuth access-token lifetime, which Claude
  Code currently doesn't auto-refresh.
- Drop it from `api-keys.cfg` so the long-lived `setup-token` is used instead.
  Tools that need the Anthropic API key read it from
  `private_dotfiles/api-key/anthropic` directly (the `mymcp` pattern), mirroring
  the recent `CONTEXT7_API_KEY` change. A comment records the rationale so it
  isn't re-added.

## Test plan
- [ ] In a fresh login shell: `ANTHROPIC_API_KEY` is unset and
  `CLAUDE_CODE_OAUTH_TOKEN` is set (loaded from the store).
- [ ] `claude` no longer forces re-login at the ~12h boundary (Max subscription
  via the long-lived token).
- [ ] `config/shell-startup/000-loadtokens` still loads cleanly (the new
  comment lines are skipped, no `=` parsed).