### PR TITLE
fix(ship-pr): open PR on invoke; clarify finalization steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ goes green (see the merge-time finalization in
 - **Kept `skill-creator` and put it to work** — the one non-redundant
   marketplace plugin; wired into `claude-audit` (the skills dimension) and
   `EXTENDING.md` (use it when authoring a skill). (PR #109)
+- **Refined the `ship-pr` approval model + finalization** (skill v1.9.1) —
+  invoking the skill now consents through *opening the PR* (qa-check → commit
+  → push → open PR → watch CI); merge and close still require a separate
+  explicit instruction (`gh.md` updated to match). Step 4.5/4.6 reframed as a
+  single doc-only finalization phase committed once. Also recorded
+  skill-creator dogfooding findings — its automated trigger eval returns 0% on
+  CC 2.1.x (upstream #2003 + a command-vs-`Skill` detection gap), so triggering
+  is judged manually meanwhile (caveat in `claude-audit`, decisions-log entry
+  in `SETUP-AUDIT.md`, follow-ups in `TODO.md`). (PR #112)
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -201,12 +201,36 @@ carries a doc-consultation instruction (v1.1.0). One follow-up remains
 
 Retrospective follow-up (from the PR that added the `retrospective` skill):
 `EXTENDING.md` now says to use **skill-creator** when authoring a skill, but
-`retrospective` predated that rule. Exercising skill-creator on it both
-validates the skill and starts the keep/vendor/borrow/drop learning its
-`SETUP-AUDIT.md` decision calls for.
+`retrospective` predated that rule.
 
-- [ ] Run skill-creator's eval + description-trigger optimizer on the
-  `retrospective` skill; apply or capture what it surfaces.
+**Blocked on the trigger eval:** dogfooding skill-creator on `ship-pr` showed
+`run_eval.py` returns **0% regardless** on CC 2.1.x (upstream issue #2003 + a
+command-vs-`Skill` detection gap — see `SETUP-AUDIT.md`). So the automated
+triggering eval won't help here until upstream fixes it.
+
+- [ ] When upstream fixes #2003 (or we vendor + patch `run_eval`), run the
+  trigger eval + description optimizer on `retrospective`.
+- [ ] Meanwhile, do a **manual** triggering judgment + instruction-review of
+  `retrospective` (the value skill-creator delivers that isn't blocked).
+
+## 🔌 skill-creator plugin upgrade + marketplace path-corruption (MEDIUM PRIORITY)
+
+Surfaced while dogfooding skill-creator (see `SETUP-AUDIT.md`).
+
+- [ ] **Fix the marketplace path-corruption.** CC 2.1.181 rejects the
+  `claude-plugins-official` marketplace because its recorded `installLocation`
+  is the `~/.claude/...` **symlink** path, not the real
+  `config/claude/plugins/marketplaces/...` path (the `~/.claude → config/claude`
+  symlink). It blocks `claude plugin marketplace update` / `plugin update`.
+  Sanctioned fix: `claude plugin marketplace remove claude-plugins-official`
+  then re-add — **global** (re-pulls all that marketplace's plugins; may shift
+  versions), so do it deliberately. Affects *all* plugin management, not just
+  skill-creator.
+- [ ] **Then upgrade `skill-creator`** to current upstream — its
+  `improve_description.py` dropped the `anthropic` SDK / API-key requirement
+  (now `claude -p`-based, 2026-04-23). Note: `run_eval.py` is unchanged
+  upstream, so the upgrade does **not** fix the broken trigger eval (still
+  gated on #2003).
 
 ## 🧰 Extract `config/claude/` into its own generic repo (MEDIUM PRIORITY)
 

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -237,6 +237,33 @@ decisions are also summarized in the *Decisions log*.
 
 ## Decisions log
 
+- 2026-06-18 — **Dogfooded `skill-creator` on `ship-pr`; its trigger eval is
+  broken on CC 2.1.181 (updates the "keep + put to work" entry below).** Ran
+  `run_eval.py` against ship-pr's `description` with a 20-query should/
+  should-not set. **Uniform 0% trigger rate in BOTH configs** — installed skill
+  present, *and* (per upstream issue #2003's Option-2 workaround) with the
+  installed skill moved aside so only the temp registration remained. Two root
+  causes: (1) **issue #2003** (anthropics/claude-plugins-official) — `run_eval`
+  registers a UUID-named temp copy and checks for that UUID name, but a
+  co-installed real skill is invoked instead (its name lacks the UUID) → 0%;
+  (2) **deeper, isolated by our hidden rerun** — `run_eval` writes a **command**
+  to `.claude/commands/` but detects a **`Skill`** tool-use, and on CC 2.1.181
+  that command is never invoked as a `Skill`, so it reads 0% *even with no
+  competing skill*. So #2003's hide-workaround does **not** fix it for us —
+  there is currently **no usable triggering eval here**, and the
+  `improve_description`/`run_loop` loop is moot (it depends on `run_eval`).
+  `run_eval.py` is **byte-identical to upstream `main`** (diffed) — unfixed
+  upstream; #2003 is OPEN. We commented our repro on #2003. **Verdict (revises
+  the entry below):** keep skill-creator's `SKILL.md` as *conceptual* guidance
+  — and note its **instruction-review pass produced two real `ship-pr` fixes**
+  (the genuine value this round) — but treat its **automated eval/optimize
+  machinery as non-functional on CC 2.1.x**; use **manual triggering judgment**
+  until upstream fixes #2003. **Plugin upgrade deferred** (would only modernize
+  the moot improve-loop): blocked by a **marketplace path-corruption** — the
+  `~/.claude` → `config/claude` symlink makes CC 2.1.181 reject the recorded
+  marketplace `installLocation` (not the real dotfiles path); the sanctioned
+  fix is a global marketplace remove + re-add. Both tracked in `TODO.md`.
+  Landed via dotfiles PR.
 - 2026-06-18 — **Kept `skill-creator` (the one plugin worth keeping) and put
   it to work.** Unlike the four dropped plugins, skill-creator is **not
   redundant** — it is a skill-authoring + **evaluation** harness (analyzer /

--- a/config/claude/rules/gh.md
+++ b/config/claude/rules/gh.md
@@ -4,7 +4,7 @@
 
 # gh (GitHub CLI) Rules
 
-**Version:** v1.2.0
+**Version:** v1.3.0
 
 ## Pull Requests
 
@@ -169,6 +169,10 @@ the goal; surface the list to the user when items appear.
 - Always return the PR URL after creating.
 - Use `gh` for all GitHub operations (issues, PRs, checks, releases).
 - Do not create, merge, or close PRs without explicit user approval.
+  Invoking the **ship-pr** skill (or an explicit "open a PR" / "ship it"
+  request) **is** approval to create and push the PR; **merge and close still
+  require their own separate explicit instruction**, never inferred from the
+  create approval.
 - Use `gh pr view`, `gh issue list`, etc. to check state before acting.
 - For full PR prep workflow (sync, push, create), use the
   **git-worktree-workflow** skill (Operation 4).

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -101,7 +101,13 @@ quality or whether its `description` triggers on the right requests, use the
 optimizer *measure* triggering and behaviour rather than eyeballing the
 frontmatter. This is the audit's standing tool for the skills dimension; the
 more it is used, the sooner we learn whether to leave skill-creator enabled,
-vendor it, borrow its ideas, or drop it (`SETUP-AUDIT.md`).
+vendor it, borrow its ideas, or drop it (`SETUP-AUDIT.md`). **Caveat (CC
+2.1.x):** skill-creator's automated **trigger eval** (`run_eval.py`) is
+currently broken — it returns 0% regardless of the description (upstream
+issue #2003 plus a command-vs-`Skill` detection gap; verified, see
+`SETUP-AUDIT.md`). Until upstream fixes it, judge triggering **manually**;
+skill-creator's value here is its `SKILL.md` *writing* guidance and the
+instruction-review pass, not the eval scripts.
 
 **Check reference consistency (cross-impact).** Artifacts cross-reference each
 other by greppable name — rules by filename (`git.md`), skills by name, hooks

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ship-pr
-description: Commit a finished feature branch and push it, then — each only with explicit approval — open a pull request, watch CI to green, merge it, tag the release if it ships an artifact, and clean up — using this user's gh credential fallback and the repo's branch-protection merge policy. Use whenever the user wants to land work via a PR: "ship this", "ship it", "land this branch", "commit push and PR", "open a PR and merge", "put up a PR", "get this merged", "create the PR and merge after CI", or any request to take a ready branch through the PR-and-merge sequence. Starts where git-worktree-workflow's "prep for PR" ends; works for plain feature branches too (no worktree required).
+description: Commit a finished feature branch, push it, and open a pull request, then watch CI to green and — with explicit approval — merge it, tag the release if it ships an artifact, and clean up — using this user's gh credential fallback and the repo's branch-protection merge policy. Use whenever the user wants to land work via a PR: "ship this", "ship it", "land this branch", "commit push and PR", "open a PR and merge", "put up a PR", "get this merged", "create the PR and merge after CI", or any request to take a ready branch through the PR-and-merge sequence. Starts where git-worktree-workflow's "prep for PR" ends; works for plain feature branches too (no worktree required).
 ---
 
 # Ship PR
 
-**Version:** v1.8.0
+**Version:** v1.9.0
 
 Take a finished branch through the standard landing sequence: **QA check** →
-commit → push → (approval) open PR → watch CI → (approval) merge →
+commit → push → open PR → watch CI → (approval) merge →
 (if it ships an artifact) tag → clean up.
 
 The deterministic mechanics live in the bundled **`scripts/ship.sh`** (in
@@ -46,13 +46,13 @@ auto-retries with the env tokens cleared on a PAT scope error, so the
 
 ## Guardrails (do not violate)
 
-- **Never** open or merge a PR without explicit approval (per `rules/gh.md`).
-  Invoking this skill is consent to run qa-check, commit, and push the branch
-  only. **Opening the PR requires an explicit instruction** ("open the PR",
-  "ship it", "put up a PR", etc.), and **merging requires a separate explicit
-  "merge" instruction** for this branch. If the user only said "commit and
-  push", stop after the push and ask before opening. If they only said "open
-  a PR", stop after CI and ask before merging.
+- **Never** merge or close a PR without explicit approval (per `rules/gh.md`).
+  **Invoking this skill is consent to run the flow through opening the PR** —
+  qa-check → commit → push → **open the PR** → watch CI. **Merging requires a
+  separate explicit instruction** for this branch ("merge it", "merge if CI
+  passes", etc.): stop after CI is green and ask before merging. (If the user
+  explicitly scoped the request narrower — "just commit and push" — honor that
+  and stop before opening.)
 - **Never** push to or merge directly into the default branch.
 - **Never** force-push without `--force-with-lease --force-if-includes`,
   and warn first.

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commit a finished feature branch, push it, and open a pull request,
 
 # Ship PR
 
-**Version:** v1.9.0
+**Version:** v1.9.1
 
 Take a finished branch through the standard landing sequence: **QA check** →
 commit → push → open PR → watch CI → (approval) merge →
@@ -105,9 +105,8 @@ git push -u origin "$CUR"
 
 ## Step 3 — Open the PR (model writes the body)
 
-Compose the title (< 72 chars) and a body per `rules/gh.md` (`## Summary`
-
-+ `## Test plan`), then:
+Compose the title (< 72 chars) and a body per `rules/gh.md`
+(`## Summary` + `## Test plan`), then:
 
 ```bash
 ship.sh pr-create --title "<title>" --body "<body>"
@@ -148,8 +147,10 @@ at merge time; the only changes here are documentation.
   generated changelog mutates the tree, so it is committed here, never in CI;
   see `qa.md` dim 13 and the repo's QA doc), plus any related doc updates.
 
-Commit these doc-only changes, push, and **re-watch CI** (Step 4) — quick,
-since only documentation changed. Proceed to merge only after that is green.
+Run the **Step 4.6 retrospective** next, then commit these doc-only changes —
+**together with any open `- [ ]` TODOs the retrospective adds** — push, and
+**re-watch CI** (Step 4) — quick, since only documentation changed. Proceed to
+merge only after that is green.
 
 This separates *progress tracking* (Step 1 marks items done / adds new ones as
 you work) from *finalization* (here, completed items are pruned once the PR is
@@ -164,10 +165,10 @@ patterns file, an awkward command or MCP entry. Each finding becomes a
 **detailed, open** `- [ ]` TODO (routed global vs repo-local), **not** an edit
 — capturing it keeps this PR focused; `claude-audit` works the backlog later.
 
-It is **advisory, never a gate**. Fold any TODO additions into the Step 4.5
-doc-only commit (or a quick follow-up) and re-watch CI once before merging. A
-clean retrospective ("nothing to change") is a valid outcome — say so and move
-on.
+It is **advisory, never a gate**. Its TODO additions ride along in the Step
+4.5 finalization commit (the two steps are one doc-only phase, committed
+once), so there's no extra CI cycle. A clean retrospective ("nothing to
+change") is a valid outcome — say so and move on.
 
 ## Step 5 — Merge (only with explicit approval)
 


### PR DESCRIPTION
## Summary
- Shift ship-pr's approval model: invoking the skill now consents through
  qa-check → commit → push → **open the PR** → watch CI; **merge/close** still
  require a separate explicit instruction. `rules/gh.md` updated to match.
- Repair the mangled Step 3 PR-body instruction and reframe Step 4.5/4.6 as a
  single doc-only finalization phase committed once (retrospective TODOs ride
  along — no extra CI cycle).
- Record skill-creator dogfooding findings: its automated trigger eval returns
  0% on CC 2.1.x (upstream #2003 + a command-vs-`Skill` detection gap). Caveat
  added to `claude-audit`, decisions-log entry in `SETUP-AUDIT.md`, and TODO
  items (manual triggering judgment meanwhile; marketplace path-corruption +
  deferred plugin upgrade).

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint, gitleaks, shellcheck, …)
- [ ] CI required checks pass on the PR: **bats + perl + pre-commit**
- [ ] Manual: `ship-pr/SKILL.md` and `gh.md` describe the same approval model;
      Step 4.5 ↔ 4.6 cross-references resolve coherently