### PR TITLE
feat(claude): finish the audit dimensions/design section

### DIFF
--- a/.claude/TESTS.md
+++ b/.claude/TESTS.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-**Version:** v2.4.0
+**Version:** v2.5.0
 
 ## Purpose
 
@@ -79,7 +79,10 @@ the same gating suite without breaking docker-less environments.
 - Repo-structure invariants get a guard test too: `test_skill_frontmatter.bats`
   holds every `config/claude/skills/*/SKILL.md` to the Agent Skills
   open-standard frontmatter rules (see `config/claude/EXTENDING.md` Skill ›
-  *Format*).
+  *Format*), and `test_rule_frontmatter.bats` holds every
+  `config/claude/rules/*.md` to declaring its load tier — a `paths:` key or a
+  `# No paths — <why>` comment — so a rule can't silently join the always-on
+  per-turn tier by omission (see `config/claude/rule-TEMPLATE.md`).
 
 ## Coverage priorities (incremental)
 

--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Repository Workflow
 
-**Version:** v1.3.0
+**Version:** v1.4.0
 
 ## Purpose
 
@@ -196,6 +196,17 @@ When capturing any follow-up, decide where it belongs before writing it:
   primary file and add an inline scope note pointing at the other — and, for an
   embedded config deliverable, either author it as part of the parent task or
   move it to `BACKLOG.md` when the parent completes, so it isn't stranded.
