### PR TITLE
fix(ship-pr): pin ci-watch to the branch tip SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@ goes green (see the merge-time finalization in
   OAuth access-token lifetime, which Claude Code doesn't auto-refresh). Tools
   that need the key now read it from `private_dotfiles/api-key/anthropic`
   directly (the `mymcp` pattern). (PR #110)
+- **`ship.sh ci-watch` pins to the branch tip SHA** (`ship-pr` v1.9.2) — it
+  watched the *latest run for the branch*, so a re-watch right after a push
+  could latch onto the previous commit's already-green run before the new run
+  registered (masking an in-progress run). Now resolves the run by the branch
+  tip SHA — polls until that run appears (~60s), then falls back to the latest
+  run only on timeout. (PR #114)
 
 ## 2026-06-17
 

--- a/TODO.md
+++ b/TODO.md
@@ -76,12 +76,16 @@ run. Hit on PR #112's post-finalization re-watch (it printed the old run as
 databaseId,headSha -q 'select(.headSha==$HEAD)'` then `gh run watch <id>`),
 applied preemptively on PR #113.
 
-- [ ] Fix `config/claude/skills/ship-pr/scripts/ship.sh` `ci-watch` to resolve
+- [x] Fix `config/claude/skills/ship-pr/scripts/ship.sh` `ci-watch` to resolve
   the run by the current HEAD SHA — poll until a run for that SHA registers,
   then watch *that* run — instead of "latest run for branch"; fall back to
   latest only if no SHA-matched run appears within a timeout. Update ship-pr
   Step 4 guidance if the contract changes. Pointer: PR #112 re-watch reported
   run 27804458673 (SHA 53a3941) green after pushing 25d0c8b.
+  (Done: SHA-pinned poll loop with a ~60s timeout + latest-run fallback;
+  observable contract unchanged so no Step 4 edit. ship-pr → v1.9.2. Verified
+  functionally against live gh/git data; skill helper scripts are outside the
+  `bin lib` meta-test scope, so no bats regression test was added.)
 
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,27 +65,26 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
-## 🔭 `ship.sh ci-watch` should pin to the current HEAD SHA (MEDIUM PRIORITY)
+## 🧪 Skill helper scripts have no test coverage (MEDIUM PRIORITY)
 
-Retrospective follow-up (PR #113). `ship.sh ci-watch <branch>` watches the
-*latest run for the branch*, not the run for the current HEAD commit. After a
-push it can latch onto the **previous** commit's already-complete run and
-report green before the new push's run has registered — masking an in-progress
-run. Hit on PR #112's post-finalization re-watch (it printed the old run as
-`success`); worked around by resolving the run by HEAD SHA (`gh run list --json
-databaseId,headSha -q 'select(.headSha==$HEAD)'` then `gh run watch <id>`),
-applied preemptively on PR #113.
+Retrospective follow-up (PR #114). The ci-watch bug fixed in #114 lived in
+`config/claude/skills/ship-pr/scripts/ship.sh` — a script with real logic (the
+gh credential fallback, run-polling, ruleset merge-method parsing) that the
+test suite never sees. The meta-test generator scans `bin lib` only
+(`tests/scaffold/build-meta-tests`, default roots), so every
+`config/claude/skills/*/scripts/*` is uncovered. That gap let a defect ship and
+caused manual workarounds across PRs #112–#114.
 
-- [x] Fix `config/claude/skills/ship-pr/scripts/ship.sh` `ci-watch` to resolve
-  the run by the current HEAD SHA — poll until a run for that SHA registers,
-  then watch *that* run — instead of "latest run for branch"; fall back to
-  latest only if no SHA-matched run appears within a timeout. Update ship-pr
-  Step 4 guidance if the contract changes. Pointer: PR #112 re-watch reported
-  run 27804458673 (SHA 53a3941) green after pushing 25d0c8b.
-  (Done: SHA-pinned poll loop with a ~60s timeout + latest-run fallback;
-  observable contract unchanged so no Step 4 edit. ship-pr → v1.9.2. Verified
-  functionally against live gh/git data; skill helper scripts are outside the
-  `bin lib` meta-test scope, so no bats regression test was added.)
+- [ ] Decide how to cover skill helper scripts and act on it. Options: (a)
+  extend the meta-test generator's roots to include
+  `config/claude/skills/*/scripts` (gets free static checks — shebang,
+  `bash -n`, shellcheck, shfmt — for all of them at once); and/or (b) add a
+  hand-written bats test for `ship.sh` behaviour with a `gh`/`git` stub
+  (`tests/helpers/common.bash` already has `make_stub`), at least for the
+  pure-logic parts (`ci-watch` SHA selection, `merge-methods` ruleset parse).
+  Update `TESTS.md` coverage scope once decided. Pointer: meta roots default
+  `bin lib` at `tests/scaffold/build-meta-tests`; the bug was the
+  "latest run" vs "run for HEAD SHA" selection in `cmd_ci_watch`.
 
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commit a finished feature branch, push it, and open a pull request,
 
 # Ship PR
 
-**Version:** v1.9.1
+**Version:** v1.9.2
 
 Take a finished branch through the standard landing sequence: **QA check** →
 commit → push → open PR → watch CI → (approval) merge →

--- a/config/claude/skills/ship-pr/scripts/ship.sh
+++ b/config/claude/skills/ship-pr/scripts/ship.sh
@@ -108,15 +108,44 @@ cmd_pr_create() {
     --title "$title" --body "$body"
 }
 
-# Poll the latest run for the branch until it completes. Polling avoids the
-# annotation-scope 403 that `gh run watch` can hit with a narrow PAT.
+# Watch the CI run for the branch's current tip commit until it completes.
+# Pinning to the tip SHA — not merely "the latest run for the branch" — avoids
+# latching onto a previous commit's already-finished run when the new push's
+# run has not registered yet (GitHub lags a few seconds after a push). Polling
+# (not `gh run watch`) sidesteps the annotation-scope 403 a narrow PAT can hit.
 cmd_ci_watch() {
   local branch=${1:-$(git branch --show-current)}
-  local run_id status conclusion
+  local run_id="" status conclusion target_sha attempt
 
-  sleep 6
-  run_id=$(_gh run list --branch "$branch" --limit 1 \
-    --json databaseId --jq '.[0].databaseId')
+  # The commit whose run we want is the tip we just pushed. Prefer the local
+  # ref for the named branch; fall back to HEAD.
+  target_sha=$(git rev-parse --verify --quiet "refs/heads/$branch") \
+    || target_sha=$(git rev-parse --verify --quiet HEAD) \
+    || target_sha=""
+
+  # Poll until a run for target_sha registers, then watch THAT run. Give up
+  # after ~60s and fall back to the latest run for the branch.
+  if [[ -n $target_sha ]]; then
+    for ((attempt = 0; attempt < 12; attempt++)); do
+      run_id=$(_gh run list --branch "$branch" --limit 20 \
+        --json databaseId,headSha \
+        --jq "map(select(.headSha==\"$target_sha\")) | .[0].databaseId // empty")
+
+      [[ -n $run_id ]] && break
+
+      sleep 5
+    done
+  fi
+
+  if [[ -z $run_id ]]; then
+    run_id=$(_gh run list --branch "$branch" --limit 1 \
+      --json databaseId --jq '.[0].databaseId // empty')
+
+    if [[ -n $run_id && -n $target_sha ]]; then
+      echo "ci-watch: no run for ${target_sha:0:9} yet;" \
+        "watching latest run $run_id instead" >&2
+    fi
+  fi
 
   if [[ -z $run_id ]]; then
     echo "no CI run found for $branch" >&2


### PR DESCRIPTION
## Summary
- `ship.sh ci-watch` watched the *latest run for the branch*, so a re-watch
  right after a push could latch onto the previous commit's already-green run
  before the new run registered (hit on PR #112's finalization re-watch). It
  now resolves the run by the **branch tip SHA**, polls until that run appears
  (~60s), watches it, and falls back to the latest run only on timeout.
- Observable contract (args, exit codes) unchanged; bumps ship-pr to v1.9.2.

## Test plan
- [ ] `pre-commit run --all-files` green (shellcheck/shfmt on `ship.sh`)
- [ ] CI required checks pass: **bats + perl + pre-commit**
- [ ] Live dogfood: this PR's own Step 4 ci-watch exercises the new SHA-pinned
      path (and the finalization re-watch — the exact scenario that failed)
- [ ] Verified functionally: SHA resolves, jq selects the right run id, and
      returns empty (not `null`) on no-match so the fallback fires