### PR TITLE
chore: batch — shellcheck hook, ci-watch fix, auth doc, evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ goes green (see the merge-time finalization in
   updates the security-scan skill + `.claude/QA.md`. (Checkmarx was also
   evaluated and **declined** — commercial, no free tier; `semgrep` covers
   SAST.) (PR #116)
+- **`PostToolUse` shellcheck hook** — `config/claude/hooks/shell-check.py`
+  (wired on `Edit|Write|MultiEdit`) runs `shellcheck` on a shell file right
+  after it's edited and surfaces findings to the agent, so "run shellcheck
+  after editing" is enforced, not just remembered. Check-only, shellcheck-only,
+  fail-open. Tested by `tests/python/test_shell_check.py` (7 cases); documented
+  in `rules/shellcheck.md` (v1.1.0). (PR #117)
+- **`config/claude/rules/claude-code-auth.md`** — documents this user's three
+  Claude Code auth methods, the full six-method precedence, and the
+  never-export-`ANTHROPIC_API_KEY`-globally rule. Grounded in the official auth
+  docs. (PR #117)
 
 ### Changed
 
@@ -38,6 +48,19 @@ goes green (see the merge-time finalization in
   version churn, and the lock now correctly scopes the
   cryptography/cffi/pycparser chain to `sys_platform == "linux"` instead of
   forcing it on every platform. (PR #116)
+- **`security-scan` skill (v1.1.0): dependabot reconcile made explicit** —
+  evaluated a standalone dependabot skill and **declined** it (would duplicate
+  step 2 + `rules/dependabot.md`); instead spelled out the reconcile-and-verify
+  procedure in step 2 (scan manifests → consult docs → reconcile → yamllint).
+  (PR #117)
+
+### Fixed
+
+- **`ship.sh ci-watch` watches every workflow run for the tip SHA** — it took
+  `.[0]` of the SHA-matched runs, so with two workflows per PR (`tests` +
+  `secret-scan`) it could watch the wrong one. Now collects all runs for the
+  SHA, reports per-workflow, and aggregates the exit code (any failed → 1).
+  Regression-tested via `test_ship.bats`. (PR #117)
 
 ## 2026-06-18
 

--- a/TODO.md
+++ b/TODO.md
@@ -675,15 +675,20 @@ Retrospective follow-up (PR #110): `gh.md` documents this user's dual `gh`
 credential scheme, but nothing documents the **Claude Code** auth setup —
 which cost real time (forced re-login every ~12h).
 
-- [ ] Capture the rule: **never export `ANTHROPIC_API_KEY` globally** — Claude
-  Code's auth precedence makes it override the Max subscription *and* the
-  long-lived `CLAUDE_CODE_OAUTH_TOKEN`. Prefer the long-lived `claude
-  setup-token`; Claude Code's OAuth access token is ~12h and isn't
-  auto-refreshed. Likely a short section in `mcp.md` or a new auth note.
-- [ ] Investigate why `CLAUDE_CODE_OAUTH_TOKEN` was unset in this session
-  despite the `api-keys.cfg` mapping (loader / child-session env), so the
-  long-lived token actually takes effect — ties into the `~/.claude →
-  config/claude` symlink realpath issues (CC 2.1.181).
+- [x] Documented in **`config/claude/rules/claude-code-auth.md`** (a new auth
+  note, parallel to `gh.md`) — the three methods this setup uses (Console
+  `ANTHROPIC_API_KEY`, long-lived `CLAUDE_CODE_OAUTH_TOKEN`, subscription
+  `/login`), the full six-method **precedence**, the never-export-globally
+  rule, and checking/switching. Grounded in the official Claude Code auth docs
+  (Sources cited), which corrected two beliefs: `ANTHROPIC_API_KEY` **does**
+  authenticate the CLI (it just overrides at precedence #3), and the
+  subscription OAuth **does** auto-refresh — the docs name no literal 12h
+  cycle; the global-API-key override was the actual culprit (fixed in PR #110).
+- [x] Investigated (empirically resolved): `CLAUDE_CODE_OAUTH_TOKEN` appearing
+  unset mid-session cleared after a **full `/login` logout + login**. Root
+  cause not definitively pinned (the loader / `~/.claude → config/claude`
+  symlink-realpath angle on CC 2.1.181 was the suspect) — captured the
+  logout+login fix in the rule's *gotcha* section; reopen if it recurs.
 
 ## 🧠 Claude Rules Files (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,20 +73,19 @@ findings. Research how to actually use each and whether to formalize it.
 - [ ] If a tool adds no actionable value, consider disabling its check to cut
   PR-check noise; if it does, document the triage workflow.
 
-## 🔭 ship.sh ci-watch: handle multiple workflows per PR (LOW PRIORITY)
+## 🔭 Document the kept-branch-after-squash sync mechanic (LOW PRIORITY)
 
-Retrospective follow-up (PR #116). With the new `secret-scan` workflow a PR
-now triggers **two** workflow runs (`tests` + `secret-scan`), but
-`ship.sh ci-watch` selects `.[0]` of the SHA-matched runs — so it can watch
-the wrong workflow (the non-required `secret-scan` instead of the required
-`tests`). Both runs had to be watched by hand this PR.
+Retrospective follow-up (PR #117). When a batch branch is **kept** after a
+squash-merge to continue working, syncing it with `git merge master` carries
+the already-merged commits forward as redundant history that pollutes the next
+PR's commit list — PR #117 needed a `git rebase --onto master <merge>` cleanup
+before its commit list was tidy.
 
-- [x] Made `ship.sh ci-watch` watch **all** runs for the HEAD SHA and
-  aggregate (any run failed → exit 1), reporting per-workflow results instead
-  of `.[0]`; added a short grace pass so a sibling workflow registering a beat
-  later isn't missed. The per-commit annotation scan already spanned all
-  workflows, so it's unchanged. `test_ship.bats` gains a multi-workflow
-  regression case (5 tests pass); ship-pr → v1.9.3.
+- [ ] Document the clean mechanic in `git.md` (or the ship-pr / batch
+  workflow): after a squash-merge with the branch kept, sync via
+  `git reset --hard origin/master` (the batch is already in master) or
+  `git rebase --onto`, **not** `git merge master`. (Already captured in the
+  batch-todos working memory; promote to a rule note so it isn't memory-only.)
 
 ## 🔑 Investigate GitHub as a secrets vault (MEDIUM PRIORITY)
 
@@ -132,20 +131,6 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
 - [ ] Consolidate drift: the same rule copied (and diverging) across repos
   should become one global source that repos reference.
 - [ ] Note any project that lacks a `.claude/` but should have one.
-
-## 📓 Evaluate a Dependabot skill (MEDIUM PRIORITY)
-
-`config/claude/rules/dependabot.md` already exists (since 2026-06-03) and
-carries a doc-consultation instruction (v1.1.0). One follow-up remains
-(the rule/skill-authoring doc-sourcing half is now done — see CHANGELOG):
-
-- [x] **Evaluated — declined a separate `dependabot` skill** (Rule of Three: it
-  would duplicate `security-scan` step 2 + `rules/dependabot.md`). Dependabot
-  *setup* and *triage* already live in the `security-scan` skill, and the
-  ecosystems/conventions/authoring procedure live in the rule. Instead made the
-  *reconcile-and-verify* procedure explicit in `security-scan` step 2 (scan all
-  manifests → consult official docs → reconcile to full coverage → yamllint),
-  pointing at the rule. `security-scan` → v1.1.0.
 
 ## 🧪 Dogfood skill-creator on the retrospective skill (LOW PRIORITY)
 
@@ -669,27 +654,6 @@ shim), `show-unicode` (static table), `bash-colors` (color-var defs),
   (mostly covered by the integration tests) and any scripts elsewhere.
 - [ ] Regenerate the meta suite after adding scripts; keep Phase 3 in sync.
 
-## 🔐 Document the Claude Code auth setup (MEDIUM PRIORITY)
-
-Retrospective follow-up (PR #110): `gh.md` documents this user's dual `gh`
-credential scheme, but nothing documents the **Claude Code** auth setup —
-which cost real time (forced re-login every ~12h).
-
-- [x] Documented in **`config/claude/rules/claude-code-auth.md`** (a new auth
-  note, parallel to `gh.md`) — the three methods this setup uses (Console
-  `ANTHROPIC_API_KEY`, long-lived `CLAUDE_CODE_OAUTH_TOKEN`, subscription
-  `/login`), the full six-method **precedence**, the never-export-globally
-  rule, and checking/switching. Grounded in the official Claude Code auth docs
-  (Sources cited), which corrected two beliefs: `ANTHROPIC_API_KEY` **does**
-  authenticate the CLI (it just overrides at precedence #3), and the
-  subscription OAuth **does** auto-refresh — the docs name no literal 12h
-  cycle; the global-API-key override was the actual culprit (fixed in PR #110).
-- [x] Investigated (empirically resolved): `CLAUDE_CODE_OAUTH_TOKEN` appearing
-  unset mid-session cleared after a **full `/login` logout + login**. Root
-  cause not definitively pinned (the loader / `~/.claude → config/claude`
-  symlink-realpath angle on CC 2.1.181 was the suspect) — captured the
-  logout+login fix in the rule's *gotcha* section; reopen if it recurs.
-
 ## 🧠 Claude Rules Files (MEDIUM PRIORITY)
 
 Rules files in `config/claude/rules/` (global, `~/.claude/rules/`) tell the
@@ -754,33 +718,6 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
   - other locations as discovered
   Ties into the vendored file/skill update checker (see Configuration
   Enhancements → Dependency Management).
-
-## 🪝 Claude Code PostToolUse Hooks (MEDIUM PRIORITY)
-
-Rules files instruct the agent to run shellcheck/shfmt, but only if the agent
-remembers. `PostToolUse` hooks in `settings.json` enforce this automatically
-after every `Edit` or `Write` on a shell file.
-
-- [x] **Approach:** Option B — a script, `config/claude/hooks/shell-check.py`,
-  matching the three existing hooks (`branch-protection`, `rule-coverage`,
-  `merge-finalization`).
-- [x] **Input format** (grounded in the working `rule-coverage.py`): the hook
-  reads JSON on stdin → `tool_input.file_path`; project dir via
-  `CLAUDE_PROJECT_DIR` or `cwd`; surfaces feedback to the agent (non-blocking)
-  via `print(json.dumps({"hookSpecificOutput": {"hookEventName":
-  "PostToolUse", "additionalContext": ...}}))`.
-- [x] **Implemented** on `Edit|Write|MultiEdit` in `settings.json`. Detects a
-  shell file by `.sh`/`.bash` extension or shell shebang, runs `shellcheck`,
-  and surfaces findings. **Deviations from the original sketch (deliberate):**
-  *check-only* (no `shfmt -w` — auto-fixing mid-session fights `pre-commit.md`,
-  and the file would change under the agent), and *shellcheck only* (the
-  bug-catching half; formatting stays at commit time — one container per edit,
-  not two). Fail-open (skips non-shell / out-of-project / missing-shellcheck).
-  Regression-tested: `tests/python/test_shell_check.py` (7 cases, hermetic via
-  a `shellcheck` stub).
-- [x] **Documented** in `rules/shellcheck.md` (new *Enforcement* section,
-  v1.1.0) — the rule the hook enforces — rather than `WORKFLOW.md`, since the
-  hook is **global** shell hygiene, not this repo's specific workflow.
 
 ## 🔭 Audit the Claude Code Setup (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -761,19 +761,26 @@ Rules files instruct the agent to run shellcheck/shfmt, but only if the agent
 remembers. `PostToolUse` hooks in `settings.json` enforce this automatically
 after every `Edit` or `Write` on a shell file.
 
-- [ ] Decide hook approach:
-  - Option A: inline command in `settings.json` (simple, but not version-controlled
-    separately from settings)
-  - Option B: `config/claude/bin/post-edit-shell.sh` script invoked by the hook
-    (keeps logic in a file, easier to maintain)
-- [ ] Implement hook in `config/claude/settings.json`:
-  - Match on `Edit` and `Write` tool use
-  - Detect if the modified file is a shell file (by path pattern or shebang)
-  - Run `shfmt -i 2 -s -bn -ci -sr -w <file>` then `shellcheck <file>`
-  - Output failures so Claude sees them and can fix before continuing
-- [ ] Research Claude Code hook input format: what env vars / stdin does a
-  `PostToolUse` hook receive? (need file path of edited file)
-- [ ] Document hook setup in this repo's WORKFLOW.md once stable
+- [x] **Approach:** Option B — a script, `config/claude/hooks/shell-check.py`,
+  matching the three existing hooks (`branch-protection`, `rule-coverage`,
+  `merge-finalization`).
+- [x] **Input format** (grounded in the working `rule-coverage.py`): the hook
+  reads JSON on stdin → `tool_input.file_path`; project dir via
+  `CLAUDE_PROJECT_DIR` or `cwd`; surfaces feedback to the agent (non-blocking)
+  via `print(json.dumps({"hookSpecificOutput": {"hookEventName":
+  "PostToolUse", "additionalContext": ...}}))`.
+- [x] **Implemented** on `Edit|Write|MultiEdit` in `settings.json`. Detects a
+  shell file by `.sh`/`.bash` extension or shell shebang, runs `shellcheck`,
+  and surfaces findings. **Deviations from the original sketch (deliberate):**
+  *check-only* (no `shfmt -w` — auto-fixing mid-session fights `pre-commit.md`,
+  and the file would change under the agent), and *shellcheck only* (the
+  bug-catching half; formatting stays at commit time — one container per edit,
+  not two). Fail-open (skips non-shell / out-of-project / missing-shellcheck).
+  Regression-tested: `tests/python/test_shell_check.py` (7 cases, hermetic via
+  a `shellcheck` stub).
+- [x] **Documented** in `rules/shellcheck.md` (new *Enforcement* section,
+  v1.1.0) — the rule the hook enforces — rather than `WORKFLOW.md`, since the
+  hook is **global** shell hygiene, not this repo's specific workflow.
 
 ## 🔭 Audit the Claude Code Setup (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -388,7 +388,8 @@ catches.
 
 Build out perl QA across **both the test suite and the CLI scripts** (where
 CLIs exist — e.g. `bin/parse_params`, `bin/perltidyrc-clean`), and make it as
-strict as practical, in stages.
+strict as practical, in stages. Capture the resulting toolchain in **agent
+rules/skills** (see *Rules & skills* below), not only human setup docs.
 
 ### perlcritic
 
@@ -458,6 +459,31 @@ bundles (OTRS, TryTiny).
   Prerequisites). Use the repo's standard install path — perlbrew + cpanm (see
   *Tool/Version Manager Setup*) or pinned docker wrappers — so a fresh machine
   reproduces the whole perl QA toolchain from one documented place.
+
+### Rules & skills (agent config)
+
+These stages adopt several tools the **agent** must know how to drive — capture
+each as agent config, not only human setup docs, per `CLAUDE.md` *Missing or
+Conflicting Tool Rules* and *When to Propose a Skill*. Today only a thin
+`rules/perl.md` exists (a one-line `perltidy` + `perlcritic --severity 4`
+mention) and there is **no** perl-QA skill (cf. `bats-setup`,
+`pytest-patterns`).
+
+- [ ] **Per-tool rules.** As each tool lands, create or extend its
+  `rules/<tool>.md`, **grounded in current official docs with a Sources cite**
+  (`EXTENDING.md` *Grounding & sourcing*) — never memory. Likely a dedicated
+  **`rules/perlcritic.md`** (the curated profile, policy-selection judgement,
+  staged severity ratchet, and docker-pinned-policy-set angle are far more than
+  `perl.md`'s one-liner), plus shorter rules or `perl.md` sections for
+  `perltidy`, `Devel::Cover`, and `Test::Pod::Coverage`. Wire each into the
+  tool-detection table and the `qa.md` / repo QA-doc dimension mapping.
+- [ ] **A perl-QA skill?** Decide whether the multi-step procedures here
+  (scaffold the toolchain → curate the perlcritic profile → ratchet severity in
+  stages → wire Test::Perl::Critic + coverage + POD gates) warrant a skill — a
+  perl analog of **`bats-setup`** (scaffolding) and/or **`pytest-patterns`**
+  (depth recipes). Weigh against `qa-check` (which *runs* QA) and the existing
+  skills; fold into one rather than duplicate if it already fits (Rule of
+  Three).
 
 ## 🧰 Tool/Version Manager Setup (perlbrew, nvm, …) (MEDIUM PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -139,12 +139,13 @@ promoted to the global config (`config/claude/rules/` or `.../skills/`).
 carries a doc-consultation instruction (v1.1.0). One follow-up remains
 (the rule/skill-authoring doc-sourcing half is now done — see CHANGELOG):
 
-- [ ] **Evaluate a `dependabot` skill** — a forcing function that scans the
-  repo for every manifest / Dockerfile / workflow, consults current official
-  docs, generates/reconciles `dependabot.yml` to full coverage + conventions
-  (per `rules/dependabot.md`), and verifies (yamllint). Decide scope vs the
-  existing `security-scan` skill (which *triages* Dependabot findings) — setup
-  vs triage; avoid duplication (Rule of Three).
+- [x] **Evaluated — declined a separate `dependabot` skill** (Rule of Three: it
+  would duplicate `security-scan` step 2 + `rules/dependabot.md`). Dependabot
+  *setup* and *triage* already live in the `security-scan` skill, and the
+  ecosystems/conventions/authoring procedure live in the rule. Instead made the
+  *reconcile-and-verify* procedure explicit in `security-scan` step 2 (scan all
+  manifests → consult official docs → reconcile to full coverage → yamllint),
+  pointing at the rule. `security-scan` → v1.1.0.
 
 ## 🧪 Dogfood skill-creator on the retrospective skill (LOW PRIORITY)
 

--- a/TODO.md
+++ b/TODO.md
@@ -791,23 +791,7 @@ follow-ups (e.g. the deferred `pydantic_ai` framework rule, repo-mining
 shortlists) are tracked there, not here, so this repo's `TODO.md` stays about
 actual dotfiles work.
 
-## ⌨️ Custom slash commands: /push and /push-pr (MEDIUM PRIORITY)
-
-Shortcuts for the common ship flow:
-
-- `/push` — commit (if needed) and push the current branch.
-- `/push-pr` — commit, push, and open a PR.
-
-**First evaluate workability.** A slash command is a prompt the model
-executes, so it *can* run git/`gh` (commit → push → `gh pr create`) — but it
-**suggests**, it does not guarantee, and it must respect the protected-branch
-rule (never author on master), the staging discipline (`git add -u` + explicit
-paths, never `-A`/`.`), and the gh approval gates (never open/merge a PR
-without explicit approval — `gh.md`). These largely duplicate the **ship-pr**
-skill, so the real question is whether a thin command that **delegates to
-ship-pr** (or a subset) beats just typing the request. Decide: command vs.
-skill-trigger, the exact scope of each (`/push` = commit+push only), and where
-it lives (global `commands/`).
+## 🪝 Pre-commit hooks: phased rollout (MEDIUM PRIORITY)
 
 **Key Rule:** CI/CD Phase N requires Pre-commit Phase N completed first.
 Pre-commit can progress independently. CI/CD cannot lead pre-commit.

--- a/TODO.md
+++ b/TODO.md
@@ -81,11 +81,12 @@ now triggers **two** workflow runs (`tests` + `secret-scan`), but
 the wrong workflow (the non-required `secret-scan` instead of the required
 `tests`). Both runs had to be watched by hand this PR.
 
-- [ ] Make `ship.sh ci-watch` robust to multiple workflows per PR: either
-  watch **all** runs for the HEAD SHA and aggregate their conclusions, or
-  target the gating workflow (whose jobs are the repo's required checks).
-  Pointer: `cmd_ci_watch` picks `.[0].databaseId` after SHA-matching in
-  `config/claude/skills/ship-pr/scripts/ship.sh`.
+- [x] Made `ship.sh ci-watch` watch **all** runs for the HEAD SHA and
+  aggregate (any run failed → exit 1), reporting per-workflow results instead
+  of `.[0]`; added a short grace pass so a sibling workflow registering a beat
+  later isn't missed. The per-commit annotation scan already spanned all
+  workflows, so it's unchanged. `test_ship.bats` gains a multi-workflow
+  regression case (5 tests pass); ship-pr → v1.9.3.
 
 ## 🔑 Investigate GitHub as a secrets vault (MEDIUM PRIORITY)
 

--- a/api-keys.cfg
+++ b/api-keys.cfg
@@ -4,7 +4,8 @@ AZURE_DEVOPS_EXT_PAT=azure
 # long-lived CLAUDE_CODE_OAUTH_TOKEN below, which forced a re-login every
 # ~12h. Tools that need it read private_dotfiles/api-key/anthropic
 # directly (the mymcp pattern). CLAUDE_CODE_OAUTH_TOKEN is the long-lived
-# `claude setup-token` for the Max subscription.
+# `claude setup-token` for the Max subscription. Full scheme + precedence:
+# config/claude/rules/claude-code-auth.md.
 CLAUDE_CODE_OAUTH_TOKEN=claude-code
 LINODE_TOKEN=linode
 OPENAI_API_KEY=openai

--- a/config/claude/hooks/shell-check.py
+++ b/config/claude/hooks/shell-check.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+"""PostToolUse hook: shellcheck a shell file right after it is edited.
+
+After an Edit/Write/MultiEdit, if the touched file is a shell script, run
+shellcheck and surface any findings to the agent (via additionalContext — the
+same channel rule-coverage.py uses) so a shell bug is caught at edit time, not
+only at commit. Check-only and non-blocking: it never modifies the file and
+never blocks the tool. Formatting (shfmt) stays with the commit-time fix
+config; this is the bug-catching linter only.
+
+Fail-open: any problem — no shellcheck on PATH, the file outside the project,
+a non-shell file, a timeout — exits 0 silently, so the hook can never wedge an
+edit. It is global config, so it must stay safe in every repo.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SHELL_EXTS = {".sh", ".bash"}
+SHEBANG_SH = re.compile(r"\b(?:ba|da|k)?sh\b")
+TIMEOUT_S = 25
+
+
+def _is_shell(path: Path) -> bool:
+  """True for a .sh/.bash file, or an extension-less script with a shell
+  shebang (bin/, lib/, config/shell-startup/, ...)."""
+  if path.suffix.lower() in SHELL_EXTS:
+    return True
+
+  try:
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+      first = fh.readline()
+  except OSError:
+    return False
+
+  return first.startswith("#!") and bool(SHEBANG_SH.search(first))
+
+
+def main() -> int:
+  try:
+    event = json.load(sys.stdin)
+  except Exception:
+    return 0
+
+  file_path = (event.get("tool_input") or {}).get("file_path")
+  if not file_path:
+    return 0
+
+  path = Path(file_path)
+  if not path.is_file() or not _is_shell(path):
+    return 0
+
+  project_dir = (
+    os.environ.get("CLAUDE_PROJECT_DIR") or event.get("cwd") or os.getcwd()
+  )
+
+  # bin/shellcheck is a docker wrapper that mounts $PWD and needs the file
+  # path relative to (and under) $PWD. Run from the project dir with a
+  # relative path; if the file is not under it, skip (fail-open).
+  try:
+    rel = path.resolve().relative_to(Path(project_dir).resolve())
+  except ValueError:
+    return 0
+
+  try:
+    proc = subprocess.run(
+      ["shellcheck", str(rel)],
+      cwd=project_dir,
+      capture_output=True,
+      text=True,
+      timeout=TIMEOUT_S,
+    )
+  except Exception:
+    return 0
+
+  if proc.returncode == 0:
+    return 0
+
+  findings = (proc.stdout or proc.stderr or "").strip()
+  if not findings:
+    return 0
+
+  message = (
+    f"shellcheck flagged {rel} (just edited) — fix before continuing:\n\n"
+    f"{findings}\n\n"
+    "(PostToolUse shell-check hook, check-only. Per shellcheck.md no errors "
+    "or warnings are permitted; an inline `# shellcheck disable=SCxxxx` needs "
+    "a reason comment.)"
+  )
+
+  print(
+    json.dumps({
+      "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": message,
+      }
+    })
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/config/claude/rules/claude-code-auth.md
+++ b/config/claude/rules/claude-code-auth.md
@@ -1,0 +1,83 @@
+# Claude Code Auth Rules
+
+**Version:** v1.0.0
+
+How **this user** authenticates Claude Code (the CLI), the precedence between
+methods, and the standing rule that keeps the Max subscription working — the
+parallel to `gh.md`'s dual-credential scheme, for Claude Code itself.
+
+## The methods (this setup uses three of six)
+
+Claude Code resolves auth in a fixed **precedence order** (highest wins). This
+user relies on three of the six methods:
+
+| # | Method | What it is | Lifetime |
+|---|--------|------------|----------|
+| 3 | **`ANTHROPIC_API_KEY`** | Console pay-per-use key (`X-Api-Key`). Works for terminal CLI; **overrides** the subscription once approved. | API-key validity |
+| 5 | **`CLAUDE_CODE_OAUTH_TOKEN`** | Long-lived token from `claude setup-token` (Pro/Max/Team/Enterprise). For CI / non-interactive. | **~1 year** |
+| 6 | **Subscription OAuth** (`/login`) | Interactive Max/Pro browser login — the **default**. Auto-refreshes via a stored refresh token. | short access token, auto-refreshed |
+
+Full precedence (highest → lowest), for completeness:
+
+1. Cloud provider — `CLAUDE_CODE_USE_BEDROCK` / `_VERTEX` / `_FOUNDRY`
+2. `ANTHROPIC_AUTH_TOKEN` — gateway/proxy bearer token
+3. `ANTHROPIC_API_KEY` — Console key (above)
+4. `apiKeyHelper` — a settings script returning credentials dynamically
+5. `CLAUDE_CODE_OAUTH_TOKEN` — long-lived (above)
+6. Subscription OAuth from `/login` — default fallback (above)
+
+## This user's setup
+
+- **`CLAUDE_CODE_OAUTH_TOKEN` is exported** (mapped in `api-keys.cfg` →
+  `private_dotfiles/api-key/claude-code`) — the long-lived `claude setup-token`
+  for the Max subscription. A fresh shell is authed without a browser login,
+  and it outranks the default subscription OAuth (#5 > #6).
+- **`ANTHROPIC_API_KEY` is deliberately NOT exported globally.** It sits at
+  precedence **#3 — above** both `CLAUDE_CODE_OAUTH_TOKEN` (#5) and the
+  subscription login (#6), so a global export hijacks the agent onto the
+  pay-per-use Console key and off the Max subscription. Tools that genuinely
+  need the key read `private_dotfiles/api-key/anthropic` directly (the `mymcp`
+  pattern), never the global env.
+
+## The ~12h re-login gotcha (resolved)
+
+Exporting `ANTHROPIC_API_KEY` globally forced a re-login roughly every ~12h —
+removing the global export (PR #110) fixed the root cause. A session still
+showing a stale/expired method clears with a full `/login` logout **and** login
+(re-mints the subscription OAuth) — the observed fix when
+`CLAUDE_CODE_OAUTH_TOKEN` appeared unset mid-session.
+
+> The official docs do **not** document a literal 12h cycle; the subscription
+> access token auto-refreshes normally. The breakage was the `ANTHROPIC_API_KEY`
+> override interacting badly, not the refresh mechanism itself.
+
+## Checking & switching
+
+- **Which method is active:** `/status`.
+- **A set `ANTHROPIC_API_KEY`:** approved once in interactive mode; toggle later
+  via "Use custom API key" in `/config`.
+- **Fall back to the subscription:** `unset ANTHROPIC_API_KEY` (inline / per
+  shell, never global), then `/status` to confirm.
+- **Hard guard:** `forceLoginMethod` in managed settings restricts to
+  subscription auth and blocks the env-var methods entirely.
+- **Re-mint the long-lived token:** `claude setup-token` (prints it; does not
+  save — map it into `api-keys.cfg`).
+
+## Sources
+
+- Claude Code authentication — methods, precedence, management (fetched
+  2026-06-19): <https://code.claude.com/docs/en/authentication>
+- Claude Code setup — login + token generation:
+  <https://code.claude.com/docs/en/setup>
+
+## Agent Behavior
+
+- **Never suggest exporting `ANTHROPIC_API_KEY` globally** — it outranks the
+  long-lived token and the Max subscription (precedence #3). A tool that needs
+  it reads `private_dotfiles/api-key/anthropic` directly (`mymcp`).
+- Prefer the long-lived `CLAUDE_CODE_OAUTH_TOKEN` (`claude setup-token`, ~1yr)
+  for non-interactive/CI auth; the subscription `/login` is the interactive
+  default and auto-refreshes.
+- Diagnose an auth problem with `/status` first; clear a stuck API-key override
+  with `unset ANTHROPIC_API_KEY`, and a stuck session with a full `/login`
+  logout + login.

--- a/config/claude/rules/shellcheck.md
+++ b/config/claude/rules/shellcheck.md
@@ -11,7 +11,7 @@ paths:
 
 # shellcheck Rules
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 ## Invocation
 
@@ -63,6 +63,26 @@ precedence over the global config for all files in that repo.
 must be relative to the current directory; passing a file outside `$PWD` exits
 with an error before docker runs. Run shellcheck from the repo root or the
 directory containing the files.
+
+## Enforcement (PostToolUse hook)
+
+A global **`PostToolUse` hook** — `config/claude/hooks/shell-check.py`, wired
+into `settings.json` on `Edit|Write|MultiEdit` — runs `shellcheck` on a shell
+file **right after the agent edits it** and surfaces any findings (via
+`additionalContext`), so the "run shellcheck" rule below is *enforced*, not
+merely remembered. It is:
+
+- **Check-only** — never modifies the file; fix what it reports with a normal
+  edit (formatting / `shfmt` is **not** in the hook — that stays at commit
+  time, per `pre-commit.md`'s fix-once discipline).
+- **shellcheck-only** — the bug-catching linter, not the formatter (one
+  container per edit via the docker wrapper).
+- **Fail-open** — skips silently for a non-shell file, a file outside the
+  project, or when `shellcheck` is absent; it can never block an edit.
+
+A shell file is detected by a `.sh`/`.bash` extension or a shell shebang
+(so extension-less `bin/`, `lib/`, `config/shell-startup/` scripts are
+covered). Tested by `tests/python/test_shell_check.py`.
 
 ## Agent Behavior
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -31,6 +31,11 @@
             "type": "command",
             "command": "python3 ~/.claude/hooks/rule-coverage.py",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/shell-check.py",
+            "timeout": 30
           }
         ]
       }

--- a/config/claude/skills/security-scan/SKILL.md
+++ b/config/claude/skills/security-scan/SKILL.md
@@ -5,7 +5,7 @@ description: Run and wire up source/dependency security scanning (SAST + depende
 
 # Security Scan
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 Drive source and dependency security through its rules. Security tooling is
 periodic, so the rules are easy to forget — this skill is the forcing
@@ -45,9 +45,16 @@ triage step; "set up scanning" is the wiring steps.
 1. **SAST (semgrep)** — run the `p/...` packs for the languages present,
    gating on `--severity ERROR --error` (widen later). Fix ERROR findings;
    a true false positive gets `# nosemgrep: <rule-id>` + reason.
-2. **Dependencies / supply chain** — ensure `.github/dependabot.yml` covers
-   every manifest (incl. `docker` + `github-actions`), weekly + grouped. For
-   an ad-hoc check, `trivy fs .` surfaces dependency CVEs + secrets now.
+2. **Dependencies / supply chain** — **reconcile `.github/dependabot.yml` to
+   full coverage** per `rules/dependabot.md` (the source of truth for ecosystems
+   + conventions): scan the repo for every manifest / Dockerfile / workflow, map
+   each to its ecosystem, **consult current official Dependabot docs before
+   authoring** (schema keys + supported ecosystems change), add an `updates`
+   entry for each (incl. `docker` + `github-actions`), apply the conventions
+   (weekly, group minor/patch, `chore(deps)` messages), then **verify**
+   (yamllint). This is dependabot *setup* — triaging the resulting PRs is the
+   next step. For an ad-hoc check, `trivy fs .` surfaces dependency CVEs +
+   secrets now.
 3. **Triage Dependabot PRs** — green grouped minor/patch is usually safe to
    merge; review **major** bumps individually. Never blanket-auto-merge
    majors or silence an advisory without justification.

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commit a finished feature branch, push it, and open a pull request,
 
 # Ship PR
 
-**Version:** v1.9.2
+**Version:** v1.9.3
 
 Take a finished branch through the standard landing sequence: **QA check** →
 commit → push → open PR → watch CI → (approval) merge →
@@ -39,7 +39,7 @@ auto-retries with the env tokens cleared on a PAT scope error, so the
 |------------|------|
 | `default-branch` | Print the repo's default branch. |
 | `pr-create --title T --body B [--base BR]` | Open the PR from the current branch; prints the URL. |
-| `ci-watch [BRANCH]` | Poll the latest run to completion; print job results **and any warning/error annotations**. Exit `0` clean, `1` failed, `2` passed-with-warnings. |
+| `ci-watch [BRANCH]` | Poll **every** workflow run for the branch tip SHA to completion (a push can trigger several, e.g. tests + secret-scan); print per-workflow job results **and any warning/error annotations**. Exit `0` clean, `1` any run failed, `2` passed-with-warnings. |
 | `merge-methods` | Print the merge methods the repo/ruleset allows. |
 | `merge NUMBER --squash\|--merge\|--rebase` | Merge and delete the branch. |
 | `cleanup BRANCH` | Switch to default, pull, prune the merged branch. |

--- a/config/claude/skills/ship-pr/scripts/ship.sh
+++ b/config/claude/skills/ship-pr/scripts/ship.sh
@@ -108,14 +108,17 @@ cmd_pr_create() {
     --title "$title" --body "$body"
 }
 
-# Watch the CI run for the branch's current tip commit until it completes.
-# Pinning to the tip SHA — not merely "the latest run for the branch" — avoids
-# latching onto a previous commit's already-finished run when the new push's
-# run has not registered yet (GitHub lags a few seconds after a push). Polling
-# (not `gh run watch`) sidesteps the annotation-scope 403 a narrow PAT can hit.
+# Watch the CI run(s) for the branch's current tip commit until they finish.
+# Pin to the tip SHA — not merely "the latest run for the branch" — so a
+# previous commit's already-finished run is never mistaken for this push's
+# (GitHub lags a few seconds after a push). A single push can trigger SEVERAL
+# workflows (e.g. tests + secret-scan), so watch EVERY run for the SHA and
+# aggregate — not just the first. Polling (not `gh run watch`) sidesteps the
+# annotation-scope 403 a narrow PAT can hit.
 cmd_ci_watch() {
   local branch=${1:-$(git branch --show-current)}
-  local run_id="" status conclusion target_sha attempt
+  local target_sha attempt run_id status
+  local -a run_ids=()
 
   # The commit whose run we want is the tip we just pushed. Prefer the local
   # ref for the named branch; fall back to HEAD.
@@ -123,51 +126,70 @@ cmd_ci_watch() {
     || target_sha=$(git rev-parse --verify --quiet HEAD) \
     || target_sha=""
 
-  # Poll until a run for target_sha registers, then watch THAT run. Give up
-  # after ~60s and fall back to the latest run for the branch.
+  # Poll until at least one run for target_sha registers, then a short grace
+  # pass to catch sibling workflows that register a beat later. Collect ALL of
+  # them. Give up after ~60s and fall back to the latest run for the branch.
   if [[ -n $target_sha ]]; then
     for ((attempt = 0; attempt < 12; attempt++)); do
-      run_id=$(_gh run list --branch "$branch" --limit 20 \
-        --json databaseId,headSha \
-        --jq "map(select(.headSha==\"$target_sha\")) | .[0].databaseId // empty")
+      mapfile -t run_ids < <(
+        _gh run list --branch "$branch" --limit 20 --json databaseId,headSha \
+          --jq "map(select(.headSha==\"$target_sha\")) | .[].databaseId"
+      )
 
-      [[ -n $run_id ]] && break
+      ((${#run_ids[@]} > 0)) && break
 
       sleep 5
     done
-  fi
 
-  if [[ -z $run_id ]]; then
-    run_id=$(_gh run list --branch "$branch" --limit 1 \
-      --json databaseId --jq '.[0].databaseId // empty')
-
-    if [[ -n $run_id && -n $target_sha ]]; then
-      echo "ci-watch: no run for ${target_sha:0:9} yet;" \
-        "watching latest run $run_id instead" >&2
+    if ((${#run_ids[@]} > 0)); then
+      sleep 5
+      mapfile -t run_ids < <(
+        _gh run list --branch "$branch" --limit 20 --json databaseId,headSha \
+          --jq "map(select(.headSha==\"$target_sha\")) | .[].databaseId"
+      )
     fi
   fi
 
-  if [[ -z $run_id ]]; then
+  if ((${#run_ids[@]} == 0)); then
+    run_id=$(_gh run list --branch "$branch" --limit 1 \
+      --json databaseId --jq '.[0].databaseId // empty')
+
+    if [[ -n $run_id ]]; then
+      [[ -n $target_sha ]] && echo "ci-watch: no run for ${target_sha:0:9}" \
+        "yet; watching latest run $run_id instead" >&2
+      run_ids=("$run_id")
+    fi
+  fi
+
+  if ((${#run_ids[@]} == 0)); then
     echo "no CI run found for $branch" >&2
     return 0
   fi
 
-  while :; do
-    status=$(_gh run view "$run_id" --json status --jq '.status')
+  # Wait for every collected run to complete.
+  for run_id in "${run_ids[@]}"; do
+    while :; do
+      status=$(_gh run view "$run_id" --json status --jq '.status')
 
-    if [[ $status == completed ]]; then
-      break
-    fi
+      [[ $status == completed ]] && break
 
-    sleep 15
+      sleep 15
+    done
   done
 
-  _gh run view "$run_id" --json jobs \
-    --jq '.jobs[] | "\(.name): \(.conclusion)"'
-  echo
+  # Report each run's workflow + jobs + conclusion; track the worst outcome.
+  local failed=0 name conclusion
+  for run_id in "${run_ids[@]}"; do
+    name=$(_gh run view "$run_id" --json workflowName --jq '.workflowName')
+    conclusion=$(_gh run view "$run_id" --json conclusion --jq '.conclusion')
 
-  conclusion=$(_gh run view "$run_id" --json conclusion --jq '.conclusion')
-  echo "run $run_id: $conclusion"
+    echo "$name (run $run_id): $conclusion"
+    _gh run view "$run_id" --json jobs \
+      --jq '.jobs[] | "  \(.name): \(.conclusion)"'
+
+    [[ $conclusion == success ]] || failed=1
+  done
+  echo
 
   # A "success" conclusion can still carry warning/error annotations
   # (deprecations, audit notices, lint warnings) that the conclusion hides.
@@ -177,7 +199,10 @@ cmd_ci_watch() {
   local warnings=0 errors=0
   local -a check_ids=()
 
-  sha=$(_gh run view "$run_id" --json headSha --jq '.headSha')
+  # Annotations are per-COMMIT (check-runs for the SHA span every workflow), so
+  # scan once for the tip SHA rather than per run.
+  sha=$target_sha
+  [[ -n $sha ]] || sha=$(_gh run view "${run_ids[0]}" --json headSha --jq '.headSha')
   nwo=$(_nwo)
 
   mapfile -t check_ids < <(
@@ -207,9 +232,9 @@ cmd_ci_watch() {
     echo "  total: $errors error(s), $warnings warning(s)"
   fi
 
-  # Exit codes: 1 = failed (or error annotations); 2 = passed with
+  # Exit codes: 1 = any run failed (or error annotations); 2 = passed with
   # warnings; 0 = clean. The caller decides what to do with warnings.
-  if [[ $conclusion != success ]] || ((errors > 0)); then
+  if ((failed)) || ((errors > 0)); then
     return 1
   fi
 

--- a/tests/python/test_shell_check.py
+++ b/tests/python/test_shell_check.py
@@ -1,0 +1,125 @@
+"""Tests for the shell-check PostToolUse hook.
+
+Runs the hook as a subprocess (the way Claude Code invokes it) with a stubbed
+`shellcheck` on PATH, so the tests are hermetic — no real shellcheck / docker
+needed. See the hook under config/claude/hooks/shell-check.py.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "config" / "claude" / "hooks" / "shell-check.py"
+
+# A shellcheck stub that reports one finding and exits non-zero.
+STUB_FAIL = (
+  "#!/usr/bin/env bash\n"
+  'echo "In $1 line 2:"\n'
+  'echo "SC2086 (info): Double quote to prevent globbing."\n'
+  "exit 1\n"
+)
+# A shellcheck stub that finds nothing.
+STUB_PASS = "#!/usr/bin/env bash\nexit 0\n"
+
+
+def _stub_dir(tmp_path: Path, body: str) -> Path:
+  d = tmp_path / "stubbin"
+  d.mkdir(exist_ok=True)
+  sc = d / "shellcheck"
+  sc.write_text(body, encoding="utf-8")
+  sc.chmod(0o755)
+  return d
+
+
+def _shell_file(proj: Path, name: str, content: str) -> Path:
+  proj.mkdir(parents=True, exist_ok=True)
+  f = proj / name
+  f.write_text(content, encoding="utf-8")
+  return f
+
+
+def _run(file_path: str, cwd: str, path: str) -> dict:
+  """Invoke the hook with a crafted event and a custom PATH (launched via the
+  absolute interpreter, so PATH governs only the hook's shellcheck lookup).
+  Return parsed JSON ({} when the hook stays silent)."""
+  event = {
+    "tool_name": "Write",
+    "tool_input": {
+      "file_path": file_path
+    },
+    "cwd": cwd,
+  }
+  res = subprocess.run(
+    [sys.executable, str(HOOK)],
+    input=json.dumps(event),
+    capture_output=True,
+    text=True,
+    env={"PATH": path},
+  )
+  assert res.returncode == 0, res.stderr    # always fail-safe exit 0
+  out = res.stdout.strip()
+  return json.loads(out) if out else {}
+
+
+def _context(out: dict) -> str:
+  return out.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def test_reports_findings_on_shell_file(tmp_path):
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "s.sh", "#!/usr/bin/env bash\necho $foo\n")
+  path = str(_stub_dir(tmp_path, STUB_FAIL)) + os.pathsep + os.environ["PATH"]
+  assert "SC2086" in _context(_run(str(f), str(proj), path))
+
+
+def test_silent_when_clean(tmp_path):
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "s.sh", "#!/usr/bin/env bash\necho ok\n")
+  path = str(_stub_dir(tmp_path, STUB_PASS)) + os.pathsep + os.environ["PATH"]
+  assert _run(str(f), str(proj), path) == {}
+
+
+def test_detects_shell_by_shebang(tmp_path):
+  # Extension-less script with a shell shebang is still checked.
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "myscript", "#!/usr/bin/env bash\necho $x\n")
+  path = str(_stub_dir(tmp_path, STUB_FAIL)) + os.pathsep + os.environ["PATH"]
+  assert "SC2086" in _context(_run(str(f), str(proj), path))
+
+
+def test_skips_non_shell_file(tmp_path):
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "notes.txt", "just text\n")
+  # FAIL stub present but must never be invoked for a non-shell file.
+  path = str(_stub_dir(tmp_path, STUB_FAIL)) + os.pathsep + os.environ["PATH"]
+  assert _run(str(f), str(proj), path) == {}
+
+
+def test_skips_python_shebang(tmp_path):
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "tool", "#!/usr/bin/env python3\nprint(1)\n")
+  path = str(_stub_dir(tmp_path, STUB_FAIL)) + os.pathsep + os.environ["PATH"]
+  assert _run(str(f), str(proj), path) == {}
+
+
+def test_skips_file_outside_project(tmp_path):
+  proj = tmp_path / "proj"
+  proj.mkdir()
+  f = _shell_file(
+    tmp_path / "elsewhere", "s.sh", "#!/usr/bin/env bash\necho $foo\n"
+  )
+  path = str(_stub_dir(tmp_path, STUB_FAIL)) + os.pathsep + os.environ["PATH"]
+  # File is not under cwd=proj -> skip before running shellcheck.
+  assert _run(str(f), str(proj), path) == {}
+
+
+def test_fail_open_when_shellcheck_absent(tmp_path):
+  proj = tmp_path / "proj"
+  f = _shell_file(proj, "s.sh", "#!/usr/bin/env bash\necho $foo\n")
+  empty = tmp_path / "empty"
+  empty.mkdir()
+  # PATH lacks shellcheck entirely -> FileNotFoundError -> fail-open silent.
+  assert _run(str(f), str(proj), str(empty)) == {}

--- a/tests/shell/test_ship.bats
+++ b/tests/shell/test_ship.bats
@@ -61,7 +61,12 @@ case "${args[0]}" in
   run)
     case "${args[1]}" in
       list) emit "$GH_RUNS" ;;
-      view) emit "$GH_RUN" ;;
+      view)
+        # Per-run-id data via GH_RUN_<id>, falling back to GH_RUN. Lets a test
+        # give two runs (workflows) distinct conclusions.
+        var="GH_RUN_${args[2]}"
+        emit "${!var:-$GH_RUN}"
+        ;;
     esac
     ;;
   repo) emit "$GH_REPO" ;;
@@ -96,25 +101,42 @@ EOF
   # The latest run (222) is for a different commit; the older run (111) is the
   # one for our tip. The pre-fix code took .[0] (222); the fix selects 111.
   local runs='[{"databaseId":222,"headSha":"feedface"},{"databaseId":111,"headSha":"abc123"}]'
-  local run='{"status":"completed","conclusion":"success","headSha":"abc123","jobs":[{"name":"bats","conclusion":"success"}]}'
+  local run='{"status":"completed","conclusion":"success","workflowName":"tests","headSha":"abc123","jobs":[{"name":"bats","conclusion":"success"}]}'
 
   run env "PATH=$STUB:$PATH" GIT_SHA="abc123" GH_RUNS="$runs" GH_RUN="$run" \
     "$SHIP" ci-watch some-branch
 
   assert_success
-  assert_output --partial "run 111: success"
+  assert_output --partial "tests (run 111): success"
   refute_output --partial "run 222"
 }
 
 @test "ci-watch returns non-zero when the tip run failed" {
   local runs='[{"databaseId":111,"headSha":"abc123"}]'
-  local run='{"status":"completed","conclusion":"failure","headSha":"abc123","jobs":[{"name":"bats","conclusion":"failure"}]}'
+  local run='{"status":"completed","conclusion":"failure","workflowName":"tests","headSha":"abc123","jobs":[{"name":"bats","conclusion":"failure"}]}'
 
   run env "PATH=$STUB:$PATH" GIT_SHA="abc123" GH_RUNS="$runs" GH_RUN="$run" \
     "$SHIP" ci-watch some-branch
 
   assert_failure
-  assert_output --partial "run 111: failure"
+  assert_output --partial "tests (run 111): failure"
+}
+
+@test "ci-watch watches every workflow run for the tip SHA, not just one" {
+  # Two workflows ran the same commit; the second (secret-scan) failed.
+  # Watching only .[0] (tests, success) would miss it — we must see both and
+  # fail. This is the regression for the multi-workflow gap.
+  local runs='[{"databaseId":501,"headSha":"abc123"},{"databaseId":502,"headSha":"abc123"}]'
+  local tests_run='{"status":"completed","conclusion":"success","workflowName":"tests","headSha":"abc123","jobs":[{"name":"bats","conclusion":"success"}]}'
+  local scan_run='{"status":"completed","conclusion":"failure","workflowName":"secret-scan","headSha":"abc123","jobs":[{"name":"trufflehog","conclusion":"failure"}]}'
+
+  run env "PATH=$STUB:$PATH" GIT_SHA="abc123" GH_RUNS="$runs" \
+    GH_RUN_501="$tests_run" GH_RUN_502="$scan_run" \
+    "$SHIP" ci-watch some-branch
+
+  assert_failure
+  assert_output --partial "tests (run 501): success"
+  assert_output --partial "secret-scan (run 502): failure"
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A second batch of independent TODOs (squash-merges to one commit):

- **fix(ship-pr):** `ci-watch` now watches **every** workflow run for the tip
  SHA and aggregates (a PR triggers `tests` + `secret-scan`); it picked `.[0]`
  before and could watch the wrong one. Regression test added.
- **feat(hooks):** a global `PostToolUse` hook (`shell-check.py`) runs
  `shellcheck` on a shell file right after it's edited and reports findings —
  check-only, shellcheck-only, fail-open. 7 hermetic pytest cases; documented
  in `rules/shellcheck.md`.
- **docs(auth):** new `rules/claude-code-auth.md` — the three auth methods,
  full six-method precedence, and the never-export-`ANTHROPIC_API_KEY`-globally
  rule (grounded in the official docs).
- **docs(security-scan):** evaluated a dependabot skill → **declined** (folded
  the reconcile-and-verify procedure into step 2 instead).
- **docs(todo):** perl-QA task now also tracks creating rules/skills; dropped
  the redundant `/push` / `/push-pr` proposal (ship-pr covers it).

## Test plan

- [ ] `pre-commit run --all-files` green (shellcheck/shfmt/yamllint/markdownlint/json/python)
- [ ] `bats tests/shell/test_*.bats` green (incl. updated `test_ship.bats`)
- [ ] `pytest tests/python` green (incl. new `test_shell_check.py`)
- [ ] CI required checks pass: **bats + perl + pre-commit**; `secret-scan` runs green