### PR TITLE
feat(claude): new-project setup rule + skill

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -36,7 +36,7 @@ rules) are all resolved — see [`audit/decisions-log.md`](audit/decisions-log.m
 
 | Tier | State |
 |------|-------|
-| Always-on rules | 8 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` (a conversational-trigger guardrail with no file glob — kept always-on by design). `trufflehog` was scoped to `.github/workflows/**` (2026-06-19). 42 rules are `paths:`-scoped (on-demand). |
+| Always-on rules | 8 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` (a conversational-trigger guardrail with no file glob — kept always-on by design). `trufflehog` was scoped to `.github/workflows/**` (2026-06-19). 43 rules are `paths:`-scoped (on-demand, incl. `new-project` added 2026-06-19). |
 | MCP tool schemas | context7 only, via `mymcp` at user scope. terraform / serena dropped (2026-06-10). |
 | Plugins | 1 enabled (`skill-creator`); all other marketplace plugins disabled. |
 | Hooks | 5 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`, `compact-snapshot`). |

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -80,6 +80,19 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   rule/skill, also check whether a plugin provides it or should be added.
   Extend `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a
   Skill* and the `rule-coverage.py` hook. Bias to surfacing in the moment.
+- [ ] **Canonicalize protected-branch detection in `git.md` (LOW —
+  retrospective, PR #129).** The `new-project` rule/skill needed to detect
+  branch protection for a *brownfield* repo that lacks the local
+  `no-commit-to-branch` hook, so it spelled out the concrete
+  `gh api repos/{owner}/{repo}/rules/branches/<branch>` (and `.../protection`)
+  query **inline**. But the canonical home for "how to tell whether a branch
+  is protected" is `git.md` (*Protecting the Default Branch* / *Never Work
+  Directly on a Protected Branch*), which lists the *sources* (ruleset, local
+  hook, `.claude/` docs, default-when-in-doubt) but **not** the concrete API
+  command. To stop the method drifting across two files (dedupe-the-fact,
+  `code-style.md` Rule of Three), promote the `gh api` detection command into
+  `git.md` as the canonical method and have `new-project` reference it instead
+  of carrying its own copy. Small edit; not a new artifact.
 
 ## Plugin-audit follow-ups (from the 2026-06-10/-11 passes)
 
@@ -296,40 +309,6 @@ powershell, pre-commit, python, shellcheck, shfmt, yamllint, markdownlint,
 yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
 
 - [ ] Remaining rules to author:
-  - [x] new project setup — **DONE:** built **both** a thin path-scoped
-    `rules/new-project.md` (policy + the experience notes below) and the
-    on-demand **`new-project` skill** (greenfield init **and** brownfield
-    "convert an existing repo to the claude setup" modes). Language
-    bootstrapping is **delegated** to the per-language rules (not inlined),
-    per the split this item flagged. The points-from-experience were folded
-    into the rule's policy. *(decisions-log + prune at merge.)*
-    Original framing — general checklist for initializing a project (git
-    init, pre-commit, .claude/ scaffold, DEVELOPER.md, TODO.md, etc.);
-    evaluate splitting language-specific bootstrapping steps (e.g. NeoForge
-    MDK, Poetry, npm init) into the relevant per-language rules file rather
-    than bloating the general rule. Points considered from experience:
-    - Investigate actual storage/file formats before designing around them;
-      official docs may describe outdated formats (e.g. JourneyMap switched
-      from per-waypoint JSON to a binary DAT in 6.x without updating docs)
-    - Check whether related/foreign repos are already cloned as siblings
-      before suggesting clone locations (../reponame convention)
-    - Defer .claude/ scaffold until project-specific conventions emerge;
-      Phase 0 setup rarely produces enough repo-specific content to justify it
-    - Editor config belongs in the editor's own config repo, not the project;
-      DEVELOPER.md should note the maintainer's editor but not prescribe setup
-    - When adding language support to an editor config, verify that
-      indentation and formatting settings match the chosen formatter's output
-      rather than blindly following language community conventions (e.g.
-      google-java-format uses 2-space, not the traditional 4-space Java style)
-    - New project setup frequently exposes gaps in existing global config
-      (missing docs, redundant settings, stale paths); capture these as
-      follow-up items in the relevant repo's TODO rather than blocking setup
-    - DEVELOPER.md should cover the full build/test workflow including
-      platform-specific quirks (e.g. build in WSL2, test in Windows Minecraft)
-    - Pin pre-commit hook versions to current stable at time of setup;
-      note that versions need periodic review as hooks release updates
-    - Document the rationale for non-obvious decisions (e.g. why 2-space
-      Java indent) so future sessions don't relitigate them
   - [ ] commitizen — rule and/or skill for conventional commit message
     formatting; evaluate whether a rule (policy + invocation) is sufficient
     or whether the multi-step workflow warrants a skill

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -296,12 +296,18 @@ powershell, pre-commit, python, shellcheck, shfmt, yamllint, markdownlint,
 yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
 
 - [ ] Remaining rules to author:
-  - [ ] new project setup — rule covering the general checklist for
-    initializing a project (git init, pre-commit, .claude/ scaffold,
-    DEVELOPER.md, TODO.md, etc.); evaluate splitting language-specific
-    bootstrapping steps (e.g. NeoForge MDK, Poetry, npm init) into the
-    relevant per-language rules file rather than bloating the general rule.
-    Points to consider from experience:
+  - [x] new project setup — **DONE:** built **both** a thin path-scoped
+    `rules/new-project.md` (policy + the experience notes below) and the
+    on-demand **`new-project` skill** (greenfield init **and** brownfield
+    "convert an existing repo to the claude setup" modes). Language
+    bootstrapping is **delegated** to the per-language rules (not inlined),
+    per the split this item flagged. The points-from-experience were folded
+    into the rule's policy. *(decisions-log + prune at merge.)*
+    Original framing — general checklist for initializing a project (git
+    init, pre-commit, .claude/ scaffold, DEVELOPER.md, TODO.md, etc.);
+    evaluate splitting language-specific bootstrapping steps (e.g. NeoForge
+    MDK, Poetry, npm init) into the relevant per-language rules file rather
+    than bloating the general rule. Points considered from experience:
     - Investigate actual storage/file formats before designing around them;
       official docs may describe outdated formats (e.g. JourneyMap switched
       from per-waypoint JSON to a binary DAT in 6.x without updating docs)

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,34 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Authored the "new project setup" item as both a rule and a
+  skill.** Worked the long-standing BACKLOG item (under *Claude Rules Files*).
+  **Kind decision:** by `EXTENDING.md`'s primitive guidance a multi-step init
+  is skill-shaped, but the user chose **both** — a thin **policy** rule plus
+  the **procedure** skill, the `bats-setup → bats.md` pattern. **Context
+  economy:** the rule is **path-scoped** to manifest/scaffold files
+  (`pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `Gemfile`, the
+  pre-commit configs, `DEVELOPER.md`) so it never joins the always-on tier — a
+  setup rule has no natural glob and would otherwise be per-turn bloat
+  (scoped-rule count 42→43; always-on stays 8). The backlog's
+  "points-from-experience" became the rule's policy; **language bootstrapping
+  is delegated to the per-language rules**, not inlined (the split the item
+  flagged), per *Layer the generic over the specific*. **Brownfield mode:**
+  the skill also **converts an existing repo to the claude setup**
+  (inventory → gap-analyze → wire missing layers non-destructively → the
+  `.claude/` decision → promote repo-local rules to global) — folding in a
+  convert-existing idea
+  the user expected captured separately but that only existed implicitly here.
+  **Protected-branch detection fix:** the "never author on a protected branch"
+  guidance originally leaned on the local `no-commit-to-branch` hook, which a
+  not-yet-converted repo lacks (circular); reworked to detect via the host
+  ruleset/branch-protection **API** (`gh api .../rules/branches/<branch>`) →
+  `.claude/` docs → local hook args, default-protected when unsure, and **ask
+  the user** if nothing resolves it. Grounding: house convention (no external
+  source). Retrospective filed (BACKLOG, LOW): promote that concrete detection
+  command into `git.md` as the canonical source so it doesn't drift. Shipped
+  PR #129. Files: `rules/new-project.md`, `skills/new-project/SKILL.md`,
+  `SETUP-AUDIT.md`.
 - 2026-06-19 — **Settled Claude Code compaction control; wired a
   `SessionStart`/`compact` snapshot hook.** Worked the BACKLOG item, grounded
   in current official docs (claude-code-guide). **Q1 — the `# Compact

--- a/config/claude/rules/new-project.md
+++ b/config/claude/rules/new-project.md
@@ -70,10 +70,21 @@ rather than restating them; defer to each on its specifics.
   audit backlog for agent-config gaps) rather than letting it stall the
   setup.
 
-- **Never author on a protected branch.** A conversion lands through the
-  repo's normal workflow — branch first, PR, approval — never direct commits
-  to a protected default (`git.md` *Never Work Directly on a Protected
-  Branch*).
+- **Never author on a protected branch — for a conversion, detect protection
+  deliberately.** A setup lands through the repo's normal workflow (branch
+  first, PR, approval) — never direct commits to a protected default
+  (`git.md` *Never Work Directly on a Protected Branch*). The usual local
+  signal is the `no-commit-to-branch` pre-commit hook (what the edit-time
+  `branch-protection.py` guard reads), but an **existing repo being converted
+  likely hasn't configured it yet** — so don't rely on that signal alone.
+  Determine protection from whatever sources exist, in order: (1) the host's
+  branch-protection / ruleset **API**, authoritative — `gh api
+  repos/{owner}/{repo}/rules/branches/<branch>` for the rules applying to a
+  branch, or `.../branches/<branch>/protection` for classic protection; (2)
+  the repo's `.claude/` docs, if any name the protected branch; (3) the local
+  `no-commit-to-branch` hook args, if configured. Treat the **default branch
+  as protected when in doubt**, and if **none of these resolve it, ask the
+  user** before authoring on the branch rather than assuming it is safe.
 
 ## Sources
 

--- a/config/claude/rules/new-project.md
+++ b/config/claude/rules/new-project.md
@@ -1,0 +1,93 @@
+---
+# Setup activity has no single file type; scope to the manifest and
+# scaffolding files a project init / conversion actually touches, so this
+# policy loads then but never joins the always-on tier.
+paths:
+  - "pyproject.toml"
+  - "package.json"
+  - "Cargo.toml"
+  - "go.mod"
+  - "Gemfile"
+  - ".pre-commit-config.yaml"
+  - ".pre-commit-config-fix.yaml"
+  - "DEVELOPER.md"
+---
+
+# New Project Setup Rules
+
+**Version:** v1.0.0
+
+Standing policy for **initializing a new repository** *or* **converting an
+existing one** to these conventions. This is the passive policy that should
+shape setup decisions even when the procedure isn't explicitly invoked; the
+**procedure** is the **`new-project` skill** (`skills/new-project/`) — reach
+for it to actually run a setup. It composes the existing rules
+(`git.md`, `gh.md`, `pre-commit.md`, `testing.md`, the per-language rules)
+rather than restating them; defer to each on its specifics.
+
+## Policy
+
+- **Language bootstrapping lives in the per-language rule**, not here. Poetry
+  (`poetry.md`), npm, cargo, a NeoForge MDK, etc. each own their own
+  `<tool> init` / scaffold steps. This rule and the skill stay
+  stack-agnostic and **delegate** to them — keep one language's specifics out
+  of the generic layer (`EXTENDING.md` *Layer the generic over the
+  specific*). A language with no bootstrapping coverage in its rule is a gap
+  to capture (`CLAUDE.md` *Missing or Conflicting Tool Rules*), not to inline
+  here.
+
+- **Defer the `.claude/` scaffold** until repo-specific conventions actually
+  emerge. Phase-0 setup rarely produces enough repo-specific content
+  (CONVENTIONS / WORKFLOW / TESTS, local rules) to justify it — the global
+  config already covers the generic case. Create it when the repo has
+  something to say that the global layer doesn't.
+
+- **Editor config belongs in the editor's own config repo, not the project.**
+  `DEVELOPER.md` may *note* the maintainer's editor; it must not prescribe
+  editor setup. When wiring a formatter/linter, match any committed
+  editor/format settings (`.editorconfig`, indent width) to **the formatter's
+  output**, not language-community defaults — e.g. `google-java-format` emits
+  2-space, not the traditional 4-space Java style. Record the rationale for a
+  non-obvious choice (an `adr`, or a `DEVELOPER.md` note) so a later session
+  doesn't relitigate it.
+
+- **Pin tool versions to current stable at setup** — pre-commit hook `rev`s
+  especially — and note that they need periodic review as the tools release
+  updates (the `deps-update` skill).
+
+- **Investigate actual storage / file formats before designing around them.**
+  Official docs may describe an outdated format (e.g. a tool that switched
+  from per-record JSON to a binary blob without updating its docs). Verify
+  against the real artifact, not memory.
+
+- **Check for already-cloned sibling repos** (`$PARENT_DIR/<repo-name>/`)
+  before suggesting a clone location for a related/foreign dependency — see
+  `git.md` *Related/Foreign Repositories*.
+
+- **Capture gaps, don't block on them.** Setup frequently exposes gaps in the
+  global config (missing docs, redundant settings, stale paths). Capture each
+  as a follow-up `- [ ]` in the relevant repo's `TODO.md` (or the dotfiles
+  audit backlog for agent-config gaps) rather than letting it stall the
+  setup.
+
+- **Never author on a protected branch.** A conversion lands through the
+  repo's normal workflow — branch first, PR, approval — never direct commits
+  to a protected default (`git.md` *Never Work Directly on a Protected
+  Branch*).
+
+## Sources
+
+House convention — no external source. Grounded in this repo's own setup
+practice and the rules it composes (`git.md`, `gh.md`, `pre-commit.md`,
+`testing.md`, the per-language rules); recorded in
+`config/claude/audit/decisions-log.md`.
+
+## Agent Behavior
+
+- When starting a new repo, or converting an existing one to these
+  conventions, **invoke the `new-project` skill** and apply the policy above
+  throughout.
+- Bootstrap a language via **its** rule; never inline language-specific
+  scaffold steps into the generic setup.
+- Defer the `.claude/` scaffold until the repo has repo-specific content;
+  capture global-config gaps as TODO follow-ups instead of blocking.

--- a/config/claude/skills/new-project/SKILL.md
+++ b/config/claude/skills/new-project/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: new-project
+description: Initialize a new repository, or convert an existing one to these dotfiles' conventions (the "claude setup"). Greenfield mode scaffolds git + default branch, a pinned pre-commit baseline, README/TODO/DEVELOPER docs, a test harness, CI, and branch protection, delegating language bootstrapping to the per-language rule. Brownfield mode inventories an existing repo, gap-analyzes it against the conventions, and wires the missing layers without clobbering what's there — including the CLAUDE.md/.claude/ decision and promoting repo-local rules to global. Use when setting up or onboarding a repo: "set up a new project", "scaffold a repo", "start a new project", "convert this repo to my claude setup", "onboard this repo", "bring this repo up to my conventions", "add the claude config here", "adopt the dotfiles setup".
+---
+
+# new-project
+
+**Version:** v1.0.0
+
+The procedure for **standing up a new repository** or **converting an existing
+one** to these conventions. `rules/new-project.md` is the standing **policy**
+— read it first and apply it throughout; this skill is the **steps**. It
+orchestrates the existing rules and setup skills rather than restating them:
+
+- Git init / default branch / branch protection / sibling repos → `git.md`.
+- PR flow → `gh.md`, the `ship-pr` skill.
+- Pre-commit baseline (phased) → `pre-commit.md`.
+- Test harness → `testing.md` + the language's setup skill (`bats-setup`,
+  `pytest-patterns`, …).
+- Language bootstrapping (Poetry, npm, cargo, MDK) → the **per-language rule**
+  (`poetry.md`, …) — this skill **delegates**, never inlines it.
+
+Grounding: house convention (no external source) — see the rule's *Sources*.
+
+## Pick the mode
+
+- **Greenfield** — an empty or brand-new repo with nothing set up yet.
+- **Brownfield** — an existing repo that works but doesn't yet follow these
+  conventions / lacks the claude setup. **Inventory first, never clobber.**
+
+## Mode A — Greenfield (new repo)
+
+Run in order; skip a step only with a stated reason.
+
+1. **Git.** `git init`, set the default branch to the user's convention
+   (`git.md` *Default Branch* — don't hardcode `main`/`master`), make the
+   first commit. Decide early whether the default branch will be PR-only
+   (step 7).
+
+2. **Language bootstrap.** Identify the stack and run **its** rule's
+   scaffold steps (e.g. `poetry.md` for a Python package). If that language
+   has no rule, surface the gap (`CLAUDE.md` *Missing or Conflicting Tool
+   Rules*) before improvising.
+
+3. **Pre-commit baseline.** Add `.pre-commit-config.yaml` (check) and
+   `.pre-commit-config-fix.yaml` (fix) per `pre-commit.md`'s phased strategy,
+   **version-pinned to current stable**. Include `no-commit-to-branch` for the
+   protected branch (step 7). `pre-commit install`.
+
+4. **Docs scaffold** (`WORKFLOW.md` *Documentation Philosophy* — inline-first,
+   minimal):
+   - `README.md` — minimal: setup + navigation only.
+   - `TODO.md` — the task/triage queue.
+   - `DEVELOPER.md` — the full build/test workflow incl. platform quirks
+     (e.g. build in WSL2, test in Windows); may *note* the maintainer's editor
+     but not prescribe editor setup (per the rule).
+
+5. **Test harness.** Stand it up via the language's setup skill (`bats-setup`
+   for shell, the pytest pattern for Python, …); a starter test proving the
+   wiring, covering a success and a failure path (`testing.md`).
+
+6. **CI.** A minimal workflow that runs pre-commit and gates the test suite.
+   Required checks come later once the suite is green.
+
+7. **Branch protection** *(if the default branch is PR-only)*. Apply the three
+   layers from `git.md` *Protecting the Default Branch* — server-side ruleset
+   (authoritative), the `no-commit-to-branch` hook (step 3), and the
+   edit-time `branch-protection.py` guard (automatic where the hook is
+   configured).
+
+8. **`.claude/` scaffold — defer.** Do **not** create it reflexively. Add
+   `CLAUDE.md` / `.claude/` only once the repo has repo-specific conventions
+   the global config doesn't already cover (per the rule). Until then the
+   global config carries it.
+
+9. **Capture gaps.** Log any global-config gaps setup exposed as `- [ ]`
+   follow-ups (repo `TODO.md`, or the dotfiles audit backlog for agent-config
+   gaps) — don't block setup on them.
+
+## Mode B — Brownfield (convert an existing repo)
+
+The goal is to bring an existing repo up to these conventions / onto the
+claude setup **incrementally and non-destructively**.
+
+1. **Inventory what exists.** Check each layer before touching it: default
+   branch + protection, `.pre-commit-config*.yaml`, test layout + runner, CI
+   workflows, `README` / `DEVELOPER.md` / `TODO.md`, and any `CLAUDE.md` /
+   `.claude/`. Read what's there; a working setup that differs from ours is a
+   reconcile, not a rip-and-replace.
+
+2. **Gap-analyze** against Mode A's layers. List what's missing, what's stale,
+   and what already conforms. Surface conflicts (e.g. a different test layout)
+   rather than silently overwriting.
+
+3. **Wire the missing layers**, each via its own rule/skill (steps 3–7
+   above), smallest-first. Match the repo's existing idioms where they're
+   sound; only change what genuinely diverges from the conventions.
+
+4. **The `.claude/` decision.** If the repo has no agent config, rely on the
+   global config and add a local `.claude/` only for genuinely repo-specific
+   content (same defer rule as Mode A, step 8). If it *has* one, reconcile it
+   with the global set.
+
+5. **Promote, don't duplicate.** If the repo carries repo-local rules/skills
+   that are actually language- or repo-agnostic (tier 1/2 of `CLAUDE.md`
+   *Configuration Migration*), flag them for promotion to the global config
+   instead of leaving a divergent copy — this is the inbound half of the
+   "Audit Project .claude/ Dirs for Promotable Rules/Skills" backlog item.
+
+6. **Land via PR.** All changes go through the repo's normal workflow — branch
+   first, PR, approval (`ship-pr`); never edit a protected branch directly
+   (`git.md`).
+
+## What this skill does not do
+
+- It does **not** carry language-specific scaffold commands — those live in
+  the per-language rules it delegates to.
+- It does **not** force a `.claude/` scaffold — deferral is the default.
+- It does **not** merge or push to a protected branch — landing is the repo's
+  PR workflow.

--- a/config/claude/skills/new-project/SKILL.md
+++ b/config/claude/skills/new-project/SKILL.md
@@ -86,7 +86,10 @@ claude setup **incrementally and non-destructively**.
    branch + protection, `.pre-commit-config*.yaml`, test layout + runner, CI
    workflows, `README` / `DEVELOPER.md` / `TODO.md`, and any `CLAUDE.md` /
    `.claude/`. Read what's there; a working setup that differs from ours is a
-   reconcile, not a rip-and-replace.
+   reconcile, not a rip-and-replace. **Detect branch protection deliberately**
+   — a not-yet-converted repo usually lacks the local `no-commit-to-branch`
+   signal, so use the API / `.claude/` sources in `rules/new-project.md` and
+   **ask the user if it's undetermined** before authoring on the branch.
 
 2. **Gap-analyze** against Mode A's layers. List what's missing, what's stale,
    and what already conforms. Surface conflicts (e.g. a different test layout)


### PR DESCRIPTION
## Summary
- Author the long-standing "new project setup" backlog item as **both** a thin
  path-scoped `rules/new-project.md` (standing policy) and an on-demand
  **`new-project` skill** (the procedure) — per `EXTENDING.md`'s primitive
  guidance and the `bats-setup → bats.md` precedent.
- The rule path-scopes to manifest/scaffold files so it never joins the
  always-on tier; the experience notes (defer `.claude/` scaffold, editor
  config lives elsewhere, pin tool versions, verify real file formats, check
  sibling repos, capture gaps don't block) live there. Language bootstrapping
  is **delegated** to the per-language rules, not inlined.
- The skill has a **greenfield** mode (new repo) and a **brownfield** mode that
  **converts an existing repo to the claude setup** — inventory, gap-analyze,
  wire missing layers non-destructively, the `.claude/` decision, and promote
  repo-local rules to global.
- Robust **protected-branch detection** for conversions: a not-yet-converted
  repo lacks the local `no-commit-to-branch` signal, so detect via the host
  ruleset/branch-protection API → `.claude/` docs → local hook args, treat the
  default branch as protected when in doubt, and **ask the user** if nothing
  resolves it.
- Backlog sub-item marked done; `SETUP-AUDIT.md` scoped-rule count 42→43.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.).
- [ ] `bats tests/shell/test_skill_frontmatter.bats` green (new skill conforms:
      name matches dir, description 818 ≤ 1024).
- [ ] Docs/config-only change — no runtime behavior to exercise.