### PR TITLE
fix(hooks): allow branch-protection edits to gitignored untracked files

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -152,9 +152,11 @@ advisory — the remote enforces it:
   actually enforces it). See `config/claude/rules/git.md`.
 * The global `branch-protection.py` `PreToolUse` hook blocks an agent
   `Edit`/`Write`/`MultiEdit` while `master` is checked out — the earliest
-  guard, at edit time. It derives the protected branch from the
-  `no-commit-to-branch` args above, so this repo activates it automatically.
-  See `config/claude/rules/git.md` *Protecting the Default Branch*.
+  guard, at edit time (it allows plan files and gitignored, untracked files —
+  local-only state that can't be committed). It derives the protected branch
+  from the `no-commit-to-branch` args above, so this repo activates it
+  automatically. See `config/claude/rules/git.md` *Protecting the Default
+  Branch*.
 
 To change the ruleset, edit the JSON and re-apply with the OAuth token (the
 narrow PAT lacks admin):

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,21 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **`branch-protection.py` hook now allows edits to gitignored,
+  untracked files.** The edit-time guard blocked an edit to a **gitignored**
+  memory file while on `master` — and the report wrongly called that an
+  inherent limitation ("the hook can't tell tracked from untracked"). The user
+  corrected it: `git check-ignore` / `git ls-files --error-unmatch` answer
+  exactly that. Added `_is_local_only(repo, target)` — **ignored AND
+  untracked** — and a short-circuit allow in `main()`. The *untracked* half is
+  load-bearing: a force-added file that is both tracked and ignore-matched can
+  still land in a commit, so it stays protected (verified by a dedicated test).
+  Rationale: the rule guards *commits* on the protected branch, and an
+  ignored, untracked file (logs, caches, the agent's own memory) can never
+  become one. Two new tests in `test_branch_protection.py` (allow ignored;
+  block tracked-but-ignored); docs updated in `git.md` (v1.9.0→v1.10.0,
+  layer 3) and `.claude/WORKFLOW.md`. Same-file edit (the `~/.claude →
+  config/claude` symlink) means no separate deploy.
 - 2026-06-19 — **Documented the kept-branch-after-squash sync mechanic in
   `git.md`.** Worked the BACKLOG item (a PR #117 retrospective follow-up).
   Added a new section *Continuing on a Kept Branch After a Squash-Merge*

--- a/config/claude/hooks/branch-protection.py
+++ b/config/claude/hooks/branch-protection.py
@@ -26,7 +26,12 @@ guard here — the agent's git.md discipline and the server ruleset still apply.
 Revisit if that gap bites in practice.
 
 Edits to a plan file (`.../claude/plans/...`) are always allowed, so plan mode
-is never blocked.
+is never blocked. Edits to a **gitignored, untracked** file are likewise
+allowed: such a file is local-only state (logs, caches, the agent's own
+gitignored memory) that can never be committed to the protected branch, so the
+"don't author on it" rule does not apply. The *untracked* half matters — a
+force-added file that is both tracked and ignore-matched can still land in a
+commit, so it stays protected.
 
 Fail-safe: any error exits 0 silently so a hook bug can never block editing.
 """
@@ -78,6 +83,33 @@ def _git(repo: Path, *args: str) -> str | None:
   if res.returncode != 0:
     return None
   return res.stdout.strip()
+
+
+def _git_ok(repo: Path, *args: str) -> bool:
+  """True iff `git <args>` exits 0 in `repo`. For check-ignore / ls-files
+  probes where only the exit status matters; any error is False (fail-safe —
+  an unconfirmed probe falls through to the normal protection logic)."""
+  try:
+    res = subprocess.run(
+      ["git", "-C", str(repo), *args],
+      capture_output=True,
+      text=True,
+      timeout=5,
+    )
+  except Exception:
+    return False
+  return res.returncode == 0
+
+
+def _is_local_only(repo: Path, target: Path) -> bool:
+  """True when `target` is gitignored AND not tracked — purely local state
+  (logs, caches, the agent's own gitignored memory) that can never be
+  committed, so editing it on a protected branch breaks nothing. A force-added
+  file that is both tracked and ignore-matched stays protected (it can still
+  land in a commit), which is why the tracked check is required."""
+  if not _git_ok(repo, "check-ignore", "-q", "--", str(target)):
+    return False
+  return not _git_ok(repo, "ls-files", "--error-unmatch", "--", str(target))
 
 
 def _existing_ancestor(path: Path) -> Path | None:
@@ -182,6 +214,12 @@ def main() -> int:
   repo = _repo_root(target)
   if repo is None:
     return 0  # not in a git repo → nothing to protect
+
+  # A gitignored, untracked file is local-only state that can never be
+  # committed to the protected branch, so the "don't author on it" rule does
+  # not apply — allow it (e.g. the agent's own gitignored memory files).
+  if _is_local_only(repo, target):
+    return 0
 
   protected = _protected_branches(repo)
   if not protected:

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.9.0
+**Version:** v1.10.0
 
 ## Commit Messages
 
@@ -98,12 +98,14 @@ time and edit time:
 3. **Edit-time Claude Code hook** (earliest, agent-only): the global
    `branch-protection.py` `PreToolUse` hook blocks an `Edit`/`Write`/
    `MultiEdit` while a protected branch is checked out, so the agent is told
-   to branch *before* writing the first character. It reads the protected set
-   straight from the repo's `no-commit-to-branch` args (layer 2), so it
-   activates **only where that hook is configured** — a repo without it (a
-   cloned upstream/fork) gets no edit-time guard. It is a backstop for the
-   agent, not a constraint on a human editor, and fails safe (any error
-   allows the edit).
+   to branch *before* writing the first character. (It allows edits to plan
+   files and to **gitignored, untracked** files — local-only state, such as
+   the agent's own memory, that can never be committed to the branch.) It
+   reads the protected set straight from the repo's `no-commit-to-branch` args
+   (layer 2), so it activates **only where that hook is configured** — a repo
+   without it (a cloned upstream/fork) gets no edit-time guard. It is a
+   backstop for the agent, not a constraint on a human editor, and fails safe
+   (any error allows the edit).
 
 The local guards are conveniences, not substitutes — without the server-side
 ruleset, anyone (or any tool) without the hooks installed can still push. The

--- a/tests/python/test_branch_protection.py
+++ b/tests/python/test_branch_protection.py
@@ -125,6 +125,32 @@ def test_allows_plan_files_even_on_protected_branch(tmp_path):
   assert out == {}
 
 
+def test_allows_gitignored_untracked_file_on_protected_branch(tmp_path):
+  # A gitignored (untracked) file is local-only and can never be committed,
+  # so editing it on protected master is allowed (e.g. agent memory files).
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+  out = _run(str(repo / "scratch.log"), str(repo))
+  assert out == {}
+
+
+def test_blocks_tracked_file_even_if_ignore_matched(tmp_path):
+  # A file that is BOTH tracked (force-added) and ignore-matched can still
+  # land in a commit, so it stays protected on master — the tracked check,
+  # not check-ignore alone, is what makes this correct.
+  repo = _make_repo(tmp_path, "master", PROTECT_MASTER)
+  (repo / ".gitignore").write_text("tracked.log\n", encoding="utf-8")
+  f = repo / "tracked.log"
+  f.write_text("x\n", encoding="utf-8")
+  _git(repo, "add", "-f", "tracked.log")
+  _git(
+    repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m",
+    "force-add ignored file"
+  )
+  out = _run(str(f), str(repo))
+  assert _is_deny(out)
+
+
 def test_allows_outside_any_git_repo(tmp_path):
   out = _run(str(tmp_path / "loose.txt"), str(tmp_path))
   assert out == {}


### PR DESCRIPTION
## Summary
- The edit-time `branch-protection.py` hook blocked an edit to a **gitignored**
  memory file while on a protected branch. Such a file is local-only state
  (logs, caches, the agent's own gitignored memory) that can **never be
  committed**, so the "don't author on the protected branch" rule doesn't apply.
- Adds `_is_local_only(repo, target)` — **gitignored AND untracked**, via
  `git check-ignore -q` + `git ls-files --error-unmatch` — and a short-circuit
  allow in `main()`.
- The *untracked* half is load-bearing: a force-added file that is both tracked
  and ignore-matched can still land in a commit, so it stays protected.
- Docs updated where the hook's behavior is described: `git.md` layer 3
  (v1.9.0→v1.10.0) and `.claude/WORKFLOW.md`.

This corrects my earlier (wrong) claim that the hook couldn't distinguish
tracked from untracked — git answers exactly that.

## Test plan
- [ ] `pytest tests/python/test_branch_protection.py` green (CI) — two new
      tests: allow ignored+untracked on master; block tracked-but-ignored.
- [ ] Functionally verified locally: ignored+untracked → allow, normal file →
      deny, force-added-tracked-ignored → deny, working branch → allow.
- [ ] `pre-commit run --all-files` green (yapf/isort/flake8/markdownlint).