+* **Cross-repo** → a follow-up that belongs to a **different repo than the one
+  you're in** (e.g. a global-config change that spawns a per-repo evaluation
+  for pigify / scripturestudy-app). You usually can't write it into the target
+  repo's `TODO.md` from here, so don't lose it or mis-home it: **capture
+  it where the originating work lives** (the dotfiles `BACKLOG.md` for
+  config-spawned items, else the current repo's `TODO.md`), tag it with the
+  **target repo** and a **migrate-on-next-visit trigger** — e.g. "→ pigify:
+  migrate to its `TODO.md` when next working it". The reciprocal: when you
+  **start work in a repo**, scan the dotfiles `BACKLOG.md` (and any other
+  parking spot) for items tagged to it and migrate them into its `TODO.md`.
+  The **github-tasks** sweep is the natural place to run that inbound check.
 
 The reciprocal pointers live in each file's header and in `TODO.md`'s *Audit
 the Claude Code Setup* section.
@@ -292,7 +303,7 @@ See individual tool configurations for additional variables.
 ### Versioning
 
 * `CLAUDE.md` - Versioned (see that file)
-* `WORKFLOW.md` - Versioned (this file, v1.3.0)
+* `WORKFLOW.md` - Versioned (this file, v1.4.0)
 * `TESTS.md` - Versioned (see that file)
 * `.claude/rules/*.md` - Individual versions
 

--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -139,6 +139,11 @@ gone stale relative to current best practice:
   single-repo need. The repo override belongs in `.claude/`; the global
   rule changes only when the new behavior is genuinely better for all
   consumers.
+- Consider a **plugin** too: before authoring, check whether an installed or
+  available plugin already provides the capability (or should be added) —
+  decide adopt-vs-build per `EXTENDING.md` *Build vs adopt* and `rules/mcp.md`
+  (plugins are global-only and always-on, so only a good global fit earns
+  one).
 
 ## When to Propose a Skill
 
@@ -161,6 +166,11 @@ using the three-tier model in *Configuration Migration*:
 
 - Generally useful across repos → propose a global skill.
 - Repo-specific workflow → propose a repo-level skill (or a script).
+
+Before building one, also check whether a **plugin** already packages this (a
+marketplace skill/command) — adopt-vs-build per `EXTENDING.md` *Build vs
+adopt*; prefer our own lean skill when the plugin is bloated for the context
+it costs.
 
 Do not invent skills for one-shot tool invocations — those belong in a
 rule. The threshold is "this is a procedure I would write up for a new

--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -39,5 +39,5 @@ rules) are all resolved — see [`audit/decisions-log.md`](audit/decisions-log.m
 | Always-on rules | 8 unscoped: the 7 cross-cutting (`code-style`, `documentation`, `gh`, `git`, `qa`, `testing`, `troubleshooting`) plus `claude-code-auth` (a conversational-trigger guardrail with no file glob — kept always-on by design). `trufflehog` was scoped to `.github/workflows/**` (2026-06-19). 43 rules are `paths:`-scoped (on-demand, incl. `new-project` added 2026-06-19). |
 | MCP tool schemas | context7 only, via `mymcp` at user scope. terraform / serena dropped (2026-06-10). |
 | Plugins | 1 enabled (`skill-creator`); all other marketplace plugins disabled. |
-| Hooks | 5 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`, `compact-snapshot`). |
+| Hooks | 6 bespoke (`branch-protection`, `merge-finalization`, `rule-coverage`, `shell-check`, `compact-snapshot`, `audit-cadence`). |
 | Always-on memory | global `CLAUDE.md` + the repo's `.claude/` (WORKFLOW / CONVENTIONS / TESTS). |

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -61,24 +61,27 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   against our own: adopt when good and lean (vendor-and-modify with a
   `SOURCE.md`); write our own when the plugin is bloated/over-scoped for the
   context it costs. Weigh context cost vs maintenance burden explicitly.
-- [ ] **External validation (GitHub Apps).** Evaluate third-party App checks as
-  outside quality signals: what is wired (CodeFactor, Snyk) vs candidates
-  (Codecov for coverage, Codacy / SonarCloud) — what each adds, its noise/cost,
-  whether it earns its place. *(Partly advanced 2026-06-19: CodeFactor/Snyk
-  resolved via the `security-scan` §4 escape hatch; the broader candidate sweep
-  now lives in the "🏅 credibility signals / badges" research task below — keep
-  them in sync.)*
-- [ ] **Cross-repo follow-up routing (LOW — retrospective, PR #123).** The
-  TODO-routing convention (`WORKFLOW.md`) routes a follow-up to *its* repo's
-  `TODO.md` — but a global-config change can spawn a follow-up **for a different
-  repo I'm not currently in** (here: per-repo Snyk evals for pigify /
-  scripturestudy-app). There's no first-class capture for that; they were
-  parked in this BACKLOG with a "migrate when next in that repo" flag — a
-  workaround. Decide a convention (or a tiny mechanism) for cross-repo
-  follow-ups so they aren't lost or mis-homed. Likely a short addition to the
-  `WORKFLOW.md` TODO-routing section.
-- [ ] **Delegated research can over-claim — demand exact doc quotes (LOW —
-  retrospective, PRs #126/#127).** Twice in one session a delegated research
+- [x] **External validation (GitHub Apps). DONE (resolved + redirected):**
+  CodeFactor/Snyk were resolved via the `security-scan` §4 escape hatch
+  (2026-06-19), and the broader candidate sweep (Codecov, Codacy, SonarCloud,
+  OpenSSF Scorecard, …) now lives in the open "🏅 credibility signals /
+  badges" research task below — that task is the single home for the
+  outstanding work. Closing this design-dimension entry to avoid a duplicate
+  tracker; the badges task carries it forward.
+- [x] **Cross-repo follow-up routing (LOW — retrospective, PR #123). DONE:**
+  added a **Cross-repo** case to `WORKFLOW.md`'s *TODO Routing* section
+  (v1.4.0) — capture the follow-up where the originating work lives, tag it
+  with the target repo + a "migrate to its `TODO.md` when next working it"
+  trigger, and scan the parking spot for inbound items at the start of work in
+  a repo (the **github-tasks** sweep runs that check). This formalizes the
+  workaround the per-repo Snyk evals (pigify / scripturestudy-app) were parked
+  under.
+- [x] **Delegated research can over-claim — demand exact doc quotes (LOW —
+  retrospective, PRs #126/#127). DONE:** added a *Delegated research can
+  over-claim* paragraph to the `claude-audit` skill's grounding notes —
+  require an exact quote + doc URL for any feature/behaviour claim that drives
+  an action, treat unsourced specifics as unconfirmed. Twice in one session a
+  delegated research
   agent asserted a plausible-but-false feature: a name "must not contain
   `claude`/`anthropic`" rule (#126) and a `# Compact instructions` CLAUDE.md
   heading (#127). Both were caught by re-verifying against primary docs before
@@ -88,10 +91,12 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   CLAUDE.md block, wiring a hook), require an **exact quote + doc URL** and
   treat unsourced specifics as unconfirmed. Small wording add to the skill's
   *Check grounding* / *Verify currency* notes; not a new artifact.
-- [ ] **Plugin-aware proposals (behavior rule).** When proposing a new
-  rule/skill, also check whether a plugin provides it or should be added.
-  Extend `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a
-  Skill* and the `rule-coverage.py` hook. Bias to surfacing in the moment.
+- [x] **Plugin-aware proposals (behavior rule). DONE:** added a plugin-check
+  to `CLAUDE.md`'s *Missing or Conflicting Tool Rules* and *When to Propose a
+  Skill* (consider whether a plugin already provides it / should be added —
+  adopt-vs-build per `EXTENDING.md`, `rules/mcp.md`), and extended the
+  `rule-coverage.py` reminder message with the same nudge. Bias to surfacing
+  in the moment.
 - [x] **Canonicalize protected-branch detection in `git.md` (LOW —
   retrospective, PR #129). DONE:** promoted the concrete `gh api
   rules/branches` / `.../protection` detection commands into `git.md` *Never

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -23,29 +23,41 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   records decisions here. Expect the **global** config to be re-evaluated from
   many repos — possibly several times a day; that repetition is by design (see
   the claude-audit skill, *Global is re-evaluated from every repo*).
-- [ ] **Context-load tiering.** Classify every artifact by *when* it loads:
+- [x] **Context-load tiering.** *Folded into the `claude-audit` skill
+  (Procedure step 1–2: "classify every artifact by load tier — always-on /
+  on-demand / isolated"). Checkbox closed; this is now a standing dimension of
+  every run, not open work.* Classify every artifact by *when* it loads:
   always-on (every turn: global CLAUDE.md, unscoped rules, enabled MCP tool
   schemas — the expensive tier), on-demand (path-scoped rules, skills, deferred
   MCP tools), isolated (agents — ~free to the main thread). Highest-leverage
   lever: push always-on content down a tier.
-- [ ] **Recategorize / split / merge.** For each artifact ask whether it is the
+- [x] **Recategorize / split / merge.** *Folded into the `claude-audit` skill
+  (Procedure step 2: assess right-fit / "is it the correct kind" + "has a
+  category grown too big and need splitting"). Checkbox closed; standing
+  dimension now.* For each artifact ask whether it is the
   right *kind*: a "rule" that is really a procedure → skill; one that must
   happen every time → hook; a bloated multi-tool rule → split per tool;
   duplicated content → dedupe to one canonical source.
-- [ ] **Enforce always-on intent: flag rules with no frontmatter** (LOW —
-  retrospective, PR #122). Both `trufflehog.md` and `claude-code-auth.md` were
+- [x] **Enforce always-on intent: flag rules with no frontmatter** (LOW —
+  retrospective, PR #122). **DONE:** built it as a **meta-test**
+  (`tests/shell/test_rule_frontmatter.bats`), mirroring the skills guard
+  (`test_skill_frontmatter.bats`) rather than a `PostToolUse` hook — rules are
+  added rarely, so a CI gate suffices and costs nothing per edit. It flags any
+  `config/claude/rules/*.md` whose frontmatter has neither `paths:` nor a
+  `# No paths` comment. `rule-TEMPLATE.md` and `.claude/TESTS.md` updated to
+  match. Both `trufflehog.md` and `claude-code-auth.md` were
   added *always-on by omission* (no `paths:` and no `# No paths` comment) — only
-  an audit caught it. Now every `rules/*.md` is either `paths:`-scoped or
-  carries a `# No paths — <why>` comment. A tiny **meta-test or `PostToolUse`
-  hook** could keep it that way: flag any `config/claude/rules/*.md` whose
-  frontmatter has neither `paths:` nor a documenting comment, so a new rule
-  can't silently join the per-turn tier. Decide kind (meta-test vs hook) and
-  whether the leverage justifies the check.
-- [ ] **Plugins / MCP dimension.** Inventory every enabled plugin (what it
+  an audit caught it; now a new rule can't silently join the per-turn tier.
+- [x] **Plugins / MCP dimension.** *Folded into the `claude-audit` skill
+  (Procedure step 3 + `rules/mcp.md`: plugin/MCP inventory and cull). Checkbox
+  closed; standing dimension now.* Inventory every enabled plugin (what it
   does/bundles, whether used); cull duplicates of the `gh` CLI / existing
   rules+skills and unused ones; remember plugins carry context cost. MCP
   servers here come *from* plugins (no hand-maintained `mcp.json`).
-- [ ] **Build vs. adopt.** For each capability weigh a maintained plugin/skill
+- [x] **Build vs. adopt.** *Folded into the `claude-audit` skill (mining/
+  "Judging": score generic value, then overlap with built-ins, vendor-with-
+  `SOURCE.md` vs write-our-own). Checkbox closed; standing dimension now.* For
+  each capability weigh a maintained plugin/skill
   against our own: adopt when good and lean (vendor-and-modify with a
   `SOURCE.md`); write our own when the plugin is bloated/over-scoped for the
   context it costs. Weigh context cost vs maintenance burden explicitly.
@@ -80,8 +92,12 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   rule/skill, also check whether a plugin provides it or should be added.
   Extend `CLAUDE.md`'s *Missing or Conflicting Tool Rules* + *When to Propose a
   Skill* and the `rule-coverage.py` hook. Bias to surfacing in the moment.
-- [ ] **Canonicalize protected-branch detection in `git.md` (LOW —
-  retrospective, PR #129).** The `new-project` rule/skill needed to detect
+- [x] **Canonicalize protected-branch detection in `git.md` (LOW —
+  retrospective, PR #129). DONE:** promoted the concrete `gh api
+  rules/branches` / `.../protection` detection commands into `git.md` *Never
+  Work Directly on a Protected Branch* as the numbered canonical method
+  (git.md v1.11.0); `new-project.md` now references it instead of carrying its
+  own copy. The `new-project` rule/skill needed to detect
   branch protection for a *brownfield* repo that lacks the local
   `no-commit-to-branch` hook, so it spelled out the concrete
   `gh api repos/{owner}/{repo}/rules/branches/<branch>` (and `.../protection`)

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -17,9 +17,15 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   dotfiles PR and sets up the local repo.
   (`claude-code-setup:claude-automation-recommender` can help gap-finding
   within a run.)
-- [ ] **Cadence.** Run `claude-audit` on a cadence — a quick pass *often*
+- [x] **Cadence. DONE (SessionStart hook nudge):** added
+  `config/claude/hooks/audit-cadence.py`, a SessionStart hook
+  (startup/resume/clear) that injects a once-a-day nudge to run a
+  `/claude-audit` pass — deduped via an `XDG_STATE_HOME/claude-audit-cadence`
+  date marker so it reminds without nagging every session. Fail-safe (exit 0
+  on any error). Tested by `tests/python/test_audit_cadence.py`. Run
+  `claude-audit` on a cadence — a quick pass *often*
   (enabled plugins/MCP, obvious always-on bloat) and a deeper audit
-  *periodically*. Wire it to a reminder / `/schedule`. Each detailed run
+  *periodically*. Each detailed run
   records decisions here. Expect the **global** config to be re-evaluated from
   many repos — possibly several times a day; that repetition is by design (see
   the claude-audit skill, *Global is re-evaluated from every repo*).

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -120,6 +120,16 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
   `code-style.md` Rule of Three), promote the `gh api` detection command into
   `git.md` as the canonical method and have `new-project` reference it instead
   of carrying its own copy. Small edit; not a new artifact.
+- [ ] **Prose-wrap check for agent-config Markdown (LOW — retrospective, PR
+  #130).** The 78-col prose-wrap convention (`CONVENTIONS.md`) is enforced
+  only by eye — markdownlint's `line_length` is set to 200 (tables/code),
+  so 79–80-col prose slips through; this session hand-fixed several such lines
+  (em-dashes also fool `awk length`, so the check must count *characters*).
+  Consider a small pre-commit/meta check that flags >78-col **prose** lines in
+  `config/claude/**` and `.claude/**` Markdown while exempting table rows,
+  fenced code, frontmatter `description:`, and reference-link/URL lines.
+  **Risk:** false positives on exactly those exemptions — evaluate whether a
+  reliable check is even feasible before building; it may not be worth it.
 
 ## Plugin-audit follow-ups (from the 2026-06-10/-11 passes)
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,33 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Cleared the *Audit dimensions / design* backlog section
+  (batch, PR #130).** Took the section to zero open items. The four
+  design-checklist items (context-load tiering, recategorize/split/merge,
+  plugins/MCP, build-vs-adopt) were marked done as **folded into the
+  `claude-audit` skill** — standing dimensions of every run, retained in
+  BACKLOG with a pointer (this section keeps `[x]` for continuity, like the
+  `[x] Form` item). Seven build items: (1) **rule-frontmatter guard**
+  `tests/shell/test_rule_frontmatter.bats` — flags any `rules/*.md` lacking
+  `paths:` or a `# No paths` comment; a CI gate, not a hook (rules are added
+  rarely); `rule-TEMPLATE.md` + `.claude/TESTS.md` (v2.5.0) updated. (2)
+  **Canonical protected-branch detection** in `git.md` (v1.11.0) — the
+  `gh api rules/branches` / `.../protection` commands as the numbered method;
+  `new-project.md` now references it (resolves the PR #129 retrospective). (3)
+  **Plugin-aware proposals** — CLAUDE.md's *Missing or Conflicting Tool Rules*
+  and *When to Propose a Skill* + the `rule-coverage.py` reminder now add an
+  adopt-vs-build plugin check. (4) **Cross-repo follow-up routing** —
+  WORKFLOW.md (v1.4.0) gains a *Cross-repo* TODO-routing case. (5)
+  **Delegated-research over-claim** — claude-audit grounding notes demand an
+  exact quote + doc URL for any feature claim driving an action. (6)
+  **External validation** closed as resolved+redirected to the badges task.
+  (7) **Cadence
+  (user chose the SessionStart hook nudge):** `config/claude/hooks/
+  audit-cadence.py` injects a once-a-day `/claude-audit` nudge on
+  startup/resume/clear, deduped via an `XDG_STATE_HOME/claude-audit-cadence`
+  date marker, fail-safe; `tests/python/test_audit_cadence.py` (5 cases); hook
+  count 5→6. Retrospective filed (LOW): a prose-wrap check for agent-config
+  Markdown.
 - 2026-06-19 — **Authored the "new project setup" item as both a rule and a
   skill.** Worked the long-standing BACKLOG item (under *Claude Rules Files*).
   **Kind decision:** by `EXTENDING.md`'s primitive guidance a multi-step init

--- a/config/claude/hooks/audit-cadence.py
+++ b/config/claude/hooks/audit-cadence.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""SessionStart hook: a once-a-day nudge that a claude-audit pass is due.
+
+Wired in settings.json for SessionStart sources startup/resume/clear (NOT
+compact — that has its own compact-snapshot.py). It injects a short
+additionalContext suggesting a quick `/claude-audit` pass, deduped to at most
+one nudge per calendar day via a state file, so it reminds without nagging
+every session.
+
+The audit re-evaluates the global config from whatever repo invoked it (by
+design — see the claude-audit skill, "Global is re-evaluated from every
+repo"), so the nudge is global, not dotfiles-only.
+
+Fail-safe: any error exits 0 silently so the session is never disrupted.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+from pathlib import Path
+
+NUDGE = (
+  "Audit cadence (daily nudge): a `/claude-audit` pass is due. Quick pass — "
+  "scan enabled plugins/MCP and obvious always-on bloat; run a deeper audit "
+  "periodically. The audit re-evaluates the global config from whatever repo "
+  "you're in (by design). Decisions are recorded in "
+  "config/claude/audit/decisions-log.md. Fires at most once per day; skip it "
+  "if now isn't the time."
+)
+
+#------------------------------------------------------------------------------
+# The per-day dedup marker lives in the XDG state dir; it holds the date
+# of the last nudge (YYYY-MM-DD). A separate file (not a project state
+# dir) because the cadence is global, not per-repo.
+
+
+def _state_file() -> Path:
+  base = os.environ.get("XDG_STATE_HOME") or os.path.join(
+    os.path.expanduser("~"), ".local", "state"
+  )
+
+  return Path(base) / "claude-audit-cadence"
+
+
+def _already_nudged_today(state: Path, today: str) -> bool:
+  try:
+    return state.read_text(encoding="utf-8").strip() == today
+  except OSError:
+    return False
+
+
+def _record(state: Path, today: str) -> None:
+  state.parent.mkdir(parents=True, exist_ok=True)
+  state.write_text(today + "\n", encoding="utf-8")
+
+
+def main() -> int:
+  try:
+    json.load(sys.stdin)
+  except Exception:
+    return 0
+
+  today = datetime.date.today().isoformat()
+  state = _state_file()
+
+  if _already_nudged_today(state, today):
+    return 0
+
+  _record(state, today)
+
+  print(
+    json.dumps({
+      "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": NUDGE,
+      }
+    })
+  )
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/config/claude/hooks/rule-coverage.py
+++ b/config/claude/hooks/rule-coverage.py
@@ -272,8 +272,9 @@ def main() -> int:
     f"{rules_dir}/<name>.md —\n - " + "\n - ".join(lines)
     + '\n\nPer the global CLAUDE.md "Missing or Conflicting Tool Rules" '
     "policy, surface this to the user and propose creating the rule(s) "
-    "(decide scope via the three-tier model). Skip genuinely trivial "
-    "utilities. This reminder will not repeat for the same items in "
+    "(decide scope via the three-tier model; also consider whether a plugin "
+    "already provides it — EXTENDING.md Build vs adopt). Skip genuinely "
+    "trivial utilities. This reminder will not repeat for the same items in "
     "this project."
   )
 

--- a/config/claude/rule-TEMPLATE.md
+++ b/config/claude/rule-TEMPLATE.md
@@ -1,7 +1,12 @@
 ---
-# List glob patterns for files this tool applies to.
-# Omit the paths key entirely for tools that are not file-type-specific
-# (e.g. git, gh).
+# Declare the load tier — a conformance guard (test_rule_frontmatter.bats)
+# enforces that this block has one or the other, so a rule can't silently
+# join the expensive always-on tier by omission:
+#  - Path-scoped (on-demand): keep `paths:` with the globs this rule applies
+#    to.
+#  - Always-on (every turn): for a rule not tied to a file type (e.g. git,
+#    gh), DELETE the `paths:` key and replace it with a documenting
+#    `# No paths — <why>` comment. Do NOT leave the block empty.
 paths:
   - "**/*.ext"  # replace .ext with actual extension(s)
 ---

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.10.0
+**Version:** v1.11.0
 
 ## Commit Messages
 
@@ -127,12 +127,25 @@ though uncommitted changes carry across `git checkout -b`, accumulating work
 on the protected branch is exactly the habit this rule forbids (one slip and
 the change is committed where it must never land).
 
-To tell whether a branch is protected: a server-side ruleset / branch
-protection, a local `no-commit-to-branch` hook (above), or the repo's
-`.claude/` docs name it. When in doubt, treat the default branch as
-protected. In a repo that configures `no-commit-to-branch`, the edit-time
-`branch-protection.py` hook enforces this rule for the agent automatically
-(see *Protecting the Default Branch*).
+To tell whether a branch is protected, check the available signals **in
+order** — this is the canonical detection method other rules/skills reference:
+
+1. **Server-side ruleset / branch protection** (authoritative) — query the
+   host's API. For GitHub,
+   `gh api repos/{owner}/{repo}/rules/branches/<branch>` lists the rules that
+   apply to a branch (ruleset-aware), and
+   `gh api repos/{owner}/{repo}/branches/<branch>/protection` reports classic
+   branch protection. (`gh` fills `{owner}`/`{repo}` from the current repo.)
+2. **Local `no-commit-to-branch` hook** args (above), if the repo configures
+   it.
+3. The repo's **`.claude/` docs** naming the protected branch.
+
+When in doubt, treat the **default branch as protected**. When **none** of
+these resolve it — common for a freshly cloned or not-yet-configured repo that
+lacks the local hook — **ask the user** before authoring on the branch rather
+than assuming it is safe. In a repo that configures `no-commit-to-branch`, the
+edit-time `branch-protection.py` hook enforces this rule for the agent
+automatically (see *Protecting the Default Branch*).
 
 ## Worktrees
 

--- a/config/claude/rules/new-project.md
+++ b/config/claude/rules/new-project.md
@@ -74,17 +74,12 @@ rather than restating them; defer to each on its specifics.
   deliberately.** A setup lands through the repo's normal workflow (branch
   first, PR, approval) — never direct commits to a protected default
   (`git.md` *Never Work Directly on a Protected Branch*). The usual local
