### PR TITLE
feat(hooks): re-inject a git/session snapshot after compaction

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -39,5 +39,5 @@ rules) are all resolved — see [`audit/decisions-log.md`](audit/decisions-log.m
 | Always-on rules | 8 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` (a conversational-trigger guardrail with no file glob — kept always-on by design). `trufflehog` was scoped to `.github/workflows/**` (2026-06-19). 42 rules are `paths:`-scoped (on-demand). |
 | MCP tool schemas | context7 only, via `mymcp` at user scope. terraform / serena dropped (2026-06-10). |
 | Plugins | 1 enabled (`skill-creator`); all other marketplace plugins disabled. |
-| Hooks | 4 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`). |
+| Hooks | 5 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`, `compact-snapshot`). |
 | Always-on memory | global `CLAUDE.md` + the repo's `.claude/` (WORKFLOW / CONVENTIONS / TESTS). |

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -470,17 +470,19 @@ Can we steer *when* and *how* Claude Code compacts context? Two
 below, so it needs settling against current official docs (not memory) before
 acting.
 
-- [ ] **Verify the `# Compact instructions` CLAUDE.md feature.** One lookup
-  asserted a special heading in CLAUDE.md steers what compaction preserves; a
-  second, more thorough search of `code.claude.com/docs` found **no documented
-  heading-matching feature** of that name. Settle which is true. If real → add
-  the block to global `config/claude/CLAUDE.md`. If not → it's only ordinary
-  guidance text the model happens to see (CLAUDE.md is in context during
-  compaction; project-root CLAUDE.md is re-injected from disk after), with no
-  dedicated engine — don't oversell it.
-- [ ] **Evaluate a `SessionStart`/`compact` hook** as the documented, reliable
-  lever for "make X survive compaction": its stdout is injected into context
-  after a compaction. Decide whether it's worth wiring for this setup.
+- [x] **Settled the `# Compact instructions` CLAUDE.md feature — REFUTED.** No
+  such heading-matching feature is documented (the more thorough prior lookup
+  was right). What's real: project-root + global `CLAUDE.md` and `MEMORY.md` are
+  auto-reinjected after a compaction, with no magic heading filtering what's
+  kept. So **nothing added to `CLAUDE.md`**; recorded so it isn't re-attempted.
+- [x] **Wired a `SessionStart`/`compact` hook (git/session-state snapshot).**
+  Confirmed `SessionStart` fires post-compaction with `source: "compact"` and
+  its `additionalContext` is injected. Built `config/claude/hooks/
+  compact-snapshot.py` (matcher `compact`) to re-inject a short snapshot — repo,
+  branch (+ protected-default warning), the branch's open PR, working-tree
+  status — which auto-reinjection does *not* cover. Read-only, fail-safe; runs
+  only on compaction (no per-turn cost). Tested via
+  `tests/python/test_compact_snapshot.py`. See decisions-log 2026-06-19.
 
 Confirmed (not in question): there is **no** config to change the auto-compact
 *threshold*; `autoCompactEnabled: false` (or `DISABLE_AUTO_COMPACT=1`) disables

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -65,6 +65,17 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   workaround. Decide a convention (or a tiny mechanism) for cross-repo
   follow-ups so they aren't lost or mis-homed. Likely a short addition to the
   `WORKFLOW.md` TODO-routing section.
+- [ ] **Delegated research can over-claim — demand exact doc quotes (LOW —
+  retrospective, PRs #126/#127).** Twice in one session a delegated research
+  agent asserted a plausible-but-false feature: a name "must not contain
+  `claude`/`anthropic`" rule (#126) and a `# Compact instructions` CLAUDE.md
+  heading (#127). Both were caught by re-verifying against primary docs before
+  acting — but only because the claims happened to be high-stakes. Sharpen the
+  `claude-audit` skill's grounding guidance: when a research agent reports a
+  **feature/behavior claim** that would drive an action (a rename, a new
+  CLAUDE.md block, wiring a hook), require an **exact quote + doc URL** and
+  treat unsourced specifics as unconfirmed. Small wording add to the skill's
+  *Check grounding* / *Verify currency* notes; not a new artifact.
 - [ ] **Plugin-aware proposals (behavior rule).** When proposing a new
   rule/skill, also check whether a plugin provides it or should be added.
   Extend `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a
@@ -462,35 +473,6 @@ entries; `.pr.number` in the **stdin** JSON), they just can't replace the
 native display. Open upstream requests: anthropics/claude-code **#27916**,
 **#48246**. Revisit if either lands a hide option; until then, only the vim
 indicator was controllable (and is done).
-
-### Claude Code compaction control (moved from TODO.md)
-
-Can we steer *when* and *how* Claude Code compacts context? Two
-`claude-code-guide` lookups on 2026-06-19 conflicted on the central question
-below, so it needs settling against current official docs (not memory) before
-acting.
-
-- [x] **Settled the `# Compact instructions` CLAUDE.md feature — REFUTED.** No
-  such heading-matching feature is documented (the more thorough prior lookup
-  was right). What's real: project-root + global `CLAUDE.md` and `MEMORY.md` are
-  auto-reinjected after a compaction, with no magic heading filtering what's
-  kept. So **nothing added to `CLAUDE.md`**; recorded so it isn't re-attempted.
-- [x] **Wired a `SessionStart`/`compact` hook (git/session-state snapshot).**
-  Confirmed `SessionStart` fires post-compaction with `source: "compact"` and
-  its `additionalContext` is injected. Built `config/claude/hooks/
-  compact-snapshot.py` (matcher `compact`) to re-inject a short snapshot — repo,
-  branch (+ protected-default warning), the branch's open PR, working-tree
-  status — which auto-reinjection does *not* cover. Read-only, fail-safe; runs
-  only on compaction (no per-turn cost). Tested via
-  `tests/python/test_compact_snapshot.py`. See decisions-log 2026-06-19.
-
-Confirmed (not in question): there is **no** config to change the auto-compact
-*threshold*; `autoCompactEnabled: false` (or `DISABLE_AUTO_COMPACT=1`) disables
-it entirely; the statusline script is the only programmatic read of context
-fullness (`context_window.used_percentage` etc. — hooks can't read it); and
-`/compact` cannot be triggered programmatically (user-only). The statusline
-already color-codes context %, so the current workflow is manual `/compact`
-(see "Statusline Coordination").
 
 ### New rule/skill candidates
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,29 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Settled Claude Code compaction control; wired a
+  `SessionStart`/`compact` snapshot hook.** Worked the BACKLOG item, grounded
+  in current official docs (claude-code-guide). **Q1 — the `# Compact
+  instructions` CLAUDE.md heading feature is REFUTED:** no such heading-matching
+  feature is documented; the earlier claim was wrong (the more thorough prior
+  lookup was right). What is real is that project-root `CLAUDE.md` + global
+  `CLAUDE.md` + `MEMORY.md` are **auto-reinjected** after a compaction — no
+  magic heading filters what's kept. So **nothing added to `CLAUDE.md`** (and
+  recorded here so the heading idea isn't re-attempted). **Q2/Q3/Q4 confirmed:**
+  `/compact [instructions]` takes free-text focus; no threshold knob;
+  `autoCompactEnabled:false` / `DISABLE_AUTO_COMPACT=1` disable; `/compact` is
+  user-only; and the **`SessionStart` hook fires after compaction with
+  `source: "compact"`**, its `additionalContext` injected into the rebuilt
+  context — the documented lever for surviving compaction. **Decision (user
+  chose the git/session-state option):** built `config/claude/hooks/
+  compact-snapshot.py` (matcher `compact`) — it injects a short deterministic
+  snapshot (repo, branch + protected-default warning, the branch's open PR via
+  `gh`, working-tree status) that the auto-reinjection does **not** cover.
+  Read-only, fail-safe (non-git/detached/non-compact → emits nothing), gh
+  best-effort with a short timeout. Tested via `tests/python/
+  test_compact_snapshot.py` (pytest, matching the existing Python-hook test
+  convention — *not* bats). Cost is near-zero: it runs only on compaction, not
+  per turn. Hook count 4 → 5 (`SETUP-AUDIT.md`).
 - 2026-06-19 — **Investigated the agentskills.io skill-format standard;
   confirmed we're already conformant.** Worked the BACKLOG item, grounded in
   current sources (three research agents). **`agentskills.io` is the real,

--- a/config/claude/hooks/compact-snapshot.py
+++ b/config/claude/hooks/compact-snapshot.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+"""SessionStart hook: re-inject a git/session-state snapshot after compaction.
+
+Fires on `SessionStart` with source `compact` (auto or manual `/compact`). A
+compaction rebuilds the conversation from a summary; Claude Code auto-reinjects
+the durable guidance (global + project `CLAUDE.md`, `MEMORY.md`), but the
+*working git state* — which branch, which open PR, what's staged — is not
+preserved. This hook emits a short, deterministic snapshot of that state as
+`additionalContext` so it survives the compaction instead of being re-derived.
+
+There is **no** `# Compact instructions` CLAUDE.md heading feature (verified
+against the docs, 2026-06-19) — a `SessionStart`/`compact` hook is the
+documented lever for making content reappear post-compaction. See the decision
+in `config/claude/audit/decisions-log.md`.
+
+Read-only and fail-safe: any error, a non-git cwd, a detached HEAD, or a
+non-`compact` source emits nothing and exits 0, never disrupting the session.
+The `gh` PR lookup is best-effort (short timeout); if gh is absent, slow, or
+unauthenticated the PR line is simply omitted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path, timeout: float) -> str | None:
+  """Run `cmd` in `cwd`; return stripped stdout, or None on any failure."""
+  try:
+    res = subprocess.run(
+      cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout
+    )
+  except Exception:
+    return None
+
+  if res.returncode != 0:
+    return None
+
+  return res.stdout.strip()
+
+
+def _repo_root(cwd: Path) -> Path | None:
+  top = _run(["git", "rev-parse", "--show-toplevel"], cwd, 5)
+  return Path(top) if top else None
+
+
+def _default_branch(repo: Path) -> str | None:
+  ref = _run(["git", "symbolic-ref", "refs/remotes/origin/HEAD"], repo, 5)
+  return ref.rsplit("/", 1)[-1] if ref else None
+
+
+def _open_pr(repo: Path, branch: str) -> str | None:
+  """A one-line `PR #N title (url)` for the branch's OPEN PR, or None. Best
+  effort — gh may be absent/slow/unauthenticated or the repo non-GitHub."""
+  out = _run(
+    [
+      "gh",
+      "pr",
+      "view",
+      branch,
+      "--json",
+      "number,title,url,state",
+      "--jq",
+      r'select(.state == "OPEN") | "PR #\(.number) \(.title) (\(.url))"',
+    ],
+    repo,
+    8,
+  )
+  return out or None
+
+
+def _worktree(repo: Path) -> str:
+  """A short summary of the working tree: 'clean' or 'N changed (S staged)'."""
+  status = _run(["git", "status", "--porcelain"], repo, 5)
+  if status is None:
+    return "unknown"
+
+  if status == "":
+    return "clean"
+
+  lines = status.splitlines()
+  staged = sum(1 for ln in lines if ln[:1] not in (" ", "?"))
+  return f"{len(lines)} changed ({staged} staged)"
+
+
+def main() -> int:
+  try:
+    event = json.load(sys.stdin)
+  except Exception:
+    return 0
+
+  # Only after a compaction. The settings matcher already scopes this to
+  # source `compact`; the explicit check keeps the hook self-contained and
+  # testable (invoked directly, it ignores startup/resume/clear).
+  if event.get("source") != "compact":
+    return 0
+
+  cwd = Path(
+    event.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+  )
+
+  repo = _repo_root(cwd)
+  if repo is None:
+    return 0  # not in a git repo → nothing useful to snapshot
+
+  branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], repo, 5)
+  if not branch or branch == "HEAD":
+    return 0  # detached HEAD / unreadable → skip
+
+  lines = [f"Session state (post-compaction snapshot, {repo.name}):"]
+
+  if branch == _default_branch(repo):
+    lines.append(
+      f"- Branch: {branch} — this is the protected default; create a working "
+      "branch before editing."
+    )
+  else:
+    lines.append(f"- Branch: {branch}")
+
+  pr = _open_pr(repo, branch)
+  if pr:
+    lines.append(f"- Open {pr}")
+
+  lines.append(f"- Working tree: {_worktree(repo)}")
+
+  print(
+    json.dumps({
+      "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": "\n".join(lines),
+      }
+    })
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -39,6 +39,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/compact-snapshot.py",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/tests/python/test_compact_snapshot.py
+++ b/tests/python/test_compact_snapshot.py
@@ -1,0 +1,94 @@
+"""Tests for the compact-snapshot SessionStart hook.
+
+Runs the hook as a subprocess (the way Claude Code invokes it) against
+throwaway git repos, asserting it emits a git/session-state snapshot only on
+source `compact` and stays silent everywhere else. See the hook under
+config/claude/hooks/. The gh PR lookup is best-effort and omitted in these
+local (non-GitHub) repos, so the tests don't assert on it.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "config" / "claude" / "hooks" / "compact-snapshot.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+  subprocess.run(
+    ["git", "-C", str(repo), *args],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+
+
+def _make_repo(tmp_path: Path, branch: str = "feature/x") -> Path:
+  """A git repo on `branch` with one commit."""
+  repo = tmp_path / "myrepo"
+  repo.mkdir()
+  _git(repo, "init", "-q", "-b", branch)
+  _git(
+    repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+    "--allow-empty", "-m", "init"
+  )
+  return repo
+
+
+def _run(cwd: str, source: str = "compact") -> dict:
+  """Invoke the hook with a crafted SessionStart event; return parsed JSON (or
+  {} when the hook emits nothing)."""
+  event = {"hook_event_name": "SessionStart", "source": source, "cwd": cwd}
+  res = subprocess.run(
+    ["python3", str(HOOK)],
+    input=json.dumps(event),
+    capture_output=True,
+    text=True,
+  )
+  assert res.returncode == 0, res.stderr    # always fail-safe exit 0
+  out = res.stdout.strip()
+  return json.loads(out) if out else {}
+
+
+def _ctx(out: dict) -> str:
+  return out.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def test_emits_snapshot_on_compact(tmp_path):
+  repo = _make_repo(tmp_path, branch="feature/y")
+  ctx = _ctx(_run(str(repo)))
+  assert "myrepo" in ctx
+  assert "feature/y" in ctx
+  assert "Working tree: clean" in ctx
+
+
+def test_silent_on_non_compact_sources(tmp_path):
+  repo = _make_repo(tmp_path)
+  for src in ("startup", "resume", "clear"):
+    assert _run(str(repo), source=src) == {}, src
+
+
+def test_silent_outside_git_repo(tmp_path):
+  assert _run(str(tmp_path), source="compact") == {}
+
+
+def test_reports_dirty_worktree_with_staged_count(tmp_path):
+  repo = _make_repo(tmp_path)
+  (repo / "new.txt").write_text("x\n", encoding="utf-8")
+  _git(repo, "add", "new.txt")
+  ctx = _ctx(_run(str(repo)))
+  assert "1 changed (1 staged)" in ctx
+
+
+def test_flags_protected_default_branch(tmp_path):
+  # When the current branch is the repo's default, the snapshot warns to
+  # branch before editing. Point origin/HEAD at the current branch to mark it
+  # default (the symbolic-ref need not have a real target ref to be read back).
+  repo = _make_repo(tmp_path, branch="main")
+  _git(
+    repo, "symbolic-ref", "refs/remotes/origin/HEAD",
+    "refs/remotes/origin/main"
+  )
+  ctx = _ctx(_run(str(repo)))
+  assert "protected" in ctx


### PR DESCRIPTION
## Summary
- Settles the BACKLOG **compaction control** item, grounded in current docs.
  **Q1 refuted:** there is **no** `# Compact instructions` CLAUDE.md heading
  feature — CLAUDE.md/MEMORY.md auto-reinject after a compaction, but with no
  magic heading. So nothing was added to CLAUDE.md (recorded so it isn't
  re-attempted).
- **The documented lever** is a `SessionStart` hook with `source: "compact"`,
  whose `additionalContext` is injected post-compaction. Built
  **`config/claude/hooks/compact-snapshot.py`** (matcher `compact`) to re-inject
  a short, deterministic snapshot the auto-reinjection doesn't cover: repo,
  branch (+ protected-default warning), the branch's open PR (via `gh`), and
  working-tree status.
- Read-only, fail-safe (non-git / detached HEAD / non-`compact` → silent), `gh`
  best-effort with a short timeout. **Runs only on compaction**, so no per-turn
  context cost.
- Registered in `settings.json`; tested in `tests/python/test_compact_snapshot.py`
  (pytest, matching the existing Python-hook test convention — not bats); hook
  count 4 → 5 in `SETUP-AUDIT.md`.

## Test plan
- [ ] `pytest tests/python/test_compact_snapshot.py` green (CI) — emits on
      `compact`; silent on startup/resume/clear and outside a git repo; reports
      dirty/staged counts; flags the protected default branch.
- [ ] `pre-commit run --all-files` green (flake8/yapf/isort, check-json,
      markdownlint).
- [ ] Manually verified the snapshot output for feature/default/dirty/clean
      cases and the non-compact silence.