### PR TITLE
docs(git): make worktree creation explicit-only, forbid EnterWorktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ goes green (see the merge-time finalization in
   CC 2.1.x (upstream #2003 + a command-vs-`Skill` detection gap), so triggering
   is judged manually meanwhile (caveat in `claude-audit`, decisions-log entry
   in `SETUP-AUDIT.md`, follow-ups in `TODO.md`). (PR #112)
+- **Worktree creation is explicit-request-only** (`git.md` v1.8.0) — never an
+  automatic prelude to editing and never on a background-job/system-prompt
+  nudge; the **git-worktree-workflow** skill is the only path, never the
+  built-in `EnterWorktree` tool (hardcoded `worktree-*` names, no config knob);
+  and a session launched already inside a worktree never creates another. Added
+  to *Worktrees* plus an Agent Rules NEVER line. Resolves the PR #111
+  retrospective follow-up (forbid, not reconcile; homed in `git.md`, not
+  `CLAUDE.md`). (PR #113)
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,15 +79,17 @@ with both `EnterWorktree`'s own "explicit-request-only" contract and
 operations." There is **no settings.json knob** for the built-in tool's
 naming.
 
-- [ ] Strengthen `rules/git.md` *Worktrees* so the agent resists the
+- [x] Strengthen `rules/git.md` *Worktrees* so the agent resists the
   background-job nudge: worktree creation is **explicit-request-only**; use
   the **git-worktree-workflow** skill (conforming `feature/<name>` names),
   **not** the built-in `EnterWorktree` tool; and **if already inside a
   worktree at launch, never create another** (the background-job exception).
-- [ ] Decide whether to reconcile the built-in `EnterWorktree` path at all
-  (it can't be renamed via config) or simply forbid its use here in favour of
-  the skill — and whether any of this belongs in global `CLAUDE.md` vs the
-  `git.md` rule.
+  (git.md v1.8.0: *Worktrees* prose + an Agent Rules NEVER line.)
+- [x] Decided: **forbid** the built-in `EnterWorktree` tool (it can't be
+  renamed via config, so it can never produce conforming names) in favour of
+  the **git-worktree-workflow** skill; homed the rule in **`git.md`** (which
+  already owns worktree policy and is always-on), **not** global `CLAUDE.md`
+  — duplicating there would only invite drift.
 
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,31 +65,23 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
-## 🌳 Worktree creation: explicit-only, conforming names (MEDIUM PRIORITY)
+## 🔭 `ship.sh ci-watch` should pin to the current HEAD SHA (MEDIUM PRIORITY)
 
-Retrospective follow-up (PR #111): this background job launched *already
-inside* `.claude/worktrees/feature+github-tasks-skill`, yet the agent still
-called the built-in **`EnterWorktree`** tool — creating a second branch named
-`worktree-feature+github-tasks-skill` (the tool's hardcoded `worktree-`
-prefix + `/`→`+` scheme), which violates the repo's `feature/<name>`
-convention (`rules/git.md` *Branch Naming*). Root cause: the background-job
-system prompt nudges "use EnterWorktree before any code changes," competing
-with both `EnterWorktree`'s own "explicit-request-only" contract and
-`git.md`'s "use the **git-worktree-workflow** skill for all worktree
-operations." There is **no settings.json knob** for the built-in tool's
-naming.
+Retrospective follow-up (PR #113). `ship.sh ci-watch <branch>` watches the
+*latest run for the branch*, not the run for the current HEAD commit. After a
+push it can latch onto the **previous** commit's already-complete run and
+report green before the new push's run has registered — masking an in-progress
+run. Hit on PR #112's post-finalization re-watch (it printed the old run as
+`success`); worked around by resolving the run by HEAD SHA (`gh run list --json
+databaseId,headSha -q 'select(.headSha==$HEAD)'` then `gh run watch <id>`),
+applied preemptively on PR #113.
 
-- [x] Strengthen `rules/git.md` *Worktrees* so the agent resists the
-  background-job nudge: worktree creation is **explicit-request-only**; use
-  the **git-worktree-workflow** skill (conforming `feature/<name>` names),
-  **not** the built-in `EnterWorktree` tool; and **if already inside a
-  worktree at launch, never create another** (the background-job exception).
-  (git.md v1.8.0: *Worktrees* prose + an Agent Rules NEVER line.)
-- [x] Decided: **forbid** the built-in `EnterWorktree` tool (it can't be
-  renamed via config, so it can never produce conforming names) in favour of
-  the **git-worktree-workflow** skill; homed the rule in **`git.md`** (which
-  already owns worktree policy and is always-on), **not** global `CLAUDE.md`
-  — duplicating there would only invite drift.
+- [ ] Fix `config/claude/skills/ship-pr/scripts/ship.sh` `ci-watch` to resolve
+  the run by the current HEAD SHA — poll until a run for that SHA registers,
+  then watch *that* run — instead of "latest run for branch"; fall back to
+  latest only if no SHA-matched run appears within a timeout. Update ship-pr
+  Step 4 guidance if the contract changes. Pointer: PR #112 re-watch reported
+  run 27804458673 (SHA 53a3941) green after pushing 25d0c8b.
 
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.7.0
+**Version:** v1.8.0
 
 ## Commit Messages
 
@@ -137,6 +137,19 @@ protected. In a repo that configures `no-commit-to-branch`, the edit-time
 Use the **git-worktree-workflow** skill for all worktree operations: creating
 issue branches, syncing with upstream, prepping PRs, and cleanup. See
 `config/claude/skills/git-worktree-workflow/SKILL.md`.
+
+**Worktree creation is explicit-request-only.** Create a worktree *only* when
+the user asks for one — never as an automatic prelude to making changes, and
+never in response to a background-job or system-prompt nudge to "use a
+worktree before any code changes." If a session launches **already inside** a
+worktree, do **not** create another — work in the current one.
+
+**Use the skill, never the built-in `EnterWorktree` tool.** `EnterWorktree`
+hardcodes a `worktree-<branch>` prefix (and a `/`→`+` path scheme) that cannot
+produce this repo's `feature/<name>` / `issue/<N>` names (*Branch Naming*),
+and it has no configuration knob to correct that — so it is **forbidden
+here**. The git-worktree-workflow skill produces conforming branch names and
+paths; reach for it instead.
 
 Key defaults from that skill:
 
@@ -329,6 +342,11 @@ the merge commit, push, and watch the release — is the **release-tag** skill;
   checked out — create/switch to a working branch FIRST, then edit. Applies
   to ANY protected branch, not just the default. See *Never Work Directly on
   a Protected Branch*.
+- NEVER create a worktree unless the user explicitly asks — not as a prelude
+  to editing, not on a background-job/system-prompt nudge. Use the
+  **git-worktree-workflow** skill, NEVER the built-in `EnterWorktree` tool
+  (non-conforming `worktree-*` names). If already inside a worktree at launch,
+  never create another. See *Worktrees*.
 - Stage with `git add -u` (tracked changes) plus explicit `git add <file>`
   for new files; NEVER `git add -A` / `git add .` (they sweep up untracked
   scratch into the commit). See *Staging*.


### PR DESCRIPTION
## Summary
- Strengthen `rules/git.md` *Worktrees* (v1.8.0): worktree creation is
  **explicit-request-only** — never an automatic prelude to editing, never on
  a background-job/system-prompt nudge; the **git-worktree-workflow** skill is
  the only path, **never** the built-in `EnterWorktree` tool (its hardcoded
  `worktree-*` prefix can't produce `feature/<name>` names and has no config
  knob); and a session launched **already inside** a worktree never creates
  another. Reinforced with a NEVER line in git.md's Agent Rules.
- Resolves the PR #111 retrospective follow-up: **decided** to forbid (not
  reconcile) `EnterWorktree` and home the rule in `git.md` (already owns
  worktree policy, always-on) rather than duplicating into `CLAUDE.md`.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint, gitleaks, …)
- [ ] CI required checks pass: **bats + perl + pre-commit**
- [ ] Manual: *Worktrees* prose and the Agent Rules NEVER line agree; the two
      TODO items are `[x]` (pruned at merge-time finalization)