### PR TITLE
docs(skills): record agentskills.io as the SKILL.md standard we follow

### DIFF
--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -76,6 +76,10 @@ the same gating suite without breaking docker-less environments.
   test that sources them and asserts the resulting environment.
 - Multi-call dispatchers (e.g. `bin/docker_wrapper`) are tested once at the
   real file; their tool symlinks are not (the generator skips symlinks).
+- Repo-structure invariants get a guard test too: `test_skill_frontmatter.bats`
+  holds every `config/claude/skills/*/SKILL.md` to the Agent Skills
+  open-standard frontmatter rules (see `config/claude/EXTENDING.md` Skill ›
+  *Format*).
 
 ## Coverage priorities (incremental)
 

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -98,8 +98,12 @@ use it), then the Markdown body and optional `scripts/` / `references/` /
 `assets/`. Optional standard fields (`license`, `compatibility`, `metadata`,
 `allowed-tools`) are **skipped by default** for these internal skills — add
 one only when it earns its place (e.g. a vendored skill keeping its upstream
-`license`). The standard ships a validator (`skills-ref validate <dir>`); we
-don't wire it (see `audit/BACKLOG.md`).
+`license`). Conformance is guarded by
+`tests/shell/test_skill_frontmatter.bats` — a self-hosted check of the
+required-field rules above, run in the gating suite. The standard's external
+`skills-ref` validator is **ICEBOXed** (noted in that test) in favour of the
+self-hosted check, matching the repo's no-external-tool-to-lint-our-own-files
+posture.
 
 ## Agent (subagent)
 

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -88,6 +88,18 @@ description-trigger optimizer so the skill fires on the right requests, not
 just whatever wording was first guessed. We are deliberately exercising
 skill-creator on every new skill to learn its worth
 (`audit/decisions-log.md`).
+**Format:** our `SKILL.md` *is* the **Agent Skills open standard**
+([agentskills.io](https://agentskills.io/specification)) — the format
+Anthropic created and released as a cross-vendor open standard (Dec 2025). A
+skill is a directory whose name matches its `SKILL.md`'s required `name`
+(1–64 chars, lowercase/digits/hyphens, no leading/trailing or consecutive
+hyphen) plus a required `description` (≤1024 chars: what it does *and* when to
+use it), then the Markdown body and optional `scripts/` / `references/` /
+`assets/`. Optional standard fields (`license`, `compatibility`, `metadata`,
+`allowed-tools`) are **skipped by default** for these internal skills — add
+one only when it earns its place (e.g. a vendored skill keeping its upstream
+`license`). The standard ships a validator (`skills-ref validate <dir>`); we
+don't wire it (see `audit/BACKLOG.md`).
 
 ## Agent (subagent)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -416,9 +416,24 @@ duplicates / similar setups). Chart each in
 
 ### Skill-format standard: agentskills.io
 
-- [ ] Investigate whether <https://agentskills.io> is a real/emerging standard
-  (does Anthropic or another AI vendor back it?). If meaningful, align our
-  skills' format to it.
+- [x] Investigated (2026-06-19). **`agentskills.io` is the real, authoritative
+  open standard** — the `SKILL.md` format Anthropic created and released
+  cross-vendor (Dec 2025; adopted by OpenAI, Google, Microsoft/GitHub, Cursor,
+  etc.). It is **the same format we already use**, not a competitor — so we are
+  **already conformant**: all 27 skills pass the hard constraints (name matches
+  dir; lowercase/digits/hyphens; no `--`; ≤64 chars; description ≤1024). No
+  migration. Documented the standard as our reference in `EXTENDING.md`
+  (Skill › *Format*). The "no `claude`/`anthropic` in a name" rule one source
+  claimed is **not in the standard** (verified) — `claude-audit` is fine. See
+  decisions-log 2026-06-19.
+- [ ] **Optional: guard skill-frontmatter conformance against drift (LOW).**
+  We're conformant today but nothing enforces it as skills are added/renamed.
+  Decide between (a) a small **own** check (a bats/meta test asserting each
+  `SKILL.md`'s `name` matches its dir + charset/length rules — fits the repo's
+  self-hosted, no-external-dep posture, like the meta-test generator), or
+  (b) wiring the standard's **`skills-ref validate`** (external Apache-2.0 tool;
+  authoritative but adds a dependency). Lean (a). Not built — scoped out of the
+  investigation PR.
 
 ### Claude statusline enhancements (claude-hud candidates)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -426,14 +426,13 @@ duplicates / similar setups). Chart each in
   (Skill › *Format*). The "no `claude`/`anthropic` in a name" rule one source
   claimed is **not in the standard** (verified) — `claude-audit` is fine. See
   decisions-log 2026-06-19.
-- [ ] **Optional: guard skill-frontmatter conformance against drift (LOW).**
-  We're conformant today but nothing enforces it as skills are added/renamed.
-  Decide between (a) a small **own** check (a bats/meta test asserting each
-  `SKILL.md`'s `name` matches its dir + charset/length rules — fits the repo's
-  self-hosted, no-external-dep posture, like the meta-test generator), or
-  (b) wiring the standard's **`skills-ref validate`** (external Apache-2.0 tool;
-  authoritative but adds a dependency). Lean (a). Not built — scoped out of the
-  investigation PR.
+- [x] **Guarded skill-frontmatter conformance against drift (option a).** Built
+  `tests/shell/test_skill_frontmatter.bats` — a self-hosted bats check asserting
+  each `SKILL.md`'s `name` matches its dir + the charset/length rules and the
+  `description` is present and ≤1024 chars (gating suite). The external
+  Apache-2.0 **`skills-ref`** validator (option b) is left **ICEBOXed** (noted
+  in the test) — same no-external-tool-to-lint-our-own-files posture as the rest
+  of the repo. See decisions-log 2026-06-19.
 
 ### Claude statusline enhancements (claude-hud candidates)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -414,26 +414,6 @@ duplicates / similar setups). Chart each in
 - [ ] **`ruvnet/ruflo`** — evaluate whether worth exploring (not a
   plugin/skill). <https://github.com/ruvnet/ruflo>
 
