### PR TITLE
fix(statusline): drop dead .vim.mode field that shifted every field

### DIFF
--- a/bin/git-status
+++ b/bin/git-status
@@ -11,11 +11,23 @@ command -v git &> /dev/null || exit 0
 # Are we in a git repo?
 git rev-parse &> /dev/null || exit 0
 
+# --plain drops the leading space and the wrapping parens. The prompt callers
+# (lib/bash_prompt, config/python/startup) use the default; the Claude
+# statusline uses --plain because it supplies its own ' | ' separators.
+plain=0
+[[ ${1:-} == --plain ]] && plain=1
+
 # Are we in a bare repo?
 [[ $(git rev-parse --is-bare-repository) == 'true' ]] && {
   bare_color=$(ansi bg red fg yellow)
   color_off=$(ansi off)
-  printf ' %s(BARE)%s' "$bare_color" "$color_off"
+
+  if ((plain)); then
+    printf '%sBARE%s' "$bare_color" "$color_off"
+  else
+    printf ' %s(BARE)%s' "$bare_color" "$color_off"
+  fi
+
   exit 0
 }
 
@@ -96,5 +108,9 @@ if [ -n "$info" ]; then
     wt_info=" [wt:${main_repo}]"
   fi
 
-  printf ' %s(%s%s%s%s%s)%s' "$status_color" "$repo" "$branch" "$wt_info" "$upstream" "$stash_info" "$color_off"
+  if ((plain)); then
+    printf '%s%s%s%s%s%s%s' "$status_color" "$repo" "$branch" "$wt_info" "$upstream" "$stash_info" "$color_off"
+  else
+    printf ' %s(%s%s%s%s%s)%s' "$status_color" "$repo" "$branch" "$wt_info" "$upstream" "$stash_info" "$color_off"
+  fi
 fi

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -412,23 +412,31 @@ Done 2026-06-19 (fixed + regression-tested; see the decisions log): the display
 bug (leading empty field + a field-shift from the empty `.vim.mode` column —
 root-caused to the whitespace-`IFS`/`@tsv` parse, now joined on the unit
 separator so absent fields are safe), the context-% prominence, the
-**reasoning-effort `[level]`** indicator (`.effort.level`), and the
+**reasoning-effort `[level]`** indicator (`.effort.level`), the
 **rate-limit usage segment** (`5h:`/`7d:` `used_percentage` riding inside the
-context segment, colored by the shared pct ramp; hidden for non-subscribers).
-`jarrodwatts/claude-hud` was mined — full matrix in
+context segment, colored by the shared pct ramp; hidden for non-subscribers),
+and the **vim-mode segment** (`.vim.mode` rendered ourselves with
+`hideVimModeIndicator: true` — NORMAL is bright-yellow-on-red, INSERT/others
+standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
 [`mining/claude-hud.md`](mining/claude-hud.md). Remaining candidates:
 
-- [ ] **Restore `.vim.mode` (NORMAL/INSERT)?** — user decision. The field is
-  *documented* (present when Claude Code vim mode is on; the user uses vim mode);
-  it was removed in the fix because it was broken as written (built only the
-  empty label, and its empty column shifted the parse). The parse is now
-  empty-safe, so it could be re-added correctly (emit the value, bracket/guard
-  when absent). Decide whether it earns a slot.
 - [ ] **Heavier candidates** (transcript-driven — defer): the tools/agents
   lines and todos `(2/5)`. *(2026-06-19: project path, session duration, output
   speed, and token totals were skipped by the user; the context progress-bar
   glyph is `SKIP-until` on the census watch list — revisit if the plain `X%`
   stops being enough.)*
+
+**`ICEBOX:` cannot hide the native below-prompt indicator lines** — the
+**auto-accept / permission-mode** indicator (`⏵⏵ auto mode on`) and the
+**running-subagent / task** line have **no off-switch** (settings, env, or
+flag) as of 2026-06-19 — verified against the Claude Code docs and by
+re-examining `claude-hud` (which sets no suppression key, can't even read the
+permission mode, and only stacks a transcript-parsed agents line *on top of*
+the native one). The permission mode isn't in the statusline stdin JSON at all,
+so it can't be reconstructed either. Open upstream requests: anthropics/
+claude-code **#27916**, **#48246**. Revisit if either lands a hide option or
+exposes the mode in the JSON; until then, only the vim indicator was
+controllable (and is done).
 
 ### Claude Code compaction control (moved from TODO.md)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -408,22 +408,25 @@ duplicates / similar setups). Chart each in
 
 ### Claude statusline enhancements (claude-hud candidates)
 
-The urgent display bug (leading empty field + a `@tsv`/`read` field-shift from
-the dead `.vim.mode` field) and the context-% prominence are **done** (fixed +
-regression-tested 2026-06-19; see the decisions log). `jarrodwatts/claude-hud`
-was mined for further ideas — full matrix in
-[`mining/claude-hud.md`](mining/claude-hud.md). The top picks are all **gated**
-(none was a clean adopt-now), so they sit here as candidates:
+Done 2026-06-19 (fixed + regression-tested; see the decisions log): the display
+bug (leading empty field + a field-shift from the empty `.vim.mode` column —
+root-caused to the whitespace-`IFS`/`@tsv` parse, now joined on the unit
+separator so absent fields are safe), the context-% prominence, and the
+**reasoning-effort `[level]`** indicator (`.effort.level`). `jarrodwatts/claude-hud`
+was mined — full matrix in [`mining/claude-hud.md`](mining/claude-hud.md).
+Remaining candidates:
 
 - [ ] **Rate-limit / usage segment** — a `| usage NN% |` field (5h + weekly cap)
-  with our existing threshold-color trick; highest value for a Max user, pure
-  stdin JSON. **Gate:** first confirm `rate_limits` is present in our statusline
-  stdin (claude-hud notes it's absent for API-key/Bedrock/Vertex sessions).
-- [ ] **Git ahead/behind `↑N ↓N`** — cheap `git rev-list --count`. **Gate:**
-  belongs in the **shared `git-status`** helper (also feeds the bash prompt) —
-  scope it there, and check it doesn't already emit this.
-- [ ] **Reasoning-effort indicator** `[high]` — tiny, zero extra I/O. **Gate:**
-  verify an effort field is in our stdin JSON.
+  with our existing threshold-color trick; the **highest remaining value** for a
+  Max user, pure stdin JSON. Gate satisfied:
+  `rate_limits.{five_hour,seven_day}.used_percentage` is confirmed in the docs
+  (subscriber-only, present after the first API response — guard for absence).
+- [ ] **Restore `.vim.mode` (NORMAL/INSERT)?** — user decision. The field is
+  *documented* (present when Claude Code vim mode is on; the user uses vim mode);
+  it was removed in the fix because it was broken as written (built only the
+  empty label, and its empty column shifted the parse). The parse is now
+  empty-safe, so it could be re-added correctly (emit the value, bracket/guard
+  when absent). Decide whether it earns a slot.
 - [ ] **Heavier candidates** (transcript-driven, need cache/state — defer):
   context progress-bar glyph, todos `(2/5)`, session duration, output speed
   (tok/s), session token totals. See the matrix for the per-item rationale.

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -427,19 +427,23 @@ standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
   stops being enough.)*
 
 **`ICEBOX:` cannot hide the native below-prompt indicator lines** — the
-**auto-accept / permission-mode** indicator (`⏵⏵ auto mode on`) and the
-**running-subagent / task** line have **no off-switch** (settings, env, or
-flag) as of 2026-06-19 — verified against the Claude Code docs and by
-re-examining `claude-hud` (which sets no suppression key, can't even read the
-permission mode, and only stacks a transcript-parsed agents line *on top of*
-the native one). The permission mode isn't in the statusline **stdin** JSON —
-but it **is** recorded in the **transcript JSONL** (`permission-mode` / `mode`
-entries: `default` / `acceptEdits` / `plan`), so it *could* be reconstructed
-via the heavy transcript-parse path — though that would only **duplicate** the
-un-hideable native line, so it isn't worth it. Open upstream requests:
-anthropics/claude-code **#27916**, **#48246**. Revisit if either lands a hide
-option or exposes the mode in the stdin JSON; until then, only the vim indicator
-was controllable (and is done).
+**auto-accept / permission-mode** indicator (`⏵⏵ auto mode on`), the
+**running-subagent / task** line, and the **`· PR #N`** badge have **no
+off-switch** (settings, env, or flag) as of 2026-06-19 — verified against the
+Claude Code docs and by re-examining `claude-hud` (which sets no suppression
+key, can't even read the permission mode, and only stacks a transcript-parsed
+agents line *on top of* the native one). The only documented `statusLine` hide
+field is `hideVimModeIndicator`; the full set of `statusLine` sub-fields is
+`type` / `command` / `padding` / `refreshInterval` / `hideVimModeIndicator` /
+`subagentStatusLine` (the last **formats** subagent rows — it does **not** hide
+the native line). Consequence: reconstructing any of these (PR#, permission
+mode, agents) in our own statusline would only **duplicate** the un-hideable
+native badge, so it isn't worth it — the permission mode and PR# are both in
+the data (permission mode in the **transcript** `permission-mode`/`mode`
+entries; `.pr.number` in the **stdin** JSON), they just can't replace the
+native display. Open upstream requests: anthropics/claude-code **#27916**,
+**#48246**. Revisit if either lands a hide option; until then, only the vim
+indicator was controllable (and is done).
 
 ### Claude Code compaction control (moved from TODO.md)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -420,6 +420,16 @@ and the **vim-mode segment** (`.vim.mode` rendered ourselves with
 standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
 [`mining/claude-hud.md`](mining/claude-hud.md). Remaining candidates:
 
+- [ ] **Investigate `statusLine.subagentStatusLine`** (surfaced 2026-06-19
+  while confirming the PR-badge can't be hidden). It's a `statusLine` sub-field
+  that *formats* subagent rows. **Decide if it's worth using by answering one
+  thing: does it OVERRIDE the native subagent line or ADD to it?** If it
+  **overrides** (replaces the native row format), great — it's the one native
+  below-prompt element we *can* take control of, so we could restyle the
+  subagent display our way. If it only **adds** a custom row alongside the
+  native one, it would **duplicate** output — not what we want, so skip.
+  Ground the answer in the docs + a quick trial (fire a background subagent and
+  watch the row) before wiring anything.
 - [ ] **Heavier candidates** (transcript-driven — defer): the tools/agents
   lines and todos `(2/5)`. *(2026-06-19: project path, session duration, output
   speed, and token totals were skipped by the user; the context progress-bar

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -427,9 +427,11 @@ Remaining candidates:
   empty label, and its empty column shifted the parse). The parse is now
   empty-safe, so it could be re-added correctly (emit the value, bracket/guard
   when absent). Decide whether it earns a slot.
-- [ ] **Heavier candidates** (transcript-driven, need cache/state — defer):
-  context progress-bar glyph, todos `(2/5)`, session duration, output speed
-  (tok/s), session token totals. See the matrix for the per-item rationale.
+- [ ] **Heavier candidates** (transcript-driven — defer): the tools/agents
+  lines and todos `(2/5)`. *(2026-06-19: project path, session duration, output
+  speed, and token totals were skipped by the user; the context progress-bar
+  glyph is `SKIP-until` on the census watch list — revisit if the plain `X%`
+  stops being enough.)*
 
 ### Claude Code compaction control (moved from TODO.md)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -411,16 +411,13 @@ duplicates / similar setups). Chart each in
 Done 2026-06-19 (fixed + regression-tested; see the decisions log): the display
 bug (leading empty field + a field-shift from the empty `.vim.mode` column —
 root-caused to the whitespace-`IFS`/`@tsv` parse, now joined on the unit
-separator so absent fields are safe), the context-% prominence, and the
-**reasoning-effort `[level]`** indicator (`.effort.level`). `jarrodwatts/claude-hud`
-was mined — full matrix in [`mining/claude-hud.md`](mining/claude-hud.md).
-Remaining candidates:
+separator so absent fields are safe), the context-% prominence, the
+**reasoning-effort `[level]`** indicator (`.effort.level`), and the
+**rate-limit usage segment** (`5h:`/`7d:` `used_percentage` riding inside the
+context segment, colored by the shared pct ramp; hidden for non-subscribers).
+`jarrodwatts/claude-hud` was mined — full matrix in
+[`mining/claude-hud.md`](mining/claude-hud.md). Remaining candidates:
 
-- [ ] **Rate-limit / usage segment** — a `| usage NN% |` field (5h + weekly cap)
-  with our existing threshold-color trick; the **highest remaining value** for a
-  Max user, pure stdin JSON. Gate satisfied:
-  `rate_limits.{five_hour,seven_day}.used_percentage` is confirmed in the docs
-  (subscriber-only, present after the first API response — guard for absence).
 - [ ] **Restore `.vim.mode` (NORMAL/INSERT)?** — user decision. The field is
   *documented* (present when Claude Code vim mode is on; the user uses vim mode);
   it was removed in the fix because it was broken as written (built only the

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -432,11 +432,14 @@ standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
 flag) as of 2026-06-19 — verified against the Claude Code docs and by
 re-examining `claude-hud` (which sets no suppression key, can't even read the
 permission mode, and only stacks a transcript-parsed agents line *on top of*
-the native one). The permission mode isn't in the statusline stdin JSON at all,
-so it can't be reconstructed either. Open upstream requests: anthropics/
-claude-code **#27916**, **#48246**. Revisit if either lands a hide option or
-exposes the mode in the JSON; until then, only the vim indicator was
-controllable (and is done).
+the native one). The permission mode isn't in the statusline **stdin** JSON —
+but it **is** recorded in the **transcript JSONL** (`permission-mode` / `mode`
+entries: `default` / `acceptEdits` / `plan`), so it *could* be reconstructed
+via the heavy transcript-parse path — though that would only **duplicate** the
+un-hideable native line, so it isn't worth it. Open upstream requests:
+anthropics/claude-code **#27916**, **#48246**. Revisit if either lands a hide
+option or exposes the mode in the stdin JSON; until then, only the vim indicator
+was controllable (and is done).
 
 ### Claude Code compaction control (moved from TODO.md)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -406,22 +406,27 @@ duplicates / similar setups). Chart each in
   (does Anthropic or another AI vendor back it?). If meaningful, align our
   skills' format to it.
 