-  signal is the `no-commit-to-branch` pre-commit hook (what the edit-time
-  `branch-protection.py` guard reads), but an **existing repo being converted
-  likely hasn't configured it yet** — so don't rely on that signal alone.
-  Determine protection from whatever sources exist, in order: (1) the host's
-  branch-protection / ruleset **API**, authoritative — `gh api
-  repos/{owner}/{repo}/rules/branches/<branch>` for the rules applying to a
-  branch, or `.../branches/<branch>/protection` for classic protection; (2)
-  the repo's `.claude/` docs, if any name the protected branch; (3) the local
-  `no-commit-to-branch` hook args, if configured. Treat the **default branch
-  as protected when in doubt**, and if **none of these resolve it, ask the
-  user** before authoring on the branch rather than assuming it is safe.
+  signal is the `no-commit-to-branch` pre-commit hook, but an **existing repo
+  being converted likely hasn't configured it yet** — so don't rely on that
+  signal alone. Detect protection by the **canonical method in `git.md`**
+  (*Never Work Directly on a Protected Branch*: host ruleset/branch-protection
+  API → local hook args → `.claude/` docs, default-protected when unsure), and
+  **ask the user** if none of those resolve it before authoring on the branch.
 
 ## Sources
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -50,6 +50,16 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/audit-cadence.py",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -159,6 +159,18 @@ convention**: its claims may be memory-based and already stale. This pairs
 with the currency check above (Context7) — grounding is *whether* a source
 exists; currency is *whether* it is still current.
 