-### Skill-format standard: agentskills.io
-
-- [x] Investigated (2026-06-19). **`agentskills.io` is the real, authoritative
-  open standard** — the `SKILL.md` format Anthropic created and released
-  cross-vendor (Dec 2025; adopted by OpenAI, Google, Microsoft/GitHub, Cursor,
-  etc.). It is **the same format we already use**, not a competitor — so we are
-  **already conformant**: all 27 skills pass the hard constraints (name matches
-  dir; lowercase/digits/hyphens; no `--`; ≤64 chars; description ≤1024). No
-  migration. Documented the standard as our reference in `EXTENDING.md`
-  (Skill › *Format*). The "no `claude`/`anthropic` in a name" rule one source
-  claimed is **not in the standard** (verified) — `claude-audit` is fine. See
-  decisions-log 2026-06-19.
-- [x] **Guarded skill-frontmatter conformance against drift (option a).** Built
-  `tests/shell/test_skill_frontmatter.bats` — a self-hosted bats check asserting
-  each `SKILL.md`'s `name` matches its dir + the charset/length rules and the
-  `description` is present and ≤1024 chars (gating suite). The external
-  Apache-2.0 **`skills-ref`** validator (option b) is left **ICEBOXed** (noted
-  in the test) — same no-external-tool-to-lint-our-own-files posture as the rest
-  of the repo. See decisions-log 2026-06-19.
-
 ### Claude statusline enhancements (claude-hud candidates)
 
 Done 2026-06-19 (fixed + regression-tested; see the decisions log): the display

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,27 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Investigated the agentskills.io skill-format standard;
+  confirmed we're already conformant.** Worked the BACKLOG item, grounded in
+  current sources (three research agents). **`agentskills.io` is the real,
+  Anthropic-originated open standard** for Agent Skills — the `SKILL.md` format
+  Anthropic created and released as a cross-vendor open standard on 2025-12-18
+  (adopters include OpenAI Codex, Google Gemini CLI, GitHub Copilot, Cursor,
+  JetBrains, Goose, …). Crucially it is **the same format we already use**, not
+  a competing one, so there is **nothing to migrate**: a conformance sweep of
+  all 27 skills passed every hard constraint (name matches parent dir;
+  lowercase/digits/hyphens; no leading/trailing/`--`; ≤64 chars; description
+  ≤1024). **Corrected an over-claim:** one research agent asserted a name
+  "must not contain `claude`/`anthropic`" rule; a targeted re-check of the spec,
+  the Claude Code docs, and the `skills-ref` validator found **no such rule** —
+  `claude-audit` is fully valid. Decision: **document the open standard as our
+  reference** (`EXTENDING.md` Skill › *Format*) and keep the minimal
+  `name`+`description` frontmatter; **skip the optional standard fields**
+  (`license`/`compatibility`/`metadata`/`allowed-tools`) for internal skills
+  (one vendored skill, `frontend-design`, legitimately keeps an upstream
+  `license`). Left a **LOW** follow-up: optionally guard conformance against
+  drift via our own bats/meta check (preferred — self-hosted) or the external
+  `skills-ref validate`; not built, to keep this a documentation-only outcome.
 - 2026-06-19 — **`branch-protection.py` hook now allows edits to gitignored,
   untracked files.** The edit-time guard blocked an edit to a **gitignored**
   memory file while on `master` — and the report wrongly called that an

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -24,9 +24,13 @@ items) and [`idea-sources.md`](idea-sources.md) (mined repos).
   `name`+`description` frontmatter; **skip the optional standard fields**
   (`license`/`compatibility`/`metadata`/`allowed-tools`) for internal skills
   (one vendored skill, `frontend-design`, legitimately keeps an upstream
-  `license`). Left a **LOW** follow-up: optionally guard conformance against
-  drift via our own bats/meta check (preferred — self-hosted) or the external
-  `skills-ref validate`; not built, to keep this a documentation-only outcome.
+  `license`). **Guard built (option a, same PR):**
+  `tests/shell/test_skill_frontmatter.bats` self-hosts the conformance check
+  (name matches dir + charset/length; description ≤1024) in the gating suite;
+  the external Apache-2.0 `skills-ref` validator (option b) is **ICEBOXed** in
+  that test — same no-external-tool-to-lint-our-own-files posture as semgrep/
+  trufflehog/etc. Negative-tested (it fails on a missing description, bad
+  charset, and name≠dir) so it isn't a no-op.
 - 2026-06-19 — **`branch-protection.py` hook now allows edits to gitignored,
   untracked files.** The edit-time guard blocked an edit to a **gitignored**
   memory file while on `master` — and the report wrongly called that an