-### Claude statusline fix (urgent)
+### Claude statusline enhancements (claude-hud candidates)
 
-- [ ] **Fix the Claude statusline display** (`config/claude/bin/statusline.sh`).
-  Output is malformed — a leading empty field and awkward layout:
+The urgent display bug (leading empty field + a `@tsv`/`read` field-shift from
+the dead `.vim.mode` field) and the context-% prominence are **done** (fixed +
+regression-tested 2026-06-19; see the decisions log). `jarrodwatts/claude-hud`
+was mined for further ideas — full matrix in
+[`mining/claude-hud.md`](mining/claude-hud.md). The top picks are all **gated**
+(none was a clean adopt-now), so they sit here as candidates:
 
-  ```text
-    |  (dotfiles: bugfix/ci-watch-head-sha) | Opus 4.8 | Ctx: 20% | $10.36 | code v2.1.183
-  ```
-
-  Review the settings; mine <https://github.com/jarrodwatts/claude-hud> for
-  ideas. This is the **simpler, resolve-now** statusline issue — *separate*
-  from the complex four-surface *Statusline Coordination* / Task 1 in `TODO.md`
-  (which stays there, coupled to the bash/tmux/vim work).
-- [ ] **Make the context % more prominent** — since `/compact` is manual (see
-  compaction control below), surface it harder past a threshold (the user's
-  half-joke: blinking bright-yellow-on-deep-red after 60%).
+- [ ] **Rate-limit / usage segment** — a `| usage NN% |` field (5h + weekly cap)
+  with our existing threshold-color trick; highest value for a Max user, pure
+  stdin JSON. **Gate:** first confirm `rate_limits` is present in our statusline
+  stdin (claude-hud notes it's absent for API-key/Bedrock/Vertex sessions).
+- [ ] **Git ahead/behind `↑N ↓N`** — cheap `git rev-list --count`. **Gate:**
+  belongs in the **shared `git-status`** helper (also feeds the bash prompt) —
+  scope it there, and check it doesn't already emit this.
+- [ ] **Reasoning-effort indicator** `[high]` — tiny, zero extra I/O. **Gate:**
+  verify an effort field is in our stdin JSON.
+- [ ] **Heavier candidates** (transcript-driven, need cache/state — defer):
+  context progress-bar glyph, todos `(2/5)`, session duration, output speed
+  (tok/s), session token totals. See the matrix for the per-item rationale.
 
 ### Claude Code compaction control (moved from TODO.md)
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,17 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Added the rate-limit / usage segment to the statusline.**
+  Worked the top remaining claude-hud candidate. Added two fields
+  (`rate_limits.five_hour.used_percentage`, `…seven_day…`) rendered as
+  `5h:NN% 7d:NN%` **inside the context segment** (no `|` between — per the
+  user), each colored by a shared `pct_color` helper (the same calm/warn/alarm
+  ramp as context %; extracted because ctx/5h/7d all need it — Rule of Three).
+  Hidden when `rate_limits` is absent (non-subscriber sessions). jq uses
+  `(… // "") | if . == "" then "" else (floor|tostring) end` so the field is an
+  empty string (not a vanished array element) when missing — safe with the
+  unit-separator parse. Extended `test_statusline.bats` to 12 tests (present /
+  absent / color-escalation). Folded into the statusline PR.
 - 2026-06-19 — **Added the reasoning-effort indicator; root-caused the parse;
   corrected the `.vim.mode` story.** Verified against the official statusline
   docs (claude-code-guide) that **`.effort.level`** (low/medium/high/xhigh/max,

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,26 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Worked a backlog item: fixed the Claude statusline + mined
+  `claude-hud`.** First use of the *Working the backlog* step. (1) **Fixed
+  `config/claude/bin/statusline.sh`:** the reported "leading empty field" was
+  the surface of a deeper bug — the dead `mode` field (`.vim.mode`, absent from
+  Claude Code's statusline JSON) emitted an empty leading `@tsv` column, and
+  `read` with a whitespace `IFS` collapsed the leading tab and **shifted every
+  field by one** (model→mode, ctx→model, …). Removed the `mode` field
+  (eliminates both the stray `|` and the shift), added empty-part filtering for
+  robustness, and made context % escalate harder (cyan → bright-yellow ≥60% →
+  white-on-red alarm ≥80%, since compaction is manual). Added
+  `tests/shell/test_statusline.bats` (6 tests) — the regression test **caught
+  the field-shift** the cosmetic fix alone would have missed. (2) **Mined
+  `jarrodwatts/claude-hud`** (MIT, active, ~25k★) for statusline ideas via a
+  read-only agent: it's a transcript-enriching TS plugin (wrong form to vendor).
+  Recorded the full disposition in `mining/claude-hud.md` and a row in
+  `idea-sources.md`; the top ideas (rate-limit/usage segment, git ahead/behind,
+  effort indicator) are all **gated** on JSON-field verification or the shared
+  `git-status`, so captured as `BACKLOG` candidates rather than added
+  speculatively. Pruned the done statusline item from `BACKLOG`. Landed via
+  dotfiles PR.
 - 2026-06-19 — **Routed a scratch `tmptodo.txt` into `BACKLOG.md` (first live
   test of the routing convention).** Every item proved to be Claude-agent-config
   work — nothing for the dotfiles `TODO.md` — so the whole file routed to

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,26 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Added the reasoning-effort indicator; root-caused the parse;
+  corrected the `.vim.mode` story.** Verified against the official statusline
+  docs (claude-code-guide) that **`.effort.level`** (low/medium/high/xhigh/max,
+  absent when the model lacks effort) is a real field — added it to
+  `statusline.sh`, rendered `[level]` only when present. While there, fixed the
+  **root cause** of the earlier field-shift rather than just its symptom: the
+  `@tsv` + whitespace-`IFS` `read` collapsed empty/leading fields; switched to
+  `join("")` + `IFS=$'\x1f'` (non-whitespace), so an absent field stays in
+  place — effort and future fields are now safe in any position. Two
+  **corrections** the verification surfaced: (a) **`.vim.mode` IS documented**
+  (NORMAL/INSERT, present when CC vim mode is on; the user uses it) — the prior
+  commit's "not in the JSON" was wrong; the field was still broken as written
+  (emitted only the empty label) and caused the shift, so its removal was
+  functionally right but the *reason* was not. Restoring it correctly is now a
+  user-decision BACKLOG item. (b) **`rate_limits` IS present** (5h + 7-day
+  `used_percentage`, subscriber-only) — the rate-limit segment's gate is
+  satisfied; left as the top remaining candidate. Marked git ahead/behind
+  **SKIP** (already in `git-status`, user doesn't surface it). Extended
+  `test_statusline.bats` to 8 tests (effort present/absent). Folded into the
+  statusline PR.
 - 2026-06-19 — **Worked a backlog item: fixed the Claude statusline + mined
   `claude-hud`.** First use of the *Working the backlog* step. (1) **Fixed
   `config/claude/bin/statusline.sh`:** the reported "leading empty field" was

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,20 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Restored the vim-mode segment; confirmed the other native
+  indicator lines can't be hidden.** Set `statusLine.hideVimModeIndicator: true`
+  (placement confirmed against the docs — a sibling of `type`/`command`) and
+  render `.vim.mode` ourselves: a leading segment, NORMAL in bright-yellow-on-red
+  (live command keystrokes), INSERT/others standard, absent when vim mode is off.
+  This removes the built-in `-- INSERT --` text and its NORMAL-collapses-to-empty
+  vertical jitter. Two research tasks settled the rest: (a) the **auto-accept /
+  permission-mode** indicator (`⏵⏵ auto mode on`) and the **subagent/task** line
+  have **no documented or findable off-switch**, and the permission mode is **not
+  in the statusline stdin JSON** (so not reconstructable); (b) **`claude-hud`
+  offers no suppression** of native lines (sets no key, can't see the mode, just
+  stacks its transcript-parsed agents line on top). Recorded as a BACKLOG
+  `ICEBOX:` with upstream #27916 / #48246. 15 statusline tests. Folded into the
+  statusline PR.
 - 2026-06-19 — **Added the rate-limit / usage segment to the statusline.**
   Worked the top remaining claude-hud candidate. Added two fields
   (`rate_limits.five_hour.used_percentage`, `…seven_day…`) rendered as

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -10,7 +10,9 @@ items) and [`idea-sources.md`](idea-sources.md) (mined repos).
   corrected the `.vim.mode` story.** Verified against the official statusline
   docs (claude-code-guide) that **`.effort.level`** (low/medium/high/xhigh/max,
   absent when the model lacks effort) is a real field — added it to
-  `statusline.sh`, rendered `[level]` only when present. While there, fixed the
+  `statusline.sh` as a `[level]` tag riding with the model (no `|` between),
+  colored by level via the same calm/warn/alarm scheme as context %, shown only
+  when present. While there, fixed the
   **root cause** of the earlier field-shift rather than just its symptom: the
   `@tsv` + whitespace-`IFS` `read` collapsed empty/leading fields; switched to
   `join("")` + `IFS=$'\x1f'` (non-whitespace), so an absent field stays in

--- a/config/claude/audit/idea-sources.md
+++ b/config/claude/audit/idea-sources.md
@@ -24,6 +24,7 @@ again. The two are distinct by design:
 | `rafaelkamimura/claude-tools` | Layered-architecture ideas; candidate commands (`adr`, `tech-debt`, `debug-assistant`) and agents (`database-optimizer`, `api-documenter`) | MIT | 2026-06-11 | No (ideas only) |
 | `pydantic/skills` (official) | Pydantic AI **agent-framework** + Logfire skills — relevant only if we adopt LLM agents or Logfire observability; not used today | MIT (check) | 2026-06-11 | No |
 | `fabioc-aloha/spotify-skill` | Spotify Web API skill — endpoint/scope/error inventory, auto-refresh pattern, `ugc-image-upload`→401, cover-art + playlist strategies; refs are stale (pre-2024-11-27, no PKCE) so official docs win | Apache-2.0 | 2026-06-12 | Ideas → `spotify-audit` + `rules/spotify.md` (SOURCE.md) |
+| `jarrodwatts/claude-hud` | Statusline/HUD ideas — rate-limit/usage segment, git ahead/behind, reasoning-effort, progress-bar glyph, and transcript-derived segments (tools/agents/todos/tokens/speed). Top picks all gated on JSON-field verification or the shared `git-status`. Full matrix: [`mining/claude-hud.md`](mining/claude-hud.md) | MIT | 2026-06-19 | No (ideas only; TS plugin, wrong form for our bash line) |
 
 The **full disposition census** of every item in these repos (every agent /
 command / hook / skill considered, ADOPT/CANDIDATE/SKIP + reason) is in

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -49,6 +49,7 @@ new dependency or tool; the audit checks it each run.
 | **Linear** (the SaaS) | `claude-plugins` `linear` plugin (board/comment/cycle/issue-enricher) |
 | **A new language** (Go/Rust/TS…) in a repo | the matching `claude-tools` language-expert agent (Tier-3) |
 | **A browser UI / e2e need** (Playwright) | `claude-tools` `frontend-qa-tester` → the qa End-to-end (dim 8) tool |
+| **Wanting a richer context gauge** (plain `X%` no longer enough) | `claude-hud` context progress-bar glyph → the Claude statusline |
 
 (Tier-3 "build on first use" items are already watch-like by definition; listed
 here so there's one place to scan.)

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -71,7 +71,14 @@ todos `(2/5)` — heavier than a stateless bash/jq line. Reused impl: **none**
 
 While verifying the effort field, the docs also showed **`.vim.mode`
 (NORMAL/INSERT) is a real field** (present when Claude Code vim mode is on) —
-so the `mode` field removed in the statusline fix was *documented*, not
-bogus. It was still broken as written (the build emitted only the empty label,
-never the value, and the absent value shifted the parse). Whether to restore it
-(now the parse is empty-safe) is a **user decision** — see the BACKLOG entry.
+so the `mode` field removed in the statusline fix was *documented*, not bogus.
+It was **restored** 2026-06-19, rendered ourselves with `hideVimModeIndicator:
+true` (NORMAL bright-yellow-on-red, INSERT/others standard; leads the line).
+
+Re-examined `claude-hud` (2026-06-19) for a way to suppress Claude Code's
+native below-prompt lines — **it has none**: it sets no suppression key, can't
+read the permission/auto-accept mode (not in its stdin), and its agents line is
+a transcript-parsed display stacked on top of the native one. The
+**auto-accept indicator and subagent line have no off-switch** and the
+permission mode isn't in the statusline JSON — see the BACKLOG `ICEBOX:` note
+(upstream #27916 / #48246).

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -48,7 +48,7 @@ covered/not a fit.
 | **Output speed (tok/s)** | render-to-render `output_tokens` delta, cached on `sha256(transcript_path)` | CANDIDATE | clever, but needs a per-session **cache file + delta state** — heavy for a stateless line |
 | Session token totals (in/out/cache) | transcript | CANDIDATE | transcript sum |
 | Compaction count / advisor / cache-TTL / mem | transcript / OS | SKIP | niche / not session state |
-| **Reasoning-effort `[high]`** | stdin `.effort.level` | **ADOPTED** | done 2026-06-19 — `.effort.level` (low/medium/high/xhigh/max) confirmed in the docs; rendered as `[level]` only when present |
+| **Reasoning-effort `[high]`** | stdin `.effort.level` | **ADOPTED** | done 2026-06-19 — `.effort.level` (low/medium/high/xhigh/max) confirmed; rendered as a `[level]` tag attached to the model (no `\|` between), colored by level via the context calm/warn/alarm scheme; shown only when present |
 | Threshold color escalation | numeric → color | SKIP | we already do cyan/yellow/red-alarm |
 | Cost / version | stdin | SKIP | already shown |
 | `--extra-cmd` arbitrary shell | spawn | SKIP | security surface, unwanted |

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -41,7 +41,7 @@ covered/not a fit.
 | Git ahead/behind `↑N ↓N` | `git rev-list --count` | **SKIP** | already implemented in our `git-status` helper — the user deliberately does not surface it |
 | Git file stats | porcelain | SKIP | `git-status` covers dirty |
 | Context progress **bar** glyph | stdin % | **SKIP-until** | user is fine with the plain `X%` for now — revisit if a richer context gauge is wanted (on the census watch list) |
-| **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **CANDIDATE** | highest practical value for a Max user, pure-JSON. `rate_limits.{five_hour,seven_day}.used_percentage` **confirmed present** in the docs (subscriber-only, after first API response) — gate satisfied, ready to implement |
+| **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **ADOPTED** | done 2026-06-19 — `5h:`/`7d:` `used_percentage` ride inside the context segment (no `\|`), colored by the shared pct ramp; hidden when `rate_limits` is absent (non-subscriber) |
 | Tools / Skills / MCP / Agents lines | transcript | SKIP/CANDIDATE | transcript-stream heavy; agents-line is the only tempting one |
 | Todos progress `(2/5)` | transcript | CANDIDATE | nice, transcript-dependent |
 | Session duration / last-reply | transcript | SKIP | user not interested |
@@ -57,9 +57,8 @@ covered/not a fit.
 
 - **Reasoning-effort indicator** — **DONE** 2026-06-19 (`.effort.level`
   confirmed; rendered `[level]`).
-- **Rate-limit / usage segment** — **READY** (gate satisfied: `rate_limits`
-  confirmed in the docs). Best remaining value for a Max user; left as a
-  `BACKLOG` candidate.
+- **Rate-limit / usage segment** — **DONE** 2026-06-19 (`5h:`/`7d:`
+  `used_percentage` inside the context segment, colored by the pct ramp).
 - ~~Git ahead/behind~~ — **SKIP**: already in `git-status`, user doesn't
   surface it.
 - **User-trimmed (2026-06-19):** project path, session duration, output speed,

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -36,17 +36,17 @@ covered/not a fit.
 |---|---|---|---|
 | Model badge | stdin | SKIP | we show model name |
 | Provider label (Bedrock/Vertex) | stdin | SKIP | single-provider Max user |
-| Project path (1–3 levels) | cwd | CANDIDATE | cheap nicety; git branch usually conveys location |
+| Project path (1–3 levels) | cwd | SKIP | user is good with the `git-status` output; git branch conveys location |
 | Git branch + dirty | git | SKIP | our `git-status` covers it |
 | Git ahead/behind `↑N ↓N` | `git rev-list --count` | **SKIP** | already implemented in our `git-status` helper — the user deliberately does not surface it |
 | Git file stats | porcelain | SKIP | `git-status` covers dirty |
-| Context progress **bar** glyph | stdin % | CANDIDATE | nicer than our colored %, but costs width + render logic |
+| Context progress **bar** glyph | stdin % | **SKIP-until** | user is fine with the plain `X%` for now — revisit if a richer context gauge is wanted (on the census watch list) |
 | **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **CANDIDATE** | highest practical value for a Max user, pure-JSON. `rate_limits.{five_hour,seven_day}.used_percentage` **confirmed present** in the docs (subscriber-only, after first API response) — gate satisfied, ready to implement |
 | Tools / Skills / MCP / Agents lines | transcript | SKIP/CANDIDATE | transcript-stream heavy; agents-line is the only tempting one |
 | Todos progress `(2/5)` | transcript | CANDIDATE | nice, transcript-dependent |
-| Session duration / last-reply | transcript | CANDIDATE | start time needs transcript |
-| **Output speed (tok/s)** | render-to-render `output_tokens` delta, cached on `sha256(transcript_path)` | CANDIDATE | clever, but needs a per-session **cache file + delta state** — heavy for a stateless line |
-| Session token totals (in/out/cache) | transcript | CANDIDATE | transcript sum |
+| Session duration / last-reply | transcript | SKIP | user not interested |
+| **Output speed (tok/s)** | render-to-render `output_tokens` delta, cached on `sha256(transcript_path)` | SKIP | user not interested; also needs a per-session cache file + delta state |
+| Session token totals (in/out/cache) | transcript | SKIP | user not interested |
 | Compaction count / advisor / cache-TTL / mem | transcript / OS | SKIP | niche / not session state |
 | **Reasoning-effort `[high]`** | stdin `.effort.level` | **ADOPTED** | done 2026-06-19 — `.effort.level` (low/medium/high/xhigh/max) confirmed; rendered as a `[level]` tag attached to the model (no `\|` between), colored by level via the context calm/warn/alarm scheme; shown only when present |
 | Threshold color escalation | numeric → color | SKIP | we already do cyan/yellow/red-alarm |
@@ -62,10 +62,13 @@ covered/not a fit.
   `BACKLOG` candidate.
 - ~~Git ahead/behind~~ — **SKIP**: already in `git-status`, user doesn't
   surface it.
+- **User-trimmed (2026-06-19):** project path, session duration, output speed,
+  session token totals → **SKIP** (not wanted). Context progress-bar glyph →
+  **SKIP-until** (fine with the plain `X%` for now; watch list).
 
-Everything transcript-driven (tools/agents/todos/tokens/duration/speed) is
-**heavier than a stateless bash/jq line** and stays CANDIDATE. Reused impl:
-**none** (ideas only; it's a TS plugin, wrong form for our bash statusline).
+The only remaining transcript-driven CANDIDATEs are the tools/agents lines and
+todos `(2/5)` — heavier than a stateless bash/jq line. Reused impl: **none**
+(ideas only; it's a TS plugin, wrong form for our bash statusline).
 
 While verifying the effort field, the docs also showed **`.vim.mode`
 (NORMAL/INSERT) is a real field** (present when Claude Code vim mode is on) —

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -1,0 +1,68 @@
+# Mining matrix — jarrodwatts/claude-hud
+
+Mined 2026-06-19 for **statusline / HUD ideas** (triggered by the Claude
+statusline display fix). Audit-only (not context-loaded).
+
+## Metadata
+
+- **Repo:** <https://github.com/jarrodwatts/claude-hud>
+- **License:** MIT · **Language:** TypeScript · **Type:** Claude Code *plugin*
+  (not a shell script) — commands `/claude-hud:setup`, `/claude-hud:configure`.
+- **Recency:** actively maintained (pushed 2026-06-19) — well inside the >1yr
+  staleness gate. ~25k stars.
+
+## What it is
+
+A native statusline renderer (TS, stdin → line). It **enriches** the documented
+statusline JSON from three extra sources: the **transcript JSONL**
+(`transcript_path`, streamed for tool/agent/todo/skill/MCP activity, per-session
+token totals, session start, compaction count, advisor model), **git** (shell
+out for branch/dirty/ahead-behind/file-stats), and an optional snapshot /
+env-gated `--extra-cmd`. Multi-line "expanded" layout by default + a "compact"
+single-line mode; ~40 segment toggles, presets, `elementOrder`, i18n, 12
+themeable colors, configurable bar glyphs.
+
+Contrast with ours: `config/claude/bin/statusline.sh` is a **stateless** single
+` | `-joined bash/jq line (git-status, model, ctx %, cost, version) that reads
+**only** the documented stdin JSON — no transcript parsing, no per-session
+cache.
+
+## Disposition
+
+ADOPT = cheap clear win now · CANDIDATE = worth it later (note cost) · SKIP =
+covered/not a fit.
+
+| Segment / technique | Source | Disp. | Reason |
+|---|---|---|---|
+| Model badge | stdin | SKIP | we show model name |
+| Provider label (Bedrock/Vertex) | stdin | SKIP | single-provider Max user |
+| Project path (1–3 levels) | cwd | CANDIDATE | cheap nicety; git branch usually conveys location |
+| Git branch + dirty | git | SKIP | our `git-status` covers it |
+| **Git ahead/behind `↑N ↓N`** | `git rev-list --count` | **CANDIDATE** | cheap, flags unpushed/unpulled — but belongs in the **shared `git-status`** helper (touches the bash prompt too) |
+| Git file stats | porcelain | SKIP | `git-status` covers dirty |
+| Context progress **bar** glyph | stdin % | CANDIDATE | nicer than our colored %, but costs width + render logic |
+| **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **CANDIDATE (verify)** | highest practical value for a Max user, pure-JSON — **but must confirm `rate_limits` is in our stdin** (absent for API-key/Bedrock/Vertex) |
+| Tools / Skills / MCP / Agents lines | transcript | SKIP/CANDIDATE | transcript-stream heavy; agents-line is the only tempting one |
+| Todos progress `(2/5)` | transcript | CANDIDATE | nice, transcript-dependent |
+| Session duration / last-reply | transcript | CANDIDATE | start time needs transcript |
+| **Output speed (tok/s)** | render-to-render `output_tokens` delta, cached on `sha256(transcript_path)` | CANDIDATE | clever, but needs a per-session **cache file + delta state** — heavy for a stateless line |
+| Session token totals (in/out/cache) | transcript | CANDIDATE | transcript sum |
+| Compaction count / advisor / cache-TTL / mem | transcript / OS | SKIP | niche / not session state |
+| **Reasoning-effort `[high]`** | stdin effort | **CANDIDATE (verify)** | tiny, zero I/O — **if** our stdin exposes an effort field |
+| Threshold color escalation | numeric → color | SKIP | we already do cyan/yellow/red-alarm |
+| Cost / version | stdin | SKIP | already shown |
+| `--extra-cmd` arbitrary shell | spawn | SKIP | security surface, unwanted |
+
+## Top ideas (all gated — none clean-adopt-now)
+
+1. **Rate-limit / usage segment** — best value, pure-JSON, same threshold-color
+   trick. **Gate:** verify `rate_limits` exists in our statusline stdin.
+2. **Git ahead/behind `↑N ↓N`** — cheap. **Gate:** belongs in the shared
+   `git-status` helper (affects the bash prompt), and check it doesn't already
+   emit it.
+3. **Reasoning-effort indicator** — tiny. **Gate:** verify an effort field is
+   in stdin.
+
+Everything transcript-driven (tools/agents/todos/tokens/duration/speed) is
+**heavier than a stateless bash/jq line** and stays CANDIDATE. Reused impl:
+**none** (ideas only; it's a TS plugin, wrong form for our bash statusline).

--- a/config/claude/audit/mining/claude-hud.md
+++ b/config/claude/audit/mining/claude-hud.md
@@ -38,31 +38,38 @@ covered/not a fit.
 | Provider label (Bedrock/Vertex) | stdin | SKIP | single-provider Max user |
 | Project path (1–3 levels) | cwd | CANDIDATE | cheap nicety; git branch usually conveys location |
 | Git branch + dirty | git | SKIP | our `git-status` covers it |
-| **Git ahead/behind `↑N ↓N`** | `git rev-list --count` | **CANDIDATE** | cheap, flags unpushed/unpulled — but belongs in the **shared `git-status`** helper (touches the bash prompt too) |
+| Git ahead/behind `↑N ↓N` | `git rev-list --count` | **SKIP** | already implemented in our `git-status` helper — the user deliberately does not surface it |
 | Git file stats | porcelain | SKIP | `git-status` covers dirty |
 | Context progress **bar** glyph | stdin % | CANDIDATE | nicer than our colored %, but costs width + render logic |
-| **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **CANDIDATE (verify)** | highest practical value for a Max user, pure-JSON — **but must confirm `rate_limits` is in our stdin** (absent for API-key/Bedrock/Vertex) |
+| **Rate-limit / usage bar (5h + weekly)** | stdin `rate_limits` | **CANDIDATE** | highest practical value for a Max user, pure-JSON. `rate_limits.{five_hour,seven_day}.used_percentage` **confirmed present** in the docs (subscriber-only, after first API response) — gate satisfied, ready to implement |
 | Tools / Skills / MCP / Agents lines | transcript | SKIP/CANDIDATE | transcript-stream heavy; agents-line is the only tempting one |
 | Todos progress `(2/5)` | transcript | CANDIDATE | nice, transcript-dependent |
 | Session duration / last-reply | transcript | CANDIDATE | start time needs transcript |
 | **Output speed (tok/s)** | render-to-render `output_tokens` delta, cached on `sha256(transcript_path)` | CANDIDATE | clever, but needs a per-session **cache file + delta state** — heavy for a stateless line |
 | Session token totals (in/out/cache) | transcript | CANDIDATE | transcript sum |
 | Compaction count / advisor / cache-TTL / mem | transcript / OS | SKIP | niche / not session state |
-| **Reasoning-effort `[high]`** | stdin effort | **CANDIDATE (verify)** | tiny, zero I/O — **if** our stdin exposes an effort field |
+| **Reasoning-effort `[high]`** | stdin `.effort.level` | **ADOPTED** | done 2026-06-19 — `.effort.level` (low/medium/high/xhigh/max) confirmed in the docs; rendered as `[level]` only when present |
 | Threshold color escalation | numeric → color | SKIP | we already do cyan/yellow/red-alarm |
 | Cost / version | stdin | SKIP | already shown |
 | `--extra-cmd` arbitrary shell | spawn | SKIP | security surface, unwanted |
 
-## Top ideas (all gated — none clean-adopt-now)
+## Top ideas — outcome
 
-1. **Rate-limit / usage segment** — best value, pure-JSON, same threshold-color
-   trick. **Gate:** verify `rate_limits` exists in our statusline stdin.
-2. **Git ahead/behind `↑N ↓N`** — cheap. **Gate:** belongs in the shared
-   `git-status` helper (affects the bash prompt), and check it doesn't already
-   emit it.
-3. **Reasoning-effort indicator** — tiny. **Gate:** verify an effort field is
-   in stdin.
+- **Reasoning-effort indicator** — **DONE** 2026-06-19 (`.effort.level`
+  confirmed; rendered `[level]`).
+- **Rate-limit / usage segment** — **READY** (gate satisfied: `rate_limits`
+  confirmed in the docs). Best remaining value for a Max user; left as a
+  `BACKLOG` candidate.
+- ~~Git ahead/behind~~ — **SKIP**: already in `git-status`, user doesn't
+  surface it.
 
 Everything transcript-driven (tools/agents/todos/tokens/duration/speed) is
 **heavier than a stateless bash/jq line** and stays CANDIDATE. Reused impl:
 **none** (ideas only; it's a TS plugin, wrong form for our bash statusline).
+
+While verifying the effort field, the docs also showed **`.vim.mode`
+(NORMAL/INSERT) is a real field** (present when Claude Code vim mode is on) —
+so the `mode` field removed in the statusline fix was *documented*, not
+bogus. It was still broken as written (the build emitted only the empty label,
+never the value, and the absent value shifted the parse). Whether to restore it
+(now the parse is empty-safe) is a **user decision** — see the BACKLOG entry.

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -39,6 +39,12 @@ join_array() {
 declare -a vars
 declare -A jq_filter sl_label
 
+# Vim mode (NORMAL/INSERT/VISUAL/…), present only with vim editor mode +
+# hideVimModeIndicator set, so we render it ourselves instead of the built-in.
+vars+=('vim')
+jq_filter['vim']='.vim.mode // ""'
+sl_label['vim']=''
+
 vars+=('model')
 jq_filter['model']='.model.display_name // "unknown"'
 sl_label['model']=''
@@ -103,14 +109,22 @@ cost=$(printf '%.2f' "$cost" 2> /dev/null || printf '?.??')
 # bright yellow past 60%, then an alarm block (bright text on a red background)
 # once it crosses 80%.
 
-declare cyan bright_yellow alarm reset
+declare cyan bright_yellow alarm vim_normal reset
 
 if command -v ansi &> /dev/null; then
   cyan=$(ansi fg cyan)
   bright_yellow=$(ansi fg bright_yellow)
   alarm="$(ansi bg red)$(ansi fg bright_white)"
+  vim_normal="$(ansi bg red)$(ansi fg bright_yellow)"
   reset=$(ansi off)
 fi
+
+# NORMAL mode stands out (bright yellow on red — command keystrokes are live);
+# INSERT and the rest use the terminal's standard color.
+case $vim in
+  NORMAL) vim_color=$vim_normal ;;
+  *) vim_color='' ;;
+esac
 
 # Percentage fields (context %, the rate-limit usage caps) share one ramp:
 # calm cyan < 60, bright yellow 60–79, alarm block >= 80. An empty value
@@ -147,6 +161,8 @@ declare -a parts
 
 add_part() { [[ -n $1 ]] && parts+=("$1"); }
 
+# Vim mode leads the line (we render it; the built-in indicator is hidden).
+[[ -n $vim ]] && add_part "${vim_color}${vim}${reset}"
 add_part "$(git-status)"
 # Effort rides with the model (no ' | ' between them), colored by level and
 # bracketed — only when the model reports one.

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -49,7 +49,17 @@ sl_label['effort']=''
 
 vars+=('ctx')
 jq_filter['ctx']='(.context_window.used_percentage // 0) | floor | tostring'
-sl_label['ctx']='Ctx: '
+sl_label['ctx']='Ctx:'
+
+# Subscriber rate-limit usage (5-hour + 7-day caps), absent on non-subscriber
+# sessions — empty string when missing so the segment is simply skipped.
+vars+=('r5h')
+jq_filter['r5h']='(.rate_limits.five_hour.used_percentage // "") | if . == "" then "" else (floor | tostring) end'
+sl_label['r5h']=''
+
+vars+=('r7d')
+jq_filter['r7d']='(.rate_limits.seven_day.used_percentage // "") | if . == "" then "" else (floor | tostring) end'
+sl_label['r7d']=''
 
 vars+=('cost')
 jq_filter['cost']='.cost.total_cost_usd // 0 | tostring'
@@ -102,15 +112,26 @@ if command -v ansi &> /dev/null; then
   reset=$(ansi off)
 fi
 
-if ((ctx >= 80)); then
-  ctx_color=$alarm
-elif ((ctx >= 60)); then
-  ctx_color=$bright_yellow
-else
-  ctx_color=$cyan
-fi
+# Percentage fields (context %, the rate-limit usage caps) share one ramp:
+# calm cyan < 60, bright yellow 60–79, alarm block >= 80. An empty value
+# (a missing rate limit) ranks as 0 — its color is unused anyway.
+pct_color() {
+  local v=$((${1:-0} + 0))
 
-# Effort reuses the context calm/warn/alarm colors, ranked by how expensive
+  if ((v >= 80)); then
+    printf '%s' "$alarm"
+  elif ((v >= 60)); then
+    printf '%s' "$bright_yellow"
+  else
+    printf '%s' "$cyan"
+  fi
+}
+
+ctx_color=$(pct_color "$ctx")
+r5h_color=$(pct_color "$r5h")
+r7d_color=$(pct_color "$r7d")
+
+# Effort reuses the same calm/warn/alarm colors, ranked by how expensive
 # the reasoning level is (higher effort burns more, like a fuller window).
 case $effort in
   max | xhigh) effort_color=$alarm ;;
@@ -132,7 +153,13 @@ add_part "$(git-status)"
 model_part="${sl_label['model']}${model}"
 [[ -n $effort ]] && model_part+=" ${effort_color}[$effort]${reset}"
 add_part "$model_part"
-add_part "${sl_label['ctx']}${ctx_color}${ctx}%${reset}"
+# Context % and the rate-limit usage caps (5h / 7-day) ride together as one
+# segment — no ' | ' between them — each colored by the shared pct ramp.
+# Percentages are right-aligned in 3 columns so the values line up.
+ctx_part="${sl_label['ctx']}${ctx_color}$(printf '%3d' "$ctx")%${reset}"
+[[ -n $r5h ]] && ctx_part+=" 5h:${r5h_color}$(printf '%3d' "$r5h")%${reset}"
+[[ -n $r7d ]] && ctx_part+=" 7d:${r7d_color}$(printf '%3d' "$r7d")%${reset}"
+add_part "$ctx_part"
 add_part "${sl_label['cost']}${cost}"
 add_part "${sl_label['version']}${version}"
 

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -110,6 +110,14 @@ else
   ctx_color=$cyan
 fi
 
+# Effort reuses the context calm/warn/alarm colors, ranked by how expensive
+# the reasoning level is (higher effort burns more, like a fuller window).
+case $effort in
+  max | xhigh) effort_color=$alarm ;;
+  high) effort_color=$bright_yellow ;;
+  *) effort_color=$cyan ;;
+esac
+
 #------------------------------------------------------------------------------
 # Build output parts and join with ' | '. Empty fields are dropped so a blank
 # value (e.g. git-status outside a repo) leaves no stray ' | '.
@@ -119,9 +127,11 @@ declare -a parts
 add_part() { [[ -n $1 ]] && parts+=("$1"); }
 
 add_part "$(git-status)"
-add_part "${sl_label['model']}${model}"
-# effort is absent on models without it; bracket it only when present
-[[ -n $effort ]] && add_part "[$effort]"
+# Effort rides with the model (no ' | ' between them), colored by level and
+# bracketed — only when the model reports one.
+model_part="${sl_label['model']}${model}"
+[[ -n $effort ]] && model_part+=" ${effort_color}[$effort]${reset}"
+add_part "$model_part"
 add_part "${sl_label['ctx']}${ctx_color}${ctx}%${reset}"
 add_part "${sl_label['cost']}${cost}"
 add_part "${sl_label['version']}${version}"

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -31,8 +31,10 @@ join_array() {
 }
 
 #------------------------------------------------------------------------------
-# Field definitions — add/remove fields here; vars order sets display order.
-# jq expressions receive the full session JSON object.
+# Field definitions — add/remove fields here; the build section below sets
+# display order. Every jq expression MUST yield a string (use `// ""` /
+# `tostring`) so the join in Gather never sees a null. Fields may be empty
+# (effort is absent on models without it); empties are handled downstream.
 
 declare -a vars
 declare -A jq_filter sl_label
@@ -40,6 +42,10 @@ declare -A jq_filter sl_label
 vars+=('model')
 jq_filter['model']='.model.display_name // "unknown"'
 sl_label['model']=''
+
+vars+=('effort')
+jq_filter['effort']='.effort.level // ""'
+sl_label['effort']=''
 
 vars+=('ctx')
 jq_filter['ctx']='(.context_window.used_percentage // 0) | floor | tostring'
@@ -50,14 +56,16 @@ jq_filter['cost']='.cost.total_cost_usd // 0 | tostring'
 sl_label['cost']='$'
 
 vars+=('version')
-jq_filter['version']='.version'
+jq_filter['version']='.version // ""'
 sl_label['version']='code v'
 
 #------------------------------------------------------------------------------
-# Gather data — single jq call via @tsv, one read
+# Gather data — single jq call, one read.
 #
-# @tsv formats the jq array as tab-separated values so that a single
-# IFS=$'\t' read can split all fields into their named variables in one pass.
+# Fields are joined on the ASCII unit separator (US, 0x1f) rather than @tsv:
+# a tab is an IFS whitespace char, so `read` would collapse a leading/empty
+# field and shift every value left (an absent effort/version would scramble
+# the line). US is non-whitespace, so `read` preserves empty fields in place.
 
 data=$(cat)
 
@@ -66,11 +74,11 @@ for v in "${vars[@]}"; do
   jq_parts+=("(${jq_filter[$v]})")
 done
 
-IFS=$'\t' read -r "${vars[@]}" < <(
+IFS=$'\x1f' read -r "${vars[@]}" < <(
   printf '%s' "$data" | jq -r "[ $(
     IFS=','
     printf '%s' "${jq_parts[*]}"
-  ) ] | @tsv" 2> /dev/null
+  ) ] | join(\"\u001f\")" 2> /dev/null
 ) || true
 
 #------------------------------------------------------------------------------
@@ -112,6 +120,8 @@ add_part() { [[ -n $1 ]] && parts+=("$1"); }
 
 add_part "$(git-status)"
 add_part "${sl_label['model']}${model}"
+# effort is absent on models without it; bracket it only when present
+[[ -n $effort ]] && add_part "[$effort]"
 add_part "${sl_label['ctx']}${ctx_color}${ctx}%${reset}"
 add_part "${sl_label['cost']}${cost}"
 add_part "${sl_label['version']}${version}"

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -37,10 +37,6 @@ join_array() {
 declare -a vars
 declare -A jq_filter sl_label
 
-vars+=('mode')
-jq_filter['mode']='.vim.mode'
-sl_label['mode']=
-
 vars+=('model')
 jq_filter['model']='.model.display_name // "unknown"'
 sl_label['model']=''
@@ -84,35 +80,40 @@ ctx=$((${ctx%%.*} + 0))
 cost=$(printf '%.2f' "$cost" 2> /dev/null || printf '?.??')
 
 #------------------------------------------------------------------------------
-# Set colors
+# Set colors. Context % escalates so a near-full window is hard to miss —
+# compaction is manual, so the percentage is the only warning: calm cyan, then
+# bright yellow past 60%, then an alarm block (bright text on a red background)
+# once it crosses 80%.
 
-declare red yellow cyan reset
+declare cyan bright_yellow alarm reset
 
 if command -v ansi &> /dev/null; then
-  red=$(ansi fg red)
-  yellow=$(ansi fg yellow)
   cyan=$(ansi fg cyan)
+  bright_yellow=$(ansi fg bright_yellow)
+  alarm="$(ansi bg red)$(ansi fg bright_white)"
   reset=$(ansi off)
 fi
 
-if ((ctx >= 75)); then
-  ctx_color=$red
-elif ((ctx >= 50)); then
-  ctx_color=$yellow
+if ((ctx >= 80)); then
+  ctx_color=$alarm
+elif ((ctx >= 60)); then
+  ctx_color=$bright_yellow
 else
   ctx_color=$cyan
 fi
 
 #------------------------------------------------------------------------------
-# Build output parts and join with ' | '
+# Build output parts and join with ' | '. Empty fields are dropped so a blank
+# value (e.g. git-status outside a repo) leaves no stray ' | '.
 
 declare -a parts
 
-parts+=("${sl_label['mode']}")
-parts+=("$(git-status)")
-parts+=("${sl_label['model']}${model}")
-parts+=("${sl_label['ctx']}${ctx_color}${ctx}%${reset}")
-parts+=("${sl_label['cost']}${cost}")
-parts+=("${sl_label['version']}${version}")
+add_part() { [[ -n $1 ]] && parts+=("$1"); }
+
+add_part "$(git-status)"
+add_part "${sl_label['model']}${model}"
+add_part "${sl_label['ctx']}${ctx_color}${ctx}%${reset}"
+add_part "${sl_label['cost']}${cost}"
+add_part "${sl_label['version']}${version}"
 
 printf '%s\n' "$(join_array ' | ' 'parts')"

--- a/config/claude/bin/statusline.sh
+++ b/config/claude/bin/statusline.sh
@@ -163,7 +163,8 @@ add_part() { [[ -n $1 ]] && parts+=("$1"); }
 
 # Vim mode leads the line (we render it; the built-in indicator is hidden).
 [[ -n $vim ]] && add_part "${vim_color}${vim}${reset}"
-add_part "$(git-status)"
+# --plain: no wrapping parens / leading space; the ' | ' join handles spacing.
+add_part "$(git-status --plain)"
 # Effort rides with the model (no ' | ' between them), colored by level and
 # bracketed — only when the model reports one.
 model_part="${sl_label['model']}${model}"

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -44,7 +44,8 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/bin/statusline.sh",
-    "refreshInterval": 5
+    "refreshInterval": 5,
+    "hideVimModeIndicator": true
   },
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true

--- a/tests/shell/test_git-status.bats
+++ b/tests/shell/test_git-status.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# Covers bin/git-status's --plain flag (used by the Claude statusline): it drops
+# the leading space + wrapping parens the prompt callers keep. Runs against this
+# real repo; skips if git-status emits nothing (no __git_ps1 available).
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  ROOT="$(dotfiles_root)"
+}
+
+# Strip ANSI color + charset-select codes so paren/space checks see plain text.
+strip_ansi() {
+  sed 's/\x1b\[[0-9;]*m//g; s/\x1b(B//g'
+}
+
+@test "git-status (default) wraps the repo in parens for the prompt" {
+  run "$ROOT/bin/git-status"
+  [[ -n $output ]] || skip "git-status produced no output (no __git_ps1?)"
+
+  local plain
+  plain=$(printf '%s' "$output" | strip_ansi)
+  [[ $plain == *'('* ]] || fail "default output lost its parens: $plain"
+}
+
+@test "git-status --plain drops the parens and the leading space" {
+  run "$ROOT/bin/git-status" --plain
+  [[ -n $output ]] || skip "git-status produced no output (no __git_ps1?)"
+
+  local plain
+  plain=$(printf '%s' "$output" | strip_ansi)
+  [[ $plain != *'('* ]] || fail "--plain output still has parens: $plain"
+  [[ $plain != *')'* ]] || fail "--plain output still has parens: $plain"
+  [[ $plain != ' '* ]] || fail "--plain output has a leading space: $plain"
+}

--- a/tests/shell/test_git-status.bats
+++ b/tests/shell/test_git-status.bats
@@ -14,6 +14,12 @@ setup() {
   load_bats_libs
   ROOT="$(dotfiles_root)"
 
+  # Stub `ansi` to a no-op — NOT because ansi is broken (it already degrades to
+  # silence in an incomplete terminal: TERM=dumb / no tput). The stub is purely
+  # for the test: bin/ isn't on PATH in CI, so git-status's bare `ansi` call
+  # would print "command not found" to stderr (which `run` captures), and the
+  # stub also strips real color codes so the paren/space assertions see clean
+  # text.
   STUB="$(make_stub_dir)"
   printf '#!/usr/bin/env bash\n' > "$STUB/ansi"
   chmod +x "$STUB/ansi"

--- a/tests/shell/test_git-status.bats
+++ b/tests/shell/test_git-status.bats
@@ -1,37 +1,46 @@
 #!/usr/bin/env bats
 
 # Covers bin/git-status's --plain flag (used by the Claude statusline): it drops
-# the leading space + wrapping parens the prompt callers keep. Runs against this
-# real repo; skips if git-status emits nothing (no __git_ps1 available).
+# the leading space + wrapping parens the prompt callers keep.
+#
+# Runs in a throwaway repo with a normal (non-detached) branch and a no-op
+# `ansi` stub, so output is deterministic regardless of CI's detached HEAD or
+# whether `ansi` is on PATH. Skips if __git_ps1 isn't available (git-status
+# then prints nothing).
 
 load ../helpers/common
 
 setup() {
   load_bats_libs
   ROOT="$(dotfiles_root)"
+
+  STUB="$(make_stub_dir)"
+  printf '#!/usr/bin/env bash\n' > "$STUB/ansi"
+  chmod +x "$STUB/ansi"
+
+  REPO="$BATS_TEST_TMPDIR/sample"
+  git init -q "$REPO"
+  git -C "$REPO" -c user.email=t@example.com -c user.name=t \
+    commit -q --allow-empty -m init
 }
 
-# Strip ANSI color + charset-select codes so paren/space checks see plain text.
-strip_ansi() {
-  sed 's/\x1b\[[0-9;]*m//g; s/\x1b(B//g'
+teardown() {
+  rm -rf "$STUB"
 }
 
-@test "git-status (default) wraps the repo in parens for the prompt" {
-  run "$ROOT/bin/git-status"
+@test "git-status (default) wraps the repo as ' (repo: branch)'" {
+  cd "$REPO"
+  run env PATH="$STUB:$PATH" "$ROOT/bin/git-status"
   [[ -n $output ]] || skip "git-status produced no output (no __git_ps1?)"
-
-  local plain
-  plain=$(printf '%s' "$output" | strip_ansi)
-  [[ $plain == *'('* ]] || fail "default output lost its parens: $plain"
+  assert_output --regexp '^ \(sample: '
 }
 
 @test "git-status --plain drops the parens and the leading space" {
-  run "$ROOT/bin/git-status" --plain
+  cd "$REPO"
+  run env PATH="$STUB:$PATH" "$ROOT/bin/git-status" --plain
   [[ -n $output ]] || skip "git-status produced no output (no __git_ps1?)"
-
-  local plain
-  plain=$(printf '%s' "$output" | strip_ansi)
-  [[ $plain != *'('* ]] || fail "--plain output still has parens: $plain"
-  [[ $plain != *')'* ]] || fail "--plain output still has parens: $plain"
-  [[ $plain != ' '* ]] || fail "--plain output has a leading space: $plain"
+  refute_output --partial '('
+  refute_output --partial ')'
+  refute_output --regexp '^ '
+  assert_output --partial 'sample: '
 }

--- a/tests/shell/test_statusline.bats
+++ b/tests/shell/test_statusline.bats
@@ -139,6 +139,31 @@ STUBEOF
   assert_output --partial '<bg red>'
 }
 
+@test "vim NORMAL leads the line in bright-yellow on red" {
+  local json='{"vim":{"mode":"NORMAL"},"model":{"display_name":"O"},"context_window":{"used_percentage":20},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  # leads the line (before the first ' | '), red bg + bright-yellow fg
+  assert_output --regexp '^[^|]*NORMAL'
+  assert_output --partial '<bg red>'
+  assert_output --partial '<fg bright_yellow>'
+}
+
+@test "vim INSERT uses the standard color (no alarm)" {
+  local json='{"vim":{"mode":"INSERT"},"model":{"display_name":"O"},"context_window":{"used_percentage":20},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  assert_output --regexp '^[^|]*INSERT'
+  refute_output --partial '<bg red>'
+}
+
+@test "vim segment is absent when no vim mode is reported" {
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  refute_output --partial 'NORMAL'
+  refute_output --partial 'INSERT'
+}
+
 @test "missing jq prints a graceful notice and exits 0" {
   run env PATH="$STUB" "$BASH_BIN" "$SL" <<< "$JSON"
   assert_success

--- a/tests/shell/test_statusline.bats
+++ b/tests/shell/test_statusline.bats
@@ -80,11 +80,25 @@ STUBEOF
   assert_output --partial '<fg cyan>'
 }
 
-@test "reasoning effort is shown bracketed when present" {
+@test "effort rides with the model (no pipe between) and is bracketed" {
   local json='{"model":{"display_name":"Opus"},"effort":{"level":"high"},"context_window":{"used_percentage":20},"cost":{"total_cost_usd":1},"version":"1"}'
   run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
   assert_success
   assert_output --partial '[high]'
+  # no ' | ' separator between the model and the effort segment
+  assert_output --regexp 'Opus[^|]*\[high\]'
+}
+
+@test "effort color escalates by level (high=yellow, max=alarm)" {
+  # ctx held low (cyan) so any warn/alarm color must come from effort
+  local base='"context_window":{"used_percentage":20},"cost":{"total_cost_usd":1},"version":"1"'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "{\"model\":{\"display_name\":\"O\"},\"effort\":{\"level\":\"high\"},$base}"
+  assert_success
+  assert_output --partial '<fg bright_yellow>'
+
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "{\"model\":{\"display_name\":\"O\"},\"effort\":{\"level\":\"max\"},$base}"
+  assert_success
+  assert_output --partial '<bg red>'
 }
 
 @test "effort segment is absent (no empty brackets) when the model has none" {

--- a/tests/shell/test_statusline.bats
+++ b/tests/shell/test_statusline.bats
@@ -80,6 +80,23 @@ STUBEOF
   assert_output --partial '<fg cyan>'
 }
 
+@test "reasoning effort is shown bracketed when present" {
+  local json='{"model":{"display_name":"Opus"},"effort":{"level":"high"},"context_window":{"used_percentage":20},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  assert_output --partial '[high]'
+}
+
+@test "effort segment is absent (no empty brackets) when the model has none" {
+  # default JSON has no .effort — and an absent field must not shift the line
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  refute_output --partial '[]'
+  refute_output --partial '['
+  assert_output --partial 'Opus 4.8'
+  assert_output --partial 'code v2.1.183'
+}
+
 @test "missing jq prints a graceful notice and exits 0" {
   run env PATH="$STUB" "$BASH_BIN" "$SL" <<< "$JSON"
   assert_success

--- a/tests/shell/test_statusline.bats
+++ b/tests/shell/test_statusline.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# Regression tests for config/claude/bin/statusline.sh.
+#
+# Guards the leading-empty-field bug (parts[0] was an empty mode label, so the
+# line rendered as ' | (dotfiles: …)') and the context-% colour escalation.
+# jq is real; ansi + git-status are stubbed (ansi echoes its args so colour
+# choices are assertable).
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+  command -v jq > /dev/null || skip "jq not installed"
+
+  ROOT="$(dotfiles_root)"
+  SL="$ROOT/config/claude/bin/statusline.sh"
+  BASH_BIN="$(command -v bash)"
+  STUB="$(make_stub_dir)"
+
+  cat > "$STUB/ansi" << 'STUBEOF'
+#!/usr/bin/env bash
+printf '<%s>' "$*"
+STUBEOF
+
+  cat > "$STUB/git-status" << 'STUBEOF'
+#!/usr/bin/env bash
+printf 'REPO'
+STUBEOF
+
+  chmod +x "$STUB/ansi" "$STUB/git-status"
+
+  JSON='{"model":{"display_name":"Opus 4.8"},"context_window":{"used_percentage":20},"cost":{"total_cost_usd":10.36},"version":"2.1.183"}'
+}
+
+teardown() {
+  rm -rf "$STUB"
+}
+
+@test "output has no leading empty field / separator" {
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  refute_output --regexp '^[[:space:]]*\|'
+}
+
+@test "all expected fields are present" {
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  assert_output --partial 'REPO'
+  assert_output --partial 'Opus 4.8'
+  assert_output --partial 'Ctx: '
+  assert_output --partial '20%'
+  # shellcheck disable=SC2016  # literal '$' cost prefix, not a variable
+  assert_output --partial '$10.36'
+  assert_output --partial 'code v2.1.183'
+}
+
+@test "an empty git-status leaves no stray separator" {
+  cat > "$STUB/git-status" << 'STUBEOF'
+#!/usr/bin/env bash
+STUBEOF
+  chmod +x "$STUB/git-status"
+
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  refute_output --regexp '^[[:space:]]*\|'
+  refute_output --regexp '\|[[:space:]]+\|'
+}
+
+@test "high context (>=80) uses the alarm colour" {
+  local json='{"model":{"display_name":"X"},"context_window":{"used_percentage":85},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  assert_output --partial '<bg red>'
+}
+
+@test "low context uses the calm cyan colour" {
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  assert_output --partial '<fg cyan>'
+}
+
+@test "missing jq prints a graceful notice and exits 0" {
+  run env PATH="$STUB" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  assert_output --partial 'jq not found'
+}

--- a/tests/shell/test_statusline.bats
+++ b/tests/shell/test_statusline.bats
@@ -48,7 +48,7 @@ teardown() {
   assert_success
   assert_output --partial 'REPO'
   assert_output --partial 'Opus 4.8'
-  assert_output --partial 'Ctx: '
+  assert_output --partial 'Ctx:'
   assert_output --partial '20%'
   # shellcheck disable=SC2016  # literal '$' cost prefix, not a variable
   assert_output --partial '$10.36'
@@ -109,6 +109,34 @@ STUBEOF
   refute_output --partial '['
   assert_output --partial 'Opus 4.8'
   assert_output --partial 'code v2.1.183'
+}
+
+@test "rate-limit usage rides inside the context segment (no pipe)" {
+  local json='{"model":{"display_name":"O"},"context_window":{"used_percentage":20},"rate_limits":{"five_hour":{"used_percentage":24.5},"seven_day":{"used_percentage":41.2}},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  # label and value are split by a color code, so assert them separately
+  assert_output --partial '5h:'
+  assert_output --partial '24%'
+  assert_output --partial '7d:'
+  assert_output --partial '41%'
+  # no ' | ' between the context % and the usage figures
+  assert_output --regexp 'Ctx:[^|]*5h:[^|]*7d:'
+}
+
+@test "rate-limit usage is absent when rate_limits is missing" {
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$JSON"
+  assert_success
+  refute_output --partial '5h:'
+  refute_output --partial '7d:'
+}
+
+@test "rate-limit usage color escalates (5h near cap -> alarm)" {
+  # ctx + 7d held low (cyan) so the alarm color must come from the 5h cap
+  local json='{"model":{"display_name":"O"},"context_window":{"used_percentage":20},"rate_limits":{"five_hour":{"used_percentage":92},"seven_day":{"used_percentage":10}},"cost":{"total_cost_usd":1},"version":"1"}'
+  run env PATH="$STUB:$PATH" "$BASH_BIN" "$SL" <<< "$json"
+  assert_success
+  assert_output --partial '<bg red>'
 }
 
 @test "missing jq prints a graceful notice and exits 0" {


### PR DESCRIPTION
## Summary
- **Fix the statusline display bug** in `config/claude/bin/statusline.sh`. The
  reported leading empty `|` was the surface of a deeper bug: an empty field
  (the original `.vim.mode` column) made `@tsv` + a whitespace `IFS` `read`
  **shift every value left**. Root-caused it — fields now join on the unit
  separator and read with `IFS=$'\x1f'`, so absent fields stay in place.
- **Context % escalates harder** (cyan → bright-yellow ≥60% → white-on-red
  alarm ≥80%), since `/compact` is manual.
- **Reasoning-effort indicator** — verified `.effort.level` exists; render it
  as a `[level]` tag **attached to the model** (no `|` between) and **colored
  by level** with the same calm/warn/alarm scheme as context %
  (low/medium=cyan, high=yellow, xhigh/max=alarm).
- **Mined `jarrodwatts/claude-hud`** → `audit/mining/claude-hud.md` +
  idea-sources row. git-ahead/behind marked SKIP (already in `git-status`);
  rate-limit segment's gate now satisfied (`rate_limits` confirmed) — left as
  the top remaining candidate; `.vim.mode` restore left as a user-decision item.
- **9-test regression suite** (`tests/shell/test_statusline.bats`) — it caught
  the field-shift the cosmetic fix alone would have missed.

## Test plan
- [ ] `bats tests/shell/test_statusline.bats` (9/9).
- [ ] `bats tests/shell/test_*.bats` full gate green (173).
- [ ] `pre-commit run --all-files` clean.