+**Delegated research can over-claim — demand exact doc quotes.** When a
+spawned research agent (a `claude-code-guide` lookup, a doc-mining subagent)
+reports a **feature or behaviour claim** that would drive an action — a
+rename, a new `CLAUDE.md`/rule block, wiring a hook, adopting an API — do
+**not** act on the summary alone. Require an **exact quote plus the doc URL**
+backing that specific claim, and treat an unsourced specific as
+**unconfirmed** until checked against the primary source. Plausible-but-false
+specifics have slipped through twice (a skill-name charset rule not in the
+spec; a `# Compact instructions` CLAUDE.md heading that doesn't exist), caught
+only because they were high-stakes — make the quote-or-it-didn't-happen check
+routine, not luck.
+
 ## Mining repos for ideas
 
 An audit improves the **whole** dev environment, not just the current repo —

--- a/tests/python/test_audit_cadence.py
+++ b/tests/python/test_audit_cadence.py
@@ -1,0 +1,74 @@
+"""Tests for the audit-cadence SessionStart hook.
+
+Runs the hook as a subprocess (the way Claude Code invokes it), pointing
+XDG_STATE_HOME at a throwaway dir so the per-day dedup marker never touches
+real state. Asserts it nudges once per calendar day and stays silent on
+repeat runs the same day. See the hook under config/claude/hooks/.
+"""
+
+import datetime
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "config" / "claude" / "hooks" / "audit-cadence.py"
+
+TODAY = datetime.date.today().isoformat()
+
+
+def _run(state_home: Path, payload: str | None = None) -> dict:
+  """Invoke the hook with XDG_STATE_HOME redirected; return parsed JSON (or {}
+  when the hook emits nothing)."""
+  event = '{"hook_event_name": "SessionStart", "source": "startup"}'
+  res = subprocess.run(
+    ["python3", str(HOOK)],
+    input=event if payload is None else payload,
+    capture_output=True,
+    text=True,
+    env={
+      "XDG_STATE_HOME": str(state_home),
+      "HOME": str(state_home)
+    },
+  )
+  assert res.returncode == 0, res.stderr    # always fail-safe exit 0
+  out = res.stdout.strip()
+  return json.loads(out) if out else {}
+
+
+def _ctx(out: dict) -> str:
+  return out.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def _marker(state_home: Path) -> Path:
+  return state_home / "claude-audit-cadence"
+
+
+def test_nudges_on_first_run_of_day(tmp_path):
+  out = _run(tmp_path)
+  assert "/claude-audit" in _ctx(out)
+  assert _marker(tmp_path).read_text(encoding="utf-8").strip() == TODAY
+
+
+def test_silent_on_second_run_same_day(tmp_path):
+  assert _ctx(_run(tmp_path)) != ""    # first run nudges
+  assert _run(tmp_path) == {}          # second run is silent
+
+
+def test_nudges_again_when_marker_is_an_earlier_day(tmp_path):
+  _marker(tmp_path).write_text("2000-01-01\n", encoding="utf-8")
+  out = _run(tmp_path)
+  assert "/claude-audit" in _ctx(out)
+  assert _marker(tmp_path).read_text(encoding="utf-8").strip() == TODAY
+
+
+def test_creates_missing_state_dir(tmp_path):
+  nested = tmp_path / "deep" / "state"
+  out = _run(nested)
+  assert "/claude-audit" in _ctx(out)
+  assert _marker(nested).exists()
+
+
+def test_failsafe_on_bad_json(tmp_path):
+  assert _run(tmp_path, payload="not json") == {}
+  assert not _marker(tmp_path).exists()     # nothing recorded on a no-op

--- a/tests/shell/test_rule_frontmatter.bats
+++ b/tests/shell/test_rule_frontmatter.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# Conformance guard: every config/claude/rules/*.md must declare its load tier
+# in frontmatter — either a `paths:` key (path-scoped, on-demand) or a
+# `# No paths — <why>` comment (deliberately always-on). This stops a new rule
+# silently joining the per-turn always-on tier "by omission" (no paths and no
+# documenting comment), which an audit otherwise has to catch by hand. See
+# config/claude/SETUP-AUDIT.md, config/claude/rule-TEMPLATE.md, and the
+# decision in config/claude/audit/decisions-log.md (2026-06-19).
+#
+# This is the rules counterpart to test_skill_frontmatter.bats. Same posture:
+# a self-hosted check, no external linter just to lint our own files.
+
+load ../helpers/common
+
+setup() {
+  load_bats_libs
+
+  RULES="$(dotfiles_root)/config/claude/rules"
+}
+
+#------------------------------------------------------------------------------
+# Print the first `---`-delimited frontmatter block of a file (the lines
+# between the opening and closing `---`). Prints nothing when the file does not
+# open with a frontmatter block.
+
+frontmatter_block() {
+  awk '
+    NR == 1 && $0 != "---" { exit }
+    /^---$/ { c++; next }
+    c == 1 { print }
+    c >= 2 { exit }
+  ' "$1"
+}
+
+@test "every rule declares its load tier (paths: or a documented # No paths)" {
+  local bad=()
+
+  for f in "$RULES"/*.md; do
+    [[ -f $f ]] || continue
+
+    local fm
+    fm="$(frontmatter_block "$f")"
+
+    if [[ -z $fm ]]; then
+      bad+=("$(basename "$f"): no frontmatter block — add 'paths:' or a '# No paths — <why>' comment")
+      continue
+    fi
+
+    if ! grep -qE '^paths:' <<<"$fm" &&
+      ! grep -qiE '^#[[:space:]]*no paths' <<<"$fm"; then
+      bad+=("$(basename "$f"): frontmatter has neither 'paths:' nor a '# No paths' comment")
+    fi
+  done
+
+  ((${#bad[@]} == 0)) || fail "$(printf '%s\n' "${bad[@]}")"
+}


### PR DESCRIPTION
## Summary
Work the entire **Audit dimensions / design** section of the audit backlog
(`config/claude/audit/BACKLOG.md`) to zero open items.

- **Closed the four design-checklist (a) items** now folded into the
  `claude-audit` skill (context-load tiering, recategorize/split/merge,
  plugins/MCP, build-vs-adopt) — standing dimensions of every run.
- **Enforce always-on intent:** new `tests/shell/test_rule_frontmatter.bats`
  flags any `rules/*.md` lacking `paths:` or a `# No paths` comment (CI gate,
  mirrors the skills guard); `rule-TEMPLATE.md` + `TESTS.md` updated (v2.5.0).
- **Canonicalize protected-branch detection:** the `gh api rules/branches` /
  `.../protection` commands now live in `git.md` (v1.11.0) as the numbered
  canonical method; `new-project.md` references it.
- **Plugin-aware proposals:** CLAUDE.md's two proposal sections + the
  `rule-coverage.py` reminder now prompt an adopt-vs-build plugin check.
- **Cross-repo follow-up routing:** WORKFLOW.md (v1.4.0) gains a *Cross-repo*
  TODO-routing case (tag target repo + migrate-on-next-visit; github-tasks
  runs the inbound scan).
- **Delegated-research over-claim:** `claude-audit` grounding notes now demand
  an exact quote + doc URL for any feature claim that drives an action.
- **External validation:** closed as resolved+redirected (badges task).
- **Cadence:** `config/claude/hooks/audit-cadence.py` — a SessionStart
  (startup/resume/clear) hook injecting a once-a-day `/claude-audit` nudge,
  deduped via an `XDG_STATE_HOME` date marker, fail-safe; registered in
  `settings.json`; hook count 5→6.

## Test plan
- [ ] `pre-commit run --all-files` green.
- [ ] `bats tests/shell/test_*.bats` green (incl. new `test_rule_frontmatter`).
- [ ] `pytest tests/python` green (incl. new `test_audit_cadence`, 5 cases).
- [ ] Config/docs/test-only — no runtime behavior beyond the hooks, which are
      covered by tests.