### PR TITLE
refactor(rules): scope trufflehog; document auth always-on

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -36,7 +36,7 @@ rules) are all resolved — see [`audit/decisions-log.md`](audit/decisions-log.m
 
 | Tier | State |
 |------|-------|
-| Always-on rules | 9 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` + `trufflehog` (scoping review queued in `BACKLOG.md`). 41 rules are `paths:`-scoped (on-demand). |
+| Always-on rules | 8 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` (a conversational-trigger guardrail with no file glob — kept always-on by design). `trufflehog` was scoped to `.github/workflows/**` (2026-06-19). 42 rules are `paths:`-scoped (on-demand). |
 | MCP tool schemas | context7 only, via `mymcp` at user scope. terraform / serena dropped (2026-06-10). |
 | Plugins | 1 enabled (`skill-creator`); all other marketplace plugins disabled. |
 | Hooks | 4 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`). |

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -10,18 +10,6 @@ merely coupled (see `WORKFLOW.md` → *TODO routing*). Read when running
 summarized in [`decisions-log.md`](decisions-log.md) and retained here for
 continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
 
-## Always-on rule scoping
-
-- [x] **Evaluated `claude-code-auth.md` and `trufflehog.md` for path-scoping
-  (2026-06-19 audit; resolved 2026-06-19).** `trufflehog.md` → **scoped** to
-  `.github/workflows/**` (its whole concern is the `secret-scan.yml` workflow;
-  mirrors the `github-actions.md` precedent; the security-scan skill still
-  reads it by name on-demand). `claude-code-auth.md` → **kept always-on** with
-  a documenting `# No paths` frontmatter — it is a conversational-trigger
-  guardrail (never export `ANTHROPIC_API_KEY` globally) with no file glob, so
-  path-scoping would make it miss exactly when needed. Always-on rules now
-  number 8 (7 cross-cutting + `claude-code-auth`). See `decisions-log.md`.
-
 ## Audit dimensions / design
 
 - [x] **Form: the audit is the `claude-audit` skill** (`/claude-audit`) —
@@ -44,6 +32,15 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   right *kind*: a "rule" that is really a procedure → skill; one that must
   happen every time → hook; a bloated multi-tool rule → split per tool;
   duplicated content → dedupe to one canonical source.
+- [ ] **Enforce always-on intent: flag rules with no frontmatter** (LOW —
+  retrospective, PR #122). Both `trufflehog.md` and `claude-code-auth.md` were
+  added *always-on by omission* (no `paths:` and no `# No paths` comment) — only
+  an audit caught it. Now every `rules/*.md` is either `paths:`-scoped or
+  carries a `# No paths — <why>` comment. A tiny **meta-test or `PostToolUse`
+  hook** could keep it that way: flag any `config/claude/rules/*.md` whose
+  frontmatter has neither `paths:` nor a documenting comment, so a new rule
+  can't silently join the per-turn tier. Decide kind (meta-test vs hook) and
+  whether the leverage justifies the check.
 - [ ] **Plugins / MCP dimension.** Inventory every enabled plugin (what it
   does/bundles, whether used); cull duplicates of the `gh` CLI / existing
   rules+skills and unused ones; remember plugins carry context cost. MCP

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -12,16 +12,15 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
 
 ## Always-on rule scoping
 
-- [ ] **Evaluate `claude-code-auth.md` and `trufflehog.md` for path-scoping
-  (2026-06-19 audit).** These two are the only single-purpose rules still
-  always-on (no `paths:`) after the 2026-06-10 scoping pass — 9 always-on
-  total, of which 7 are genuinely cross-cutting (`code-style`,
-  `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`).
-  `trufflehog.md` (PR-time secret scanning) could scope to
-  `.github/workflows/**`; `claude-code-auth.md` is niche but has no natural
-  file glob (it is about the agent's own auth, not repo files) — may be a
-  legitimate always-on, or fold its essence elsewhere. Decide per rule; low
-  cost (~166 lines combined), low urgency.
+- [x] **Evaluated `claude-code-auth.md` and `trufflehog.md` for path-scoping
+  (2026-06-19 audit; resolved 2026-06-19).** `trufflehog.md` → **scoped** to
+  `.github/workflows/**` (its whole concern is the `secret-scan.yml` workflow;
+  mirrors the `github-actions.md` precedent; the security-scan skill still
+  reads it by name on-demand). `claude-code-auth.md` → **kept always-on** with
+  a documenting `# No paths` frontmatter — it is a conversational-trigger
+  guardrail (never export `ANTHROPIC_API_KEY` globally) with no file glob, so
+  path-scoping would make it miss exactly when needed. Always-on rules now
+  number 8 (7 cross-cutting + `claude-code-auth`). See `decisions-log.md`.
 
 ## Audit dimensions / design
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,25 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Resolved the always-on rule-scoping review (the last two
+  unscoped single-purpose rules).** Worked the BACKLOG *Always-on rule scoping*
+  item. **`trufflehog.md` → path-scoped** to `.github/workflows/**` (bumped
+  v1.0.0 → v1.1.0): the rule's entire concern is the `secret-scan.yml` CI
+  workflow, so it loads only when a workflow file is edited — mirroring the
+  `github-actions.md` precedent (same glob, same reasoning). The `security-scan`
+  skill reads it by name when it runs, so nothing that needs it depends on the
+  per-turn tier. **`claude-code-auth.md` → kept always-on** (bumped v1.0.0 →
+  v1.1.0, added a documenting `# No paths` frontmatter): it is a guardrail
+  (never export `ANTHROPIC_API_KEY` globally — the mistake that broke the Max
+  subscription, PR #110) whose trigger is **conversational** (auth diagnosis,
+  "/status shows the wrong method", "set up my key"), not a file edit — so
+  path-scoping would make it miss exactly those moments, and its token files
+  live in a separate repo (`private_dotfiles`) anyway. Per "trim weight, never
+  guardrails," it stays. Consequence: the always-on tier drops from 9 unscoped
+  rules to 8 (7 cross-cutting + `claude-code-auth`); 42 are now `paths:`-scoped.
+  Every always-on rule now carries an explicit `# No paths — <why>` frontmatter,
+  so "no frontmatter" is no longer an ambiguous state. Updated `SETUP-AUDIT.md`
+  baseline.
 - 2026-06-19 — **Restored the vim-mode segment; confirmed the other native
   indicator lines can't be hidden.** Set `statusLine.hideVimModeIndicator: true`
   (placement confirmed against the docs — a sibling of `type`/`command`) and

--- a/config/claude/rules/claude-code-auth.md
+++ b/config/claude/rules/claude-code-auth.md
@@ -1,6 +1,15 @@
+---
+# No paths — this is a guardrail (never export ANTHROPIC_API_KEY globally;
+# it broke the Max subscription, PR #110) whose trigger is conversational
+# (auth diagnosis, "/status shows the wrong method", "set up my key"), not a
+# file edit. Path-scoping would make it miss exactly those moments, and its
+# token files live in a separate repo (private_dotfiles) anyway. Always-on by
+# design: trim weight, never guardrails.
+---
+
 # Claude Code Auth Rules
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 How **this user** authenticates Claude Code (the CLI), the precedence between
 methods, and the standing rule that keeps the Max subscription working — the

--- a/config/claude/rules/trufflehog.md
+++ b/config/claude/rules/trufflehog.md
@@ -1,6 +1,15 @@
+---
+# On-demand: loads only when a workflow file is edited, since trufflehog's
+# whole concern is the `secret-scan.yml` GitHub Actions workflow. The
+# security-scan skill reads this rule by name when it runs, so nothing that
+# needs it depends on the per-turn tier.
+paths:
+  - ".github/workflows/**"
+---
+
 # trufflehog Rules
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 ## Detection
 


### PR DESCRIPTION
## Summary
- Resolves the backlog **Always-on rule scoping** review of the last two
  single-purpose rules still loading every turn with no `paths:`.
- **`trufflehog.md` → path-scoped to `.github/workflows/**`** (v1.0.0→v1.1.0).
  Its whole concern is the `secret-scan.yml` CI workflow, so it now loads only
  when a workflow file is edited — mirroring the `github-actions.md` precedent.
  The `security-scan` skill reads it by name on-demand, so nothing loses access.
- **`claude-code-auth.md` → kept always-on** with a documenting `# No paths`
  frontmatter (v1.0.0→v1.1.0). It is a guardrail (never export
  `ANTHROPIC_API_KEY` globally — broke the Max subscription, PR #110) whose
  trigger is *conversational*, not a file edit, so path-scoping would make it
  miss exactly when needed; its token files live in a separate repo anyway.
- Always-on rules drop **9 → 8**; every always-on rule now carries an explicit
  `# No paths — <why>` frontmatter, so "no frontmatter" is no longer ambiguous.
  `SETUP-AUDIT.md` baseline + `decisions-log.md` updated; backlog item closed.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint on all 5 docs).
- [ ] Frontmatter format matches the 41 existing `paths:`-scoped rules.
- [ ] No stale "9 always-on" / trufflehog-always-on references remain
      (`grep` clean except the updated baseline).