### PR TITLE
docs(git): document kept-branch-after-squash sync mechanic

### DIFF
--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -225,11 +225,13 @@ the already-merged commits forward as redundant history that pollutes the next
 PR's commit list — PR #117 needed a `git rebase --onto master <merge>` cleanup
 before its commit list was tidy.
 
-- [ ] Document the clean mechanic in `git.md` (or the ship-pr / batch
-  workflow): after a squash-merge with the branch kept, sync via
-  `git reset --hard origin/master` (the batch is already in master) or
-  `git rebase --onto`, **not** `git merge master`. (Already captured in the
-  batch-todos working memory; promote to a rule note so it isn't memory-only.)
+- [x] Documented the clean mechanic in `git.md` — new section *Continuing on a
+  Kept Branch After a Squash-Merge* (v1.8.0→v1.9.0) + an Agent Rules bullet:
+  after a squash-merge with the branch kept, sync via
+  `git reset --hard origin/<default>` (the batch is already merged) or
+  `git rebase --onto`, **never** `git merge <default>` (it replays
+  already-merged commits into the next PR). Promoted out of the batch-todos
+  working memory into the rule. See decisions-log 2026-06-19.
 
 ### 🧭 Audit Project .claude/ Dirs for Promotable Rules/Skills (MEDIUM PRIORITY)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -217,22 +217,6 @@ QA docs.
 - [ ] Decide which earn their surface per repo type (app vs library vs
   dotfiles) and which are pure vanity. Record the shortlist + rationale.
 
-### 🔭 Document the kept-branch-after-squash sync mechanic (LOW PRIORITY)
-
-Retrospective follow-up (PR #117). When a batch branch is **kept** after a
-squash-merge to continue working, syncing it with `git merge master` carries
-the already-merged commits forward as redundant history that pollutes the next
-PR's commit list — PR #117 needed a `git rebase --onto master <merge>` cleanup
-before its commit list was tidy.
-
-- [x] Documented the clean mechanic in `git.md` — new section *Continuing on a
-  Kept Branch After a Squash-Merge* (v1.8.0→v1.9.0) + an Agent Rules bullet:
-  after a squash-merge with the branch kept, sync via
-  `git reset --hard origin/<default>` (the batch is already merged) or
-  `git rebase --onto`, **never** `git merge <default>` (it replays
-  already-merged commits into the next PR). Promoted out of the batch-todos
-  working memory into the rule. See decisions-log 2026-06-19.
-
 ### 🧭 Audit Project .claude/ Dirs for Promotable Rules/Skills (MEDIUM PRIORITY)
 
 Review every repo under `$PROJECTS_DIR` and decide, per the three-tier model

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,21 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Documented the kept-branch-after-squash sync mechanic in
+  `git.md`.** Worked the BACKLOG item (a PR #117 retrospective follow-up).
+  Added a new section *Continuing on a Kept Branch After a Squash-Merge*
+  (git.md v1.8.0→v1.9.0) + an Agent Rules bullet. The fact: a squash-merge
+  makes the branch's changes a *new* commit on the default branch but does
+  **not** make the branch an ancestor, so `git merge <default>` into a kept
+  branch carries the branch's original commits forward as redundant history
+  that pollutes the next PR's commit list (PR #117 needed a `rebase --onto`
+  cleanup). The mechanic: `git reset --hard origin/<default>` when nothing new
+  is on the branch, or `git rebase --onto origin/<default> <last-merged>
+  <branch>` when post-squash commits exist — never `git merge`. This **promotes
+  the note out of the (untracked, personal) `batch-todos` working memory into
+  the canonical rule** so it isn't memory-only; the memory can now point at the
+  rule. Default-branch-agnostic wording (no hardcoded `master`), per `git.md`'s
+  own rule.
 - 2026-06-19 — **Evaluated CodeFactor & Snyk; relaxed the OSS-pinned-only
   security posture into a default + per-repo escape hatch.** Worked the BACKLOG
   *CodeFactor & Snyk* item, grounded in current official docs (two research

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.8.0
+**Version:** v1.9.0
 
 ## Commit Messages
 
@@ -263,6 +263,52 @@ git branch -ra
 
 The deleted branch should no longer appear in the output.
 
+## Continuing on a Kept Branch After a Squash-Merge
+
+Normally a merged branch is deleted (above). Sometimes a branch is **kept**
+after its squash-merge to keep working — e.g. the batched-TODOs flow, where
+commits accumulate on one branch across several PRs. Re-syncing that branch
+needs care, because **a squash-merge does not make the branch an ancestor of
+the default branch**: the squash created one *new* commit on the default
+branch holding the batch's changes, while the branch still holds the original
+individual commits that produced them.
+
+**Never `git merge <default>` into the kept branch.** The merge pulls in the
+squash commit while leaving the branch's original commits in place — the same
+changes now exist twice in the branch, and the *next* PR's commit list shows
+every already-merged commit again as redundant noise. (PR #117 hit exactly
+this and needed a `rebase --onto` cleanup before its commit list was tidy.)
+
+Fetch the merged tip first, then sync so the branch becomes a clean
+continuation of the default branch:
+
+```bash
+git fetch origin
+```
+
+- **Nothing new on the branch yet** (the whole batch went into the squash) —
+  reset it onto the merged tip. `--hard` discards anything not already in the
+  default branch, which is exactly right here since the batch is merged:
+
+  ```bash
+  git reset --hard origin/<default>
+  ```
+
+  New work then lands on top, so the next PR's diff is only that new work.
+
+- **New commits already made after the squash** — replay only those onto the
+  default branch, dropping the already-merged ones:
+
+  ```bash
+  git rebase --onto origin/<default> <last-merged-commit> <branch>
+  ```
+
+  where `<last-merged-commit>` is the branch tip at squash time (everything up
+  to it is already in the default branch via the squash). The result is the
+  default branch plus the new commits only.
+
+Both keep the branch a clean continuation; `git merge` does not.
+
 ## Versioning & tags
 
 Two separate things: **what a version *is*** (the `vX.Y.Z` format — universal)
@@ -368,3 +414,7 @@ the merge commit, push, and watch the release — is the **release-tag** skill;
   "Versioning & tagging" — `repo` vs `subdir`); use the **release-tag** skill.
   A new method is a config change (add it to the catalog first), not an
   ad-hoc choice. For a repo you don't own, follow ITS convention.
+- When a branch is **kept** after a squash-merge to keep working, re-sync it
+  with `git reset --hard origin/<default>` (or `git rebase --onto`), NEVER
+  `git merge <default>` — the merge replays already-merged commits into the
+  next PR. See *Continuing on a Kept Branch After a Squash-Merge*.


### PR DESCRIPTION
## Summary
- Promotes the PR #117 lesson out of the (untracked) `batch-todos` working
  memory into `git.md` so it isn't memory-only.
- New section **"Continuing on a Kept Branch After a Squash-Merge"** + an Agent
  Rules bullet (`git.md` v1.8.0→v1.9.0): a squash-merge does **not** make the
  branch an ancestor of the default branch, so `git merge <default>` into a
  kept branch replays the already-merged commits into the next PR's commit
  list. Sync instead via `git reset --hard origin/<default>` (nothing new on
  the branch) or `git rebase --onto origin/<default> <last-merged> <branch>`
  (post-squash commits to keep) — never `git merge`.
- Default-branch-agnostic wording (no hardcoded `master`), per git.md's own
  rule.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint).
- [ ] New prose wraps at 78 cols; pre-existing over-width lines left untouched.
- [ ] Mechanic matches what PR #117 actually needed (`rebase --onto` cleanup).