### PR TITLE
test: fold test-audit into test-review; cover skill scripts

### DIFF
--- a/.claude/QA.md
+++ b/.claude/QA.md
@@ -48,7 +48,7 @@ Every dimension from `qa.md`, with its status (**Active** / **Planned** +link
 | 3 | Type-check | **Off** | No typed source under active dev; Python `mypy`/`pyright` deferred to on-demand (`rules/python.md`). See TODO *pre-commit Phase 3*. |
 | 4 | Code smell / complexity | **Off** | `shellcheck` catches some; no dedicated bash complexity tool. Acknowledged gap, no tracked owner yet. |
 | 5 | Security | **Active (partial)** | Secrets: `gitleaks` + `detect-private-key` (check). SCA / supply-chain: Dependabot alerts + version updates (`.github/dependabot.yml`). SAST: **Planned** — TODO *trufflehog & Checkmarx*, *CodeFactor & Snyk*. DAST: **N/A** (no running service). Deeper triage → `security-scan` skill. |
-| 6 | Tests | **Active** | `bats tests/shell/test_*.bats` (gate), `prove tests/perl/`, `pytest tests/python` (self-activating). Layout/policy in `TESTS.md`. |
+| 6 | Tests | **Active** | `bats tests/shell/test_*.bats` (gate), `prove tests/perl/`, `pytest tests/python` (self-activating). Layout/policy in `TESTS.md`. Suite *quality/coverage* (missing, outdated, brittle tests) → the **test-review** skill (qa.md dim 6), which `qa-check` composes. |
 | 7 | UI/UX & accessibility | **N/A** | Headless dotfiles / CLI — no UI. |
 | 8 | End-to-end | **N/A** | No application. Docker integration tests that bring up a real login shell / pwsh profile live under Tests (`TESTS.md`). |
 | 9 | Compatibility | **N/A** | No external API / data-format contracts. Cross-shell (bash + PowerShell) and the docker context matrix are exercised under Tests. |

--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -86,10 +86,13 @@ the same gating suite without breaking docker-less environments.
 
 The generated **meta suite** runs language-specific static checks per file:
 bash/sh → shebang + `bash -n` + shellcheck + shfmt; perl → shebang +
-`perl -c`; python → shebang + `compile()`. It currently surfaces pre-existing
-debt (legacy bash lint/format + one perl module dependency) — tracked in
-`TODO.md` ("Lint/format Debt in Legacy Scripts"), not ignored and not
-auto-fixed. Until those are clean, only the hand-written suite is gated.
+`perl -c`; python → shebang + `compile()`. It scans `bin lib` **plus
+`config/claude/skills`** (the last covers skill helper scripts such as
+`config/claude/skills/*/scripts/*`, e.g. `ship-pr`'s `ship.sh`; non-script
+files are skipped). It currently surfaces pre-existing debt (legacy bash
+lint/format + one perl module dependency) — tracked in `TODO.md`
+("Lint/format Debt in Legacy Scripts"), not ignored and not auto-fixed. Until
+those are clean, only the hand-written suite is gated.
 
 ## Running
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,17 @@ goes green (see the merge-time finalization in
   to *Worktrees* plus an Agent Rules NEVER line. Resolves the PR #111
   retrospective follow-up (forbid, not reconcile; homed in `git.md`, not
   `CLAUDE.md`). (PR #113)
+- **`test-review` absorbs the test-audit role** (skill v1.1.0) — reconciled the
+  planned `/test-audit` skill against `test-review` and decided **not** to
+  build it (it would duplicate `test-review`, already qa.md's Tests-dimension
+  tool that `qa-check` composes). Extended `test-review` instead with an
+  untested-unit **coverage census** and a **staleness/drift** lens, and named
+  it in the repo QA doc's dim-6 row. (PR #115)
+- **Meta-test generator covers skill helper scripts** — `build-meta-tests`
+  default roots `bin lib` → `bin lib config/claude/skills`, so scripts like
+  `ship-pr`'s `ship.sh` get the static checks (shebang, `bash -n`, shellcheck,
+  shfmt) the suite never ran on them; no debt imported. `TESTS.md` scope
+  updated. (PR #115)
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -75,16 +75,17 @@ test suite never sees. The meta-test generator scans `bin lib` only
 `config/claude/skills/*/scripts/*` is uncovered. That gap let a defect ship and
 caused manual workarounds across PRs #112–#114.
 
-- [ ] Decide how to cover skill helper scripts and act on it. Options: (a)
-  extend the meta-test generator's roots to include
-  `config/claude/skills/*/scripts` (gets free static checks — shebang,
-  `bash -n`, shellcheck, shfmt — for all of them at once); and/or (b) add a
-  hand-written bats test for `ship.sh` behaviour with a `gh`/`git` stub
-  (`tests/helpers/common.bash` already has `make_stub`), at least for the
-  pure-logic parts (`ci-watch` SHA selection, `merge-methods` ruleset parse).
-  Update `TESTS.md` coverage scope once decided. Pointer: meta roots default
-  `bin lib` at `tests/scaffold/build-meta-tests`; the bug was the
-  "latest run" vs "run for HEAD SHA" selection in `cmd_ci_watch`.
+- [x] Option (a) done: extended the meta-test generator's default roots to
+  `bin lib config/claude/skills` (`tests/scaffold/build-meta-tests`), so skill
+  helper scripts now get the static checks (shebang, `bash -n`, shellcheck,
+  shfmt). `ship.sh`'s generated meta test passes all five; no debt imported.
+  `TESTS.md` coverage scope updated.
+- [ ] Option (b), still open (lower priority): a hand-written bats test for
+  `ship.sh` *behaviour* with a `gh`/`git` stub (`tests/helpers/common.bash`
+  `make_stub`) — `ci-watch` SHA selection, `merge-methods` ruleset parse.
+  Static checks (a) would **not** have caught the #114 logic bug; only a
+  behavioural test would, so this is the real regression-coverage piece if we
+  want it.
 
 ## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,44 +65,17 @@ offer and whether any help this repo:
   release tags; a commit-message pattern enforcing Conventional Commits) and
   capture their configs in `../private_dotfiles/github-rulesets/`.
 
-## 🧪 Skill helper scripts have no test coverage (MEDIUM PRIORITY)
+## 🧪 Skill helper scripts — behavioural test coverage (LOW PRIORITY)
 
-Retrospective follow-up (PR #114). The ci-watch bug fixed in #114 lived in
-`config/claude/skills/ship-pr/scripts/ship.sh` — a script with real logic (the
-gh credential fallback, run-polling, ruleset merge-method parsing) that the
-test suite never sees. The meta-test generator scans `bin lib` only
-(`tests/scaffold/build-meta-tests`, default roots), so every
-`config/claude/skills/*/scripts/*` is uncovered. That gap let a defect ship and
-caused manual workarounds across PRs #112–#114.
+*Static* coverage landed in PR #115 (the meta-test generator now scans
+`config/claude/skills`, so `ship.sh` gets shebang/`bash -n`/shellcheck/shfmt).
+But the #114 ci-watch bug was a **logic** error those static checks can't
+catch — only a behavioural test would.
 
-- [x] Option (a) done: extended the meta-test generator's default roots to
-  `bin lib config/claude/skills` (`tests/scaffold/build-meta-tests`), so skill
-  helper scripts now get the static checks (shebang, `bash -n`, shellcheck,
-  shfmt). `ship.sh`'s generated meta test passes all five; no debt imported.
-  `TESTS.md` coverage scope updated.
-- [ ] Option (b), still open (lower priority): a hand-written bats test for
-  `ship.sh` *behaviour* with a `gh`/`git` stub (`tests/helpers/common.bash`
-  `make_stub`) — `ci-watch` SHA selection, `merge-methods` ruleset parse.
-  Static checks (a) would **not** have caught the #114 logic bug; only a
-  behavioural test would, so this is the real regression-coverage piece if we
+- [ ] Add a hand-written bats test for `ship.sh` *behaviour* with a `gh`/`git`
+  stub (`tests/helpers/common.bash` `make_stub`) — `ci-watch` SHA selection,
+  `merge-methods` ruleset parse. The real regression-coverage piece, if we
   want it.
-
-## 🧪 `/test-audit` skill — flag missing/outdated tests, hook into qa-check (MEDIUM PRIORITY)
-
-Create a `/test-audit` skill that checks for **missing or outdated tests**
-(scripts/functions with no test, bug fixes without a regression test, tests
-that have drifted from the code they cover) and wire it into the `qa-check`
-skill's Tests dimension (`qa.md` dimension 6).
-
-- [x] **Reconciled with `test-review` — decided NOT to build `/test-audit`**
-  (it would duplicate `test-review`, already qa.md's dim-6 tool that `qa-check`
-  composes). Instead extended `test-review` (v1.1.0) with the unique sliver.
-- [x] Defined "outdated/untested" in `test-review`: a **coverage census**
-  (units with no test per `TESTS.md`) plus a **staleness/drift** lens (source
-  newer than its test, a test referencing removed/renamed code, a test
-  guarding deleted behavior).
-- [x] Wiring: `qa-check` already composes `test-review` for the Tests
-  dimension; named it in the repo QA doc dim-6 row (`.claude/QA.md`).
 
 ## 🔎 CodeFactor & Snyk: Use Their Output? Rule/Skill? (MEDIUM PRIORITY)
 
@@ -196,6 +169,12 @@ Retrospective follow-up (from the PR that added the `retrospective` skill):
 `run_eval.py` returns **0% regardless** on CC 2.1.x (upstream issue #2003 + a
 command-vs-`Skill` detection gap — see `SETUP-AUDIT.md`). So the automated
 triggering eval won't help here until upstream fixes it.
+
+**Reconfirmed (PR #115):** the *modify-an-existing-skill* path is unusable too
+— extending `test-review` was done by hand because skill-creator's
+improve/optimize loop depends on the same broken `run_eval`. So skill-creator
+helps with neither new-skill eval nor existing-skill edits on CC 2.1.x; treat
+it as conceptual guidance only until #2003 is fixed.
 
 - [ ] When upstream fixes #2003 (or we vendor + patch `run_eval`), run the
   trigger eval + description optimizer on `retrospective`.

--- a/TODO.md
+++ b/TODO.md
@@ -93,17 +93,15 @@ Create a `/test-audit` skill that checks for **missing or outdated tests**
 that have drifted from the code they cover) and wire it into the `qa-check`
 skill's Tests dimension (`qa.md` dimension 6).
 
-- [ ] **First reconcile with the existing `test-review` skill** — it already
-  covers "Tests dimension (quality, not execution): success AND failure
-  paths, regression-test-per-bug, edge-case gaps." Decide whether
-  `/test-audit` is a new skill or whether this is just *wiring `test-review`
-  into `qa-check`* (and possibly renaming/extending it). Avoid duplicating
-  what `test-review` already does — see the Rule of Three in `code-style.md`.
-- [ ] Define what "outdated" means concretely for this repo (e.g. a
-  `bin/`/`lib/` file newer than its `tests/shell/test_<name>.bats`, or a test
-  referencing removed code) per `TESTS.md`'s coverage rules.
-- [ ] Hook the chosen skill into `qa-check` for the Tests dimension; record
-  the status in the repo QA doc per `qa.md`.
+- [x] **Reconciled with `test-review` — decided NOT to build `/test-audit`**
+  (it would duplicate `test-review`, already qa.md's dim-6 tool that `qa-check`
+  composes). Instead extended `test-review` (v1.1.0) with the unique sliver.
+- [x] Defined "outdated/untested" in `test-review`: a **coverage census**
+  (units with no test per `TESTS.md`) plus a **staleness/drift** lens (source
+  newer than its test, a test referencing removed/renamed code, a test
+  guarding deleted behavior).
+- [x] Wiring: `qa-check` already composes `test-review` for the Tests
+  dimension; named it in the repo QA doc dim-6 row (`.claude/QA.md`).
 
 ## 🔎 CodeFactor & Snyk: Use Their Output? Rule/Skill? (MEDIUM PRIORITY)
 

--- a/config/claude/skills/test-review/SKILL.md
+++ b/config/claude/skills/test-review/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: test-review
-description: Assess the quality and coverage of a test suite — does it cover success AND failure paths, is there a regression test per past bug, are tests well-structured (arrange-act-assert, intent-revealing names) and not brittle/over-mocked, what edge cases are missing. Use for "review the tests", "are these tests any good", "test coverage gaps", "is this well tested", "what's missing from the test suite". The tool for qa.md's Tests dimension (quality, not execution). Distinct from qa-check (runs the tests) and /code-review (reviews a diff).
+description: Assess the quality and coverage of a test suite — does it cover success AND failure paths, is there a regression test per past bug, are tests well-structured (arrange-act-assert, intent-revealing names) and not brittle/over-mocked, what edge cases are missing, which units are untested, and which tests have drifted stale/outdated against the code they cover. Use for "review the tests", "are these tests any good", "test coverage gaps", "is this well tested", "what's missing from the test suite", "what's untested", "find missing or outdated tests", "audit the tests", "test-audit". The tool for qa.md's Tests dimension (quality, not execution). Distinct from qa-check (runs the tests) and /code-review (reviews a diff).
 ---
 
 # test-review
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 Assess a **test suite's quality and coverage** — not whether it passes
 (`qa-check` runs it), but whether it's *worth* passing. Subject-agnostic; the
 bar comes from `testing.md`.
+
+This skill **also covers the "test-audit" role** — flagging *missing* tests
+(units with no test) and *outdated* tests (drifted from the code they cover),
+not only weak ones — so a separate test-audit skill is unnecessary (the
+coverage census and staleness lens below absorb it).
 
 ## What it checks (the bar is `testing.md`)
 
@@ -18,6 +23,15 @@ bar comes from `testing.md`.
   failure/error path is untested.
 - **Regression coverage** — does each past bug fix have a test that would fail
   without the fix? Name behaviors with no guarding test.
+- **Untested units (coverage census)** — beyond weak tests, enumerate the
+  units with **no test at all** against the repo's coverage policy
+  (`TESTS.md`): each `bin/`/`lib/` script and `lib/` function, each new public
+  API. A unit with no test is a bigger gap than a unit with a shallow one.
+- **Staleness / drift** — tests that no longer match the code they cover: a
+  source file changed more recently than its test, a test referencing a
+  removed/renamed symbol, or a test still guarding deleted behavior. Stale
+  tests rot silently and give false confidence — flag them, not just absent
+  ones.
 - **Structure** — arrange-act-assert clarity, one behavior per test,
   intent-revealing names (`code-style.md`). A test you can't read won't be
   trusted or maintained.
@@ -45,6 +59,12 @@ file reading out of this conversation.
 
 ### Missing regression tests
 - <past bug / risky behavior> — no guarding test
+
+### Untested units
+- `unit` — no test at all (per `TESTS.md` coverage policy)
+
+### Stale / drifted tests
+- `test` — <drifted from code / references removed symbol / guards deleted behavior>
 
 ### Quality issues
 - `test` — <brittle/over-mocked/unclear> → <fix>

--- a/tests/scaffold/build-meta-tests
+++ b/tests/scaffold/build-meta-tests
@@ -11,7 +11,9 @@
 # Usage:
 #   tests/scaffold/build-meta-tests [DIR ...]
 #
-# DIR arguments are roots to scan, relative to the repo root (default: bin lib).
+# DIR arguments are roots to scan, relative to the repo root
+# (default: bin lib config/claude/skills — the last covers skill helper
+# scripts like config/claude/skills/*/scripts/*; non-scripts are skipped).
 # Output: one <dir>-<name>.meta.bats per script, written to tests/shell/ (which
 # gitignores *.meta.bats). Files listed in tests/scaffold/meta-ignore (one
 # repo-relative path per line, # comments allowed) are skipped.
@@ -49,10 +51,10 @@ done
 mkdir -p "$out_dir"
 
 #------------------------------------------------------------------------------
-# Roots to scan (repo-relative); default to bin + lib.
+# Roots to scan (repo-relative); default to bin + lib + skill helper scripts.
 
 declare -a roots=("$@")
-((${#roots[@]})) || roots=(bin lib)
+((${#roots[@]})) || roots=(bin lib config/claude/skills)
 
 #------------------------------------------------------------------------------
 # Load the ignore list (repo-relative paths) into a set.


### PR DESCRIPTION
## Summary
- **Reconciled the planned `/test-audit` skill against `test-review`** and
  decided **not** to build it — it would duplicate `test-review`, already
  qa.md's Tests-dimension tool that `qa-check` composes. Instead extended
  `test-review` (v1.1.0) with the only non-overlapping sliver: an
  untested-unit **coverage census** and a **staleness/drift** lens. Named
  `test-review` in the repo QA doc's dim-6 row.
- **Covered skill helper scripts in the meta-test generator** — default roots
  `bin lib` → `bin lib config/claude/skills`, so scripts like `ship-pr`'s
  `ship.sh` get static checks (shebang, `bash -n`, shellcheck, shfmt). No debt
  imported; `TESTS.md` scope updated.

## Test plan
- [ ] `pre-commit run --all-files` green (shellcheck/shfmt on the generator,
      markdownlint on the docs)
- [ ] CI required checks pass: **bats + perl + pre-commit**
- [ ] Verified: `tests/scaffold/build-meta-tests` regenerates and `ship.sh`'s
      meta test passes all 5 static checks