--- a/tests/shell/test_skill_frontmatter.bats
+++ b/tests/shell/test_skill_frontmatter.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# Conformance guard: every config/claude/skills/*/SKILL.md must satisfy the
+# Agent Skills open standard (agentskills.io) hard constraints for its required
+# frontmatter, so a newly added or renamed skill can't silently drift out of
+# spec. See config/claude/EXTENDING.md (Skill > Format) and the decision in
+# config/claude/audit/decisions-log.md (2026-06-19).
+#
+# Scope: the REQUIRED fields only — `name` (matches the directory; 1-64 chars;
+# lowercase letters/digits/hyphens; no leading/trailing or consecutive hyphen)
+# and `description` (present; <= 1024 chars). The optional standard fields
+# (license/compatibility/metadata/allowed-tools) are not mandated.
+#
+# ICEBOX (2026-06-19, keyword-dense: skills-ref validator, external Apache-2.0,
+# agentskills validation tool): the standard ships a reference validator,
+# `skills-ref validate <dir>`. We deliberately use this self-hosted check
+# instead — same posture as the rest of the repo (no external scanner/tool
+# dependency just to lint our own files). Revisit only if our own check proves
+# insufficient (e.g. we start relying on optional/experimental fields the
+# upstream validator understands and ours does not).
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+
+  SKILLS="$(dotfiles_root)/config/claude/skills"
+}
+
+#------------------------------------------------------------------------------
+# Print the value of a top-level frontmatter key (first match) from a SKILL.md:
+# scan only the first `---`-delimited block, strip the `key: ` prefix.
+
+frontmatter_value() {
+  awk -v k="^$2:" '
+    /^---$/ { c++; next }
+    c == 1 && $0 ~ k { sub(/^[^:]*: */, ""); print; exit }
+    c >= 2 { exit }
+  ' "$1"
+}
+
+@test "every skill has a SKILL.md with name + description frontmatter" {
+  local missing=()
+
+  for dir in "$SKILLS"/*/; do
+    local f="$dir/SKILL.md"
+
+    [[ -f $f ]] || { missing+=("$(basename "$dir"): no SKILL.md"); continue; }
+    [[ -n $(frontmatter_value "$f" name) ]] ||
+      missing+=("$(basename "$dir"): missing name")
+    [[ -n $(frontmatter_value "$f" description) ]] ||
+      missing+=("$(basename "$dir"): missing description")
+  done
+
+  ((${#missing[@]} == 0)) || fail "$(printf '%s\n' "${missing[@]}")"
+}
+
+@test "every skill name matches its directory and the charset/length rules" {
+  local bad=()
+
+  for dir in "$SKILLS"/*/; do
+    local f="$dir/SKILL.md"
+    [[ -f $f ]] || continue
+
+    local base name
+    base="$(basename "$dir")"
+    name="$(frontmatter_value "$f" name)"
+    name="${name//[\"\']/}"
+
+    [[ $name == "$base" ]] ||
+      bad+=("$base: name '$name' != directory")
+    [[ $name =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] ||
+      bad+=("$base: name '$name' not lowercase letters/digits/hyphens")
+    [[ $name != *--* ]] ||
+      bad+=("$base: name has consecutive hyphens")
+    ((${#name} >= 1 && ${#name} <= 64)) ||
+      bad+=("$base: name length ${#name} outside 1..64")
+  done
+
+  ((${#bad[@]} == 0)) || fail "$(printf '%s\n' "${bad[@]}")"
+}
+
+@test "every skill description is within the 1024-char limit" {
+  local bad=()
+
+  for dir in "$SKILLS"/*/; do
+    local f="$dir/SKILL.md"
+    [[ -f $f ]] || continue
+
+    local desc
+    desc="$(frontmatter_value "$f" description)"
+
+    ((${#desc} <= 1024)) ||
+      bad+=("$(basename "$dir"): description ${#desc} chars > 1024")
+  done
+
+  ((${#bad[@]} == 0)) || fail "$(printf '%s\n' "${bad[@]}")"
+}


### PR DESCRIPTION
## Summary
- **Investigated the `agentskills.io` skill-format question** (BACKLOG item),
  grounded in current official sources. Finding: it is the **real,
  Anthropic-originated open standard** for Agent Skills — the `SKILL.md` format
  Anthropic created and released cross-vendor (Dec 2025; adopters incl. OpenAI,
  Google, GitHub, Cursor). It is **the same format we already use**, so there is
  **nothing to migrate**.
- **Conformance verified:** all 27 skills pass the spec's hard constraints
  (name matches dir; lowercase/digits/hyphens; no `--`; ≤64 chars; description
  ≤1024).
- **Documents the standard as our reference** in `EXTENDING.md` (Skill ›
  *Format*): required `name`/`description` rules, the optional fields
  (`license`/`compatibility`/`metadata`/`allowed-tools`) we skip for internal
  skills, and the `skills-ref` validator we don't wire.
- **Corrected an over-claim** surfaced mid-research: there is **no** "name must
  not contain `claude`/`anthropic`" rule in the spec/docs/validator —
  `claude-audit` is fully valid.
- Records the decision + a **LOW** optional follow-up (a conformance drift
  guard — our own bats check, or `skills-ref`) in the audit docs.

Documentation-only outcome — no skill files changed (we were already
conformant).

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint).
- [ ] Conformance sweep clean: every `config/claude/skills/*/SKILL.md` `name`
      matches its directory and satisfies charset/length rules.