### PR TITLE
feat(skills): add github-tasks housekeeping-sweep skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ goes green (see the merge-time finalization in
   item `[x]` in the commit that completes it, so merge-time finalization is a
   mechanical prune. Placed in always-on `git.md` so it is in context at every
   commit (a skill at PR-end cannot be). (PR #109)
+- **`config/claude/skills/github-tasks/`** — a repo-agnostic GitHub
+  housekeeping skill: one sweep that gathers a repo's open GitHub state (open
+  Dependabot PRs, untriaged issues, failing required checks, stale/gone
+  branches, release/tag hygiene, unresolved review threads), triages it, and
+  presents a single ranked worklist — asking before acting on anything
+  ambiguous. It orchestrates rather than duplicates: gather/triage/label is
+  the only default-scope action; the heavy lifting routes to existing skills
+  (security-scan, qa-check, ship-pr, git-worktree-workflow, release-tag,
+  debug-assistant). Wired as the forcing function for `gh.md`'s "start of
+  git/gh work, and daily" cadence (`gh.md` v1.3.0). (PR #111)
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -96,6 +96,30 @@ Scope:
   (start of git/gh work + daily) rather than a scheduled job; decide if that
   rule should *name* the skill as its forcing function.
 
+## 🌳 Worktree creation: explicit-only, conforming names (MEDIUM PRIORITY)
+
+Retrospective follow-up (PR #111): this background job launched *already
+inside* `.claude/worktrees/feature+github-tasks-skill`, yet the agent still
+called the built-in **`EnterWorktree`** tool — creating a second branch named
+`worktree-feature+github-tasks-skill` (the tool's hardcoded `worktree-`
+prefix + `/`→`+` scheme), which violates the repo's `feature/<name>`
+convention (`rules/git.md` *Branch Naming*). Root cause: the background-job
+system prompt nudges "use EnterWorktree before any code changes," competing
+with both `EnterWorktree`'s own "explicit-request-only" contract and
+`git.md`'s "use the **git-worktree-workflow** skill for all worktree
+operations." There is **no settings.json knob** for the built-in tool's
+naming.
+
+- [ ] Strengthen `rules/git.md` *Worktrees* so the agent resists the
+  background-job nudge: worktree creation is **explicit-request-only**; use
+  the **git-worktree-workflow** skill (conforming `feature/<name>` names),
+  **not** the built-in `EnterWorktree` tool; and **if already inside a
+  worktree at launch, never create another** (the background-job exception).
+- [ ] Decide whether to reconcile the built-in `EnterWorktree` path at all
+  (it can't be renamed via config) or simply forbid its use here in favour of
+  the skill — and whether any of this belongs in global `CLAUDE.md` vs the
+  `git.md` rule.
+
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 
 Create a `/test-audit` skill that checks for **missing or outdated tests**

--- a/TODO.md
+++ b/TODO.md
@@ -71,27 +71,27 @@ Create a `/github-tasks` skill that sweeps the repo's GitHub state and drives
 the routine maintenance, then presents a prioritized worklist to the user.
 Scope:
 
-- [ ] **Dependabot PRs** — find open Dependabot PRs and work through any that
+- [x] **Dependabot PRs** — find open Dependabot PRs and work through any that
   exist (review, compat-gate via `qa-check`, land per the merge policy).
   Ties into the existing "Confirm Dependabot / auto-merge interplay" item
   under *Protect the master Branch*.
-- [ ] **Issue triage** — list open issues and auto-triage them, applying the
+- [x] **Issue triage** — list open issues and auto-triage them, applying the
   right labels (`bug`, `docs`, `feature`, etc.); fold actionable issues into
   the repo's TODO triage queue per `rules/gh.md` *Issues & triage*.
-- [ ] **Present a worklist** — surface the gathered issues/PRs as a ranked
+- [x] **Present a worklist** — surface the gathered issues/PRs as a ranked
   list of candidates to work on, and **ask the requestor clarifying
   questions** before acting on ambiguous items.
-- [ ] **Whatever else comes up** — leave room for other recurring GitHub
+- [x] **Whatever else comes up** — leave room for other recurring GitHub
   chores (stale branches, failing required checks, release/tag hygiene,
   open review threads).
-- [ ] **Reconcile with existing rules/skills** — `rules/gh.md` already
+- [x] **Reconcile with existing rules/skills** — `rules/gh.md` already
   defines the issue-triage cadence ("at the start of git/gh work, and
   daily") and the credential fallback; `ship-pr` lands PRs;
   `git-worktree-workflow` manages branches; `security-scan` triages
   Dependabot/CVE findings. Decide what `/github-tasks` orchestrates vs.
   delegates, and whether any of that content should roll into the skill or
   the skill should defer to it — avoid duplicating per the Rule of Three.
-- [ ] **Recurring, not scheduled** — this must run on a regular basis but
+- [x] **Recurring, not scheduled** — this must run on a regular basis but
   **not** on a cron. Wire it to the natural trigger already in `rules/gh.md`
   (start of git/gh work + daily) rather than a scheduled job; decide if that
   rule should *name* the skill as its forcing function.

--- a/TODO.md
+++ b/TODO.md
@@ -65,37 +65,6 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
-## 🐙 `/github-tasks` skill — recurring GitHub housekeeping (MEDIUM PRIORITY)
-
-Create a `/github-tasks` skill that sweeps the repo's GitHub state and drives
-the routine maintenance, then presents a prioritized worklist to the user.
-Scope:
-
-- [x] **Dependabot PRs** — find open Dependabot PRs and work through any that
-  exist (review, compat-gate via `qa-check`, land per the merge policy).
-  Ties into the existing "Confirm Dependabot / auto-merge interplay" item
-  under *Protect the master Branch*.
-- [x] **Issue triage** — list open issues and auto-triage them, applying the
-  right labels (`bug`, `docs`, `feature`, etc.); fold actionable issues into
-  the repo's TODO triage queue per `rules/gh.md` *Issues & triage*.
-- [x] **Present a worklist** — surface the gathered issues/PRs as a ranked
-  list of candidates to work on, and **ask the requestor clarifying
-  questions** before acting on ambiguous items.
-- [x] **Whatever else comes up** — leave room for other recurring GitHub
-  chores (stale branches, failing required checks, release/tag hygiene,
-  open review threads).
-- [x] **Reconcile with existing rules/skills** — `rules/gh.md` already
-  defines the issue-triage cadence ("at the start of git/gh work, and
-  daily") and the credential fallback; `ship-pr` lands PRs;
-  `git-worktree-workflow` manages branches; `security-scan` triages
-  Dependabot/CVE findings. Decide what `/github-tasks` orchestrates vs.
-  delegates, and whether any of that content should roll into the skill or
-  the skill should defer to it — avoid duplicating per the Rule of Three.
-- [x] **Recurring, not scheduled** — this must run on a regular basis but
-  **not** on a cron. Wire it to the natural trigger already in `rules/gh.md`
-  (start of git/gh work + daily) rather than a scheduled job; decide if that
-  rule should *name* the skill as its forcing function.
-
 ## 🌳 Worktree creation: explicit-only, conforming names (MEDIUM PRIORITY)
 
 Retrospective follow-up (PR #111): this background job launched *already

--- a/config/claude/rules/gh.md
+++ b/config/claude/rules/gh.md
@@ -4,7 +4,7 @@
 
 # gh (GitHub CLI) Rules
 
-**Version:** v1.2.0
+**Version:** v1.3.0
 
 ## Pull Requests
 
@@ -159,13 +159,20 @@ its `TODO.md` (or equivalent) — each with a priority, then resolve or close
 them. Don't let auto-created issues pile up unseen. A closed/empty queue is
 the goal; surface the list to the user when items appear.
 
+The **github-tasks** skill is the forcing function for this cadence: it runs
+this issue check as one part of a wider repo sweep (open Dependabot PRs,
+failing required checks, stale branches, release/tag hygiene) and presents a
+single ranked worklist. Reach for it at the start of git/gh work rather than
+running the `gh issue list` calls above piecemeal.
+
 ## Agent Rules
 
 - After creating a PR, follow the CI monitoring workflow in
   `github-actions.md` if Actions are configured in the repo.
 - In a repo with issue-opening automation, check `gh issue list` at the start
   of git/gh work (and daily) and add open items to the repo's TODO triage
-  queue (see *Issues & triage*).
+  queue (see *Issues & triage*). Prefer the **github-tasks** skill — it runs
+  this check as part of a single repo sweep.
 - Always return the PR URL after creating.
 - Use `gh` for all GitHub operations (issues, PRs, checks, releases).
 - Do not create, merge, or close PRs without explicit user approval.

--- a/config/claude/skills/github-tasks/SKILL.md
+++ b/config/claude/skills/github-tasks/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: github-tasks
+description: Sweep a repo's GitHub state and drive the routine maintenance — open Dependabot PRs, untriaged issues, failing required checks, stale branches, unresolved review threads, release/tag hygiene — then present a ranked worklist and ask before acting on anything ambiguous. The forcing function for rules/gh.md's "start of git/gh work, and daily" cadence. Use for "github tasks", "sweep github", "what needs doing on this repo", "any dependabot PRs / open issues", "triage this repo", "github housekeeping", "check the repo's github state", or at the start of git/gh work in any repo you control. Gathers and triages itself; delegates the heavy lifting to security-scan, ship-pr, git-worktree-workflow, and release-tag.
+---
+
+# github-tasks
+
+**Version:** v1.0.0
+
+The recurring **GitHub housekeeping sweep** for a repo you control: gather
+the repo's open GitHub state, triage it, and present a single ranked worklist
+— then act only on what the user picks. It is the **forcing function** for
+the cadence `rules/gh.md` already defines ("at the start of git/gh work, and
+at least daily"): that rule says *when* and *what* to check; this skill is the
+*how*, run as one pass instead of a scatter of half-remembered `gh` calls.
+
+This skill **gathers and triages**; it **delegates the heavy lifting**. It
+does not re-implement what a focused skill already does — landing a PR,
+managing branches, scanning dependencies, cutting a tag. Keeping it a
+sweep-and-route orchestrator is what stops it from duplicating those skills
+(Rule of Three, `code-style.md`).
+
+It is **repo-agnostic**: it learns each repo's specifics (default branch,
+required checks, merge method, label set, TODO triage queue) from the repo
+itself, not from any hard-coded assumption. Run it in any repo you own.
+
+## Not scheduled — triggered
+
+This runs **regularly but not on a cron**. The natural trigger is the one in
+`rules/gh.md`: the **start of git/gh work in a repo, and at least once a
+day**. Reach for it then, or on an explicit ask ("sweep github", "anything
+open on this repo?"). Do not wire it to a scheduled job — the point is to
+surface state *when you sit down to work the repo*, not on a timer that fires
+into the void.
+
+## Credentials
+
+Every `gh` call follows the `rules/gh.md` credential model: run plain
+(env-var PAT) first; on a scope/permission error (`Resource not accessible by
+personal access token`, HTTP 403) retry that **single** command with
+`GH_TOKEN= GITHUB_TOKEN= gh …` to fall through to the stored OAuth
+credential. Never `unset` the tokens in the session.
+
+## Step 1 — Gather (read-only)
+
+Collect the repo's open state in one pass. These are reads; nothing here
+changes anything.
+
+```bash
+gh pr list  --state open --json number,title,author,isDraft,labels,statusCheckRollup
+gh issue list --state open --json number,title,labels,createdAt
+gh run list --branch "$(default-branch)" --limit 5 --json conclusion,status,workflowName
+git branch -a --format='%(refname:short) %(upstream:track)'   # stale / gone branches
+```
+
+Derive the default branch per `rules/git.md` (never hard-code `main`/
+`master`). Separate **Dependabot** PRs (author `app/dependabot`) from human
+PRs — they route differently below. Note any PR whose `statusCheckRollup` is
+failing, and any open issue with **no** triage label.
+
+## Step 2 — Triage each category
+
+Sort the gathered state into a worklist. For each category, decide and route
+— do **not** start executing yet (Step 3 presents first).
+
+- **Dependabot PRs** — group by bump size. Green grouped **minor/patch** are
+  usually safe to land; **major** bumps get individual review. The triage
+  judgment and the compat gate are the **security-scan** skill's job (which
+  reads `rules/dependabot.md`); landing is **ship-pr**'s. Never
+  blanket-auto-merge majors. Ties into the repo's Dependabot/auto-merge
+  policy if it has one.
+- **Open issues** — apply the right label (`bug`, `docs`, `feature`,
+  `question`, …) to anything untriaged, then fold actionable issues into the
+  repo's **TODO triage queue** (a section in its `TODO.md` or equivalent),
+  each with a priority — exactly as `rules/gh.md` *Issues & triage*
+  prescribes. Auto-filed scanner issues (e.g. a nightly DAST/CVE findings
+  issue) go through **security-scan**.
+- **Failing required checks** on an open PR — surface the failing job; a fix
+  is a normal debugging task (`debug-assistant`), not something this sweep
+  does inline.
+- **Stale / gone branches** — branches whose upstream is `[gone]` or long-
+  merged are **git-worktree-workflow** cleanup candidates; list them, don't
+  delete here.
+- **Release / tag hygiene** — an unreleased merge that ships an artifact is a
+  **release-tag** candidate; flag it.
+- **Unresolved review threads** — surface PRs blocked on open threads.
+
+## Step 3 — Present a ranked worklist, then ask
+
+Output **one** prioritized list — the whole point of the sweep is a single
+place to see what the repo needs. Rank by urgency: failing checks on a PR
+about to merge and security-relevant Dependabot bumps first; cosmetic issue
+labels last. For each item give the one-line what, the suggested route (which
+skill), and your read on priority.
+
+Then **stop and ask** before acting on anything ambiguous (`AskUserQuestion`
+is good here). Invoking this skill is consent to **gather, triage, and label**
+— it is **not** consent to merge a PR, delete a branch, or cut a tag. Those
+each need the explicit go-ahead their own skill requires (`rules/gh.md`:
+never merge/close PRs without approval). Let the user pick what to work; then
+hand each chosen item to its skill below.
+
+## What it delegates to
+
+| Item | Routed to | Source of truth |
+|------|-----------|-----------------|
+| Dependabot triage / compat gate | **security-scan**, **qa-check** | `rules/dependabot.md`, `rules/qa.md` |
+| Landing a PR (commit→PR→CI→merge) | **ship-pr** | `rules/gh.md`, `rules/github-actions.md` |
+| Branch cleanup / worktrees | **git-worktree-workflow** | `rules/git.md` |
+| Cutting a release tag | **release-tag** | `rules/git.md` *Versioning & tags* |
+| Fixing a failing check | **debug-assistant** | `rules/troubleshooting.md` |
+| Issue-triage cadence + labels | *(this skill)* | `rules/gh.md` *Issues & triage* |
+
+## Guardrails
+
+- **Gather/triage/label is the default scope.** Merging, closing, deleting,
+  pushing, and tagging are **not** — each needs the explicit approval its own
+  skill requires. When in doubt, present and ask.
+- **Never** blanket-auto-merge Dependabot majors or silence an advisory
+  without justification (`security-scan`).
+- **Never** hard-code the default branch, required checks, merge method, or
+  label set — read them from the repo.
+- Do **not** schedule this on a cron; it is triggered by sitting down to work
+  the repo (above).
+- Don't let auto-filed issues pile up unseen — surface them every sweep
+  (`rules/gh.md`).


### PR DESCRIPTION
## Summary
- Add a repo-agnostic `github-tasks` skill: one sweep that gathers a repo's
  open GitHub state (Dependabot PRs, untriaged issues, failing required
  checks, stale/gone branches, release/tag hygiene, review threads), triages
  it, and presents a ranked worklist — asking before acting on ambiguous items.
- Orchestrate, don't duplicate: gather/triage/label is the only default-scope
  action; heavy lifting routes to security-scan, qa-check, ship-pr,
  git-worktree-workflow, release-tag, debug-assistant.
- Wire it as the forcing function for `rules/gh.md`'s "start of git/gh work,
  and daily" cadence (gh.md v1.2.0 -> v1.3.0).

## Test plan
- [ ] `pre-commit run --config .pre-commit-config.yaml --files <changed>` green (markdownlint, secrets, no-commit-to-branch)
- [ ] Skill frontmatter valid (name + description present)
- [ ] Cross-references resolve (gh.md <-> github-tasks; branch-cleanup routes to git-worktree-workflow, consistent with ship-pr)
- [ ] CI: bats + perl + pre-commit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)