### PR TITLE
fix(claude): prune-at-merge for the audit BACKLOG + enforce it

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Repository Workflow
 
-**Version:** v1.4.0
+**Version:** v1.5.0
 
 ## Purpose
 
@@ -178,6 +178,16 @@ which **blocks** a `gh pr merge` / `ship.sh merge` while any completed `- [x]`
 items still remain in the planning docs. See
 `config/claude/skills/ship-pr/SKILL.md` and `config/claude/rules/git.md`.
 
+The agent-config **audit backlog** is an equivalent planning list, so it is
+pruned the same way (completed items removed at merge, their record kept in
+[`audit/decisions-log.md`](../config/claude/audit/decisions-log.md)). It is
+declared as an extra planning doc the hook also enforces — repo-relative paths
+beyond the generic defaults, kept out of the global hook:
+
+```text
+merge-finalization-docs: config/claude/audit/BACKLOG.md
+```
+
 ### TODO Routing
 
 This repo splits its task tracking by **scope**, so each list stays focused.
@@ -303,7 +313,7 @@ See individual tool configurations for additional variables.
 ### Versioning
 
 * `CLAUDE.md` - Versioned (see that file)
-* `WORKFLOW.md` - Versioned (this file, v1.4.0)
+* `WORKFLOW.md` - Versioned (this file, v1.5.0)
 * `TESTS.md` - Versioned (see that file)
 * `.claude/rules/*.md` - Individual versions
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -7,119 +7,13 @@ migrated from `TODO.md`. **Routing:** a config task lands here; a dotfiles task
 in `TODO.md`; a mixed task is split with a cross-reference unless its parts are
 merely coupled (see `WORKFLOW.md` → *TODO routing*). Read when running
 `/claude-audit`. Audit-only (not context-loaded). Completed items are
-summarized in [`decisions-log.md`](decisions-log.md) and retained here for
-continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
+recorded in [`decisions-log.md`](decisions-log.md) (the durable record) and
+**pruned from here once the PR that completes them goes green** — this file
+holds only *open* work. Mined-repo provenance lives in
+[`idea-sources.md`](idea-sources.md) / [`mining-census.md`](mining-census.md).
 
 ## Audit dimensions / design
 
-- [x] **Form: the audit is the `claude-audit` skill** (`/claude-audit`) —
-  multi-step, runs its inventory *via an agent*, modifies global config via a
-  dotfiles PR and sets up the local repo.
-  (`claude-code-setup:claude-automation-recommender` can help gap-finding
-  within a run.)
-- [x] **Cadence. DONE (SessionStart hook nudge):** added
-  `config/claude/hooks/audit-cadence.py`, a SessionStart hook
-  (startup/resume/clear) that injects a once-a-day nudge to run a
-  `/claude-audit` pass — deduped via an `XDG_STATE_HOME/claude-audit-cadence`
-  date marker so it reminds without nagging every session. Fail-safe (exit 0
-  on any error). Tested by `tests/python/test_audit_cadence.py`. Run
-  `claude-audit` on a cadence — a quick pass *often*
-  (enabled plugins/MCP, obvious always-on bloat) and a deeper audit
-  *periodically*. Each detailed run
-  records decisions here. Expect the **global** config to be re-evaluated from
-  many repos — possibly several times a day; that repetition is by design (see
-  the claude-audit skill, *Global is re-evaluated from every repo*).
-- [x] **Context-load tiering.** *Folded into the `claude-audit` skill
-  (Procedure step 1–2: "classify every artifact by load tier — always-on /
-  on-demand / isolated"). Checkbox closed; this is now a standing dimension of
-  every run, not open work.* Classify every artifact by *when* it loads:
-  always-on (every turn: global CLAUDE.md, unscoped rules, enabled MCP tool
-  schemas — the expensive tier), on-demand (path-scoped rules, skills, deferred
-  MCP tools), isolated (agents — ~free to the main thread). Highest-leverage
-  lever: push always-on content down a tier.
-- [x] **Recategorize / split / merge.** *Folded into the `claude-audit` skill
-  (Procedure step 2: assess right-fit / "is it the correct kind" + "has a
-  category grown too big and need splitting"). Checkbox closed; standing
-  dimension now.* For each artifact ask whether it is the
-  right *kind*: a "rule" that is really a procedure → skill; one that must
-  happen every time → hook; a bloated multi-tool rule → split per tool;
-  duplicated content → dedupe to one canonical source.
-- [x] **Enforce always-on intent: flag rules with no frontmatter** (LOW —
-  retrospective, PR #122). **DONE:** built it as a **meta-test**
-  (`tests/shell/test_rule_frontmatter.bats`), mirroring the skills guard
-  (`test_skill_frontmatter.bats`) rather than a `PostToolUse` hook — rules are
-  added rarely, so a CI gate suffices and costs nothing per edit. It flags any
-  `config/claude/rules/*.md` whose frontmatter has neither `paths:` nor a
-  `# No paths` comment. `rule-TEMPLATE.md` and `.claude/TESTS.md` updated to
-  match. Both `trufflehog.md` and `claude-code-auth.md` were
-  added *always-on by omission* (no `paths:` and no `# No paths` comment) — only
-  an audit caught it; now a new rule can't silently join the per-turn tier.
-- [x] **Plugins / MCP dimension.** *Folded into the `claude-audit` skill
-  (Procedure step 3 + `rules/mcp.md`: plugin/MCP inventory and cull). Checkbox
-  closed; standing dimension now.* Inventory every enabled plugin (what it
-  does/bundles, whether used); cull duplicates of the `gh` CLI / existing
-  rules+skills and unused ones; remember plugins carry context cost. MCP
-  servers here come *from* plugins (no hand-maintained `mcp.json`).
-- [x] **Build vs. adopt.** *Folded into the `claude-audit` skill (mining/
-  "Judging": score generic value, then overlap with built-ins, vendor-with-
-  `SOURCE.md` vs write-our-own). Checkbox closed; standing dimension now.* For
-  each capability weigh a maintained plugin/skill
-  against our own: adopt when good and lean (vendor-and-modify with a
-  `SOURCE.md`); write our own when the plugin is bloated/over-scoped for the
-  context it costs. Weigh context cost vs maintenance burden explicitly.
-- [x] **External validation (GitHub Apps). DONE (resolved + redirected):**
-  CodeFactor/Snyk were resolved via the `security-scan` §4 escape hatch
-  (2026-06-19), and the broader candidate sweep (Codecov, Codacy, SonarCloud,
-  OpenSSF Scorecard, …) now lives in the open "🏅 credibility signals /
-  badges" research task below — that task is the single home for the
-  outstanding work. Closing this design-dimension entry to avoid a duplicate
-  tracker; the badges task carries it forward.
-- [x] **Cross-repo follow-up routing (LOW — retrospective, PR #123). DONE:**
-  added a **Cross-repo** case to `WORKFLOW.md`'s *TODO Routing* section
-  (v1.4.0) — capture the follow-up where the originating work lives, tag it
-  with the target repo + a "migrate to its `TODO.md` when next working it"
-  trigger, and scan the parking spot for inbound items at the start of work in
-  a repo (the **github-tasks** sweep runs that check). This formalizes the
-  workaround the per-repo Snyk evals (pigify / scripturestudy-app) were parked
-  under.
-- [x] **Delegated research can over-claim — demand exact doc quotes (LOW —
-  retrospective, PRs #126/#127). DONE:** added a *Delegated research can
-  over-claim* paragraph to the `claude-audit` skill's grounding notes —
-  require an exact quote + doc URL for any feature/behaviour claim that drives
-  an action, treat unsourced specifics as unconfirmed. Twice in one session a
-  delegated research
-  agent asserted a plausible-but-false feature: a name "must not contain
-  `claude`/`anthropic`" rule (#126) and a `# Compact instructions` CLAUDE.md
-  heading (#127). Both were caught by re-verifying against primary docs before
-  acting — but only because the claims happened to be high-stakes. Sharpen the
-  `claude-audit` skill's grounding guidance: when a research agent reports a
-  **feature/behavior claim** that would drive an action (a rename, a new
-  CLAUDE.md block, wiring a hook), require an **exact quote + doc URL** and
-  treat unsourced specifics as unconfirmed. Small wording add to the skill's
-  *Check grounding* / *Verify currency* notes; not a new artifact.
-- [x] **Plugin-aware proposals (behavior rule). DONE:** added a plugin-check
-  to `CLAUDE.md`'s *Missing or Conflicting Tool Rules* and *When to Propose a
-  Skill* (consider whether a plugin already provides it / should be added —
-  adopt-vs-build per `EXTENDING.md`, `rules/mcp.md`), and extended the
-  `rule-coverage.py` reminder message with the same nudge. Bias to surfacing
-  in the moment.
-- [x] **Canonicalize protected-branch detection in `git.md` (LOW —
-  retrospective, PR #129). DONE:** promoted the concrete `gh api
-  rules/branches` / `.../protection` detection commands into `git.md` *Never
-  Work Directly on a Protected Branch* as the numbered canonical method
-  (git.md v1.11.0); `new-project.md` now references it instead of carrying its
-  own copy. The `new-project` rule/skill needed to detect
-  branch protection for a *brownfield* repo that lacks the local
-  `no-commit-to-branch` hook, so it spelled out the concrete
-  `gh api repos/{owner}/{repo}/rules/branches/<branch>` (and `.../protection`)
-  query **inline**. But the canonical home for "how to tell whether a branch
-  is protected" is `git.md` (*Protecting the Default Branch* / *Never Work
-  Directly on a Protected Branch*), which lists the *sources* (ruleset, local
-  hook, `.claude/` docs, default-when-in-doubt) but **not** the concrete API
-  command. To stop the method drifting across two files (dedupe-the-fact,
-  `code-style.md` Rule of Three), promote the `gh api` detection command into
-  `git.md` as the canonical method and have `new-project` reference it instead
-  of carrying its own copy. Small edit; not a new artifact.
 - [ ] **Prose-wrap check for agent-config Markdown (LOW — retrospective, PR
   #130).** The 78-col prose-wrap convention (`CONVENTIONS.md`) is enforced
   only by eye — markdownlint's `line_length` is set to 200 (tables/code),
@@ -133,57 +27,24 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
 
 ## Plugin-audit follow-ups (from the 2026-06-10/-11 passes)
 
-- [x] **Resolved the `pydantic-ai` name-conflation (2026-06-11).** Two things
-  were conflated: (a) `pydantic_ai`, the **agent framework**
-  (provider-prefixed model strings, `@agent.tool`, `TestModel`, Logfire), vs
-  (b) **AI-assisted work on pydantic** validation models, what pigify-style
-  FastAPI apps need. Split accordingly:
-  - [x] **(b) pydantic-validation / FastAPI / SQLAlchemy patterns** — DONE.
-    Built the global on-demand skills `fastapi-patterns` +
-    `sqlalchemy-patterns` (adapted from the *Idea sources* repos), cross-linked
-    from the slim `fastapi.md` / `sqlalchemy.md` / `alembic.md` rules.
-  - [ ] **(a) `pydantic_ai` agent-framework rule** — deferred; write a
-    path-scoped `rules/pydantic-ai.md` only **when actually building agents
-    with `pydantic_ai`**. Source: `pydantic/skills` `building-pydantic-ai-agents`
-    (+ Logfire). Idea-level until then.
-- [x] **Mined the idea-source repos for non-skill borrowings (2026-06-11).**
-  Verdict: **8 of 9 already covered — only ADR was additive** (a good signal
-  the config is in shape). Applied the "layer the generic over the specific"
-  lens (`EXTENDING.md`); decisions in ADR-0001/0002.
-  - [x] `lint-explain` / `typecheck-explain` — **SKIP**; the no-suppression
-    policy already lives in `ruff.md` (Suppression: justified per-code `# noqa`)
-    + `python.md` (`# type: ignore` with reason). Interactive "explain" is
-    normal agent capability.
-  - [x] `test-first` (TDD red-phase) / `clean-review` — **SKIP**; `testing.md`
-    sets the test bar; `code-style.md` + `qa.md` Code-style audit + `/simplify`
-    cover smells/SOLID.
-  - [x] `tech-lead` `adr` — **ADOPTED** as the generic `adr` skill (house
-    Nygard template; skills-over-commands per ADR-0001). Idea-level only — not
-    cited as a tracked source.
-  - [x] `fastapi` `migration-reviewer` / `migrate-check` — **SKIP**; the whole
-    checklist is already prose in `alembic.md` ("always review the
-    autogenerated script") + the `sqlalchemy-patterns` skill.
-  - [x] `claude-tools` `database-optimizer` / `api-documenter` — **SKIP** (the
-    layering demonstrator): SQLAlchemy half in `sqlalchemy-patterns`, generic
-    "measure-first" in `qa.md`; FastAPI auto-OpenAPI via the `response_model`
-    rule covers api-docs. Looked, correctly declined to vendor the agents.
-- [x] **`git-worktree-workflow` reconcile-gone-branches** — guarded bulk-remove
-  of `[gone]` branches + worktrees (confirm each, skip dirty, no blanket
-  `--force` / `fetch --prune`). Done — Operation 7 (skill v1.1.0).
-- [x] **Decided: dropped `ralph-loop`** (2026-06-18) — not trialed; built-in
-  `/loop` covers autonomous iteration. See Decisions log. ICEBOX preserves the
-  exit-blocking technique as a revisit, *via `/loop`* rather than new
-  machinery.
-- [x] **Evaluated `pr-review-toolkit`, `feature-dev`, `security-guidance`** —
-  all dropped (redundant with built-ins / `qa.md` / `security-scan`). Vendor
-  bits surfaced by the repo that needs them — don't build proactively:
+- [ ] **`pydantic_ai` agent-framework rule (deferred).** Write a path-scoped
+  `rules/pydantic-ai.md` only **when actually building agents with
+  `pydantic_ai`** — the agent framework (provider-prefixed model strings,
+  `@agent.tool`, `TestModel`, Logfire); distinct from pydantic *validation*
+  work, which the `fastapi-patterns` / `sqlalchemy-patterns` skills already
+  cover. Source: `pydantic/skills` `building-pydantic-ai-agents` (+ Logfire).
+  Idea-level until then.
+- [ ] **Vendor-when-needed plugin bits.** From the dropped `pr-review-toolkit`
+  / `feature-dev` / `security-guidance` evaluation (all redundant with
+  built-ins / `qa.md` / `security-scan`) — surface these only when a repo
+  actually needs them, don't build proactively:
   - [ ] vendor the unique pr-review lenses (silent-failure, comment-rot,
     type-design) when a repo's review needs them — or fold into `qa.md`'s
     code-style audit.
   - [ ] vendor `/feature-dev` as a **skill** driving built-in Explore/Plan
     agents when a repo wants the phased flow.
-  - [ ] add a tiny path-only GH-Actions-injection hook only if a repo needs it
-    (likely unnecessary — `github-actions.md` covers awareness).
+  - [ ] add a tiny path-only GH-Actions-injection hook only if a repo needs
+    it (likely unnecessary — `github-actions.md` covers awareness).
 
 ## Skill ideas & future categories (not from mining)
 
@@ -206,15 +67,10 @@ continuity; mined-repo provenance in [`idea-sources.md`](idea-sources.md).
 - [ ] **`categorize-issue` skill** — triage a `gh` issue: suggest
   labels/priority/estimate from codebase context and fold it into the repo's
   TODO triage queue (the `gh.md` *Issues & triage* workflow). Category: `gh`.
-- [ ] **Future top-level categories** (per the "fold into existing categories,
-  new one only if it doesn't fit" guidance):
-  - [x] **`documentation`** — **opened** 2026-06-11: `rules/documentation.md`
-    (the doc bar + form stance) + the `write-documentation` skill. Doc tooling
-    (`markdownlint.md`) and the `adr` skill compose in. See *Decisions log*.
-  - [x] **`troubleshooting`** — **opened** 2026-06-11: a *thin* always-on
-    `rules/troubleshooting.md` (the debugging bar) + the `debug-assistant`
-    skill (the procedure). Not a qa dimension — a peer category. See
-    *Decisions log*.
+- [ ] **Future top-level categories.** Fold a new capability into an existing
+  category (`code-style` / `testing` / `qa` / `gh` / `git`); open a new
+  top-level category only when it genuinely doesn't fit. (`documentation` and
+  `troubleshooting` were opened 2026-06-11 — see the decisions log.)
 
 ## Repo-config follow-ups (migrated from TODO.md, 2026-06-19)
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,32 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Adopted prune-at-merge for the audit BACKLOG, fixed the
+  doc/enforcement gap, and cleaned out 25 stale `[x]` items (PR #131).** The
+  user noticed completed items weren't removed at merge and asked whether the
+  skill/rule covers the backlog. **Diagnosis:** two of three sources already
+  said *prune* — the `claude-audit` Finalize step ("remove the item from
+  `audit/BACKLOG.md`") and ship-pr Step 4.5 ("any equivalent planning list") —
+  but (a) the `merge-finalization.py` hook only scanned `TODO.md`/`ROADMAP.md`
+  (BACKLOG not in `PLANNING_DOCS`), so nothing enforced it; (b) the BACKLOG
+  **header said "retained for continuity,"** contradicting the prune rule; and
+  (c) I leaned on that header and skipped it in #130 — inconsistent with #129,
+  where I *did* prune. **Decision (user chose prune-at-merge):** BACKLOG
+  behaves like `TODO.md` — done items removed at merge, the record kept in
+  this log / ADRs / `mining-census.md`. **Cleanup:** rewrote the header;
+  deleted the 25 `[x]` items; because the hook can't tell a done item from a
+  *parent of open children*, **promoted** the open children to standalone
+  `[ ]` items (the deferred `pydantic_ai` agent-framework rule; the
+  pr-review-toolkit / feature-dev / GH-Actions vendor-when-needed bits) and
+  reworded the *Future top-level categories* item so it doesn't dangle a
+  now-empty list — leaving **zero `[x]`** so the hook enforcement is coherent.
+  **Enforcement:** added a generic `merge-finalization-docs:` mechanism in the
+  hook (a repo declares extra planning docs in its opt-in `.claude/` docs,
+  keeping repo-specific paths out of the global hook); dotfiles `WORKFLOW.md`
+  (v1.5.0) declares `config/claude/audit/BACKLOG.md`; ship-pr Step 4.5
+  (v1.9.4) names it explicitly; `tests/python/test_merge_finalization.py`
+  covers the new path (block on a declared doc with `[x]`, allow when clean,
+  ignore when undeclared).
 - 2026-06-19 — **Cleared the *Audit dimensions / design* backlog section
   (batch, PR #130).** Took the section to zero open items. The four
   design-checklist items (context-load tiering, recategorize/split/merge,

--- a/config/claude/hooks/merge-finalization.py
+++ b/config/claude/hooks/merge-finalization.py
@@ -21,6 +21,11 @@ its ``.claude/WORKFLOW.md`` or ``.claude/CONVENTIONS.md``:
     **allow**, injecting the finalization checklist as a reminder so the
     not-statically-checkable step (refresh the changelog) isn't forgotten.
 
+A repo can extend the pruned set beyond the generic defaults (TODO.md /
+ROADMAP.md / docs/ROADMAP.md) with a ``merge-finalization-docs:`` line in the
+same opt-in docs — keeping repo-specific paths out of this global hook (e.g.
+the dotfiles repo adds its audit ``BACKLOG.md``).
+
 Fail-safe: any error exits 0 silently so a hook bug can never block a merge.
 """
 
@@ -47,6 +52,13 @@ PLANNING_DOCS = ("TODO.md", "ROADMAP.md", "docs/ROADMAP.md", "docs/TODO.md")
 ENFORCE_MARKER = "merge-finalization: enforce"
 OPT_IN_DOCS = (".claude/WORKFLOW.md", ".claude/CONVENTIONS.md")
 
+# A repo may extend the pruned planning docs beyond the generic defaults with a
+# line in its opt-in docs (keeps repo-specific paths out of this global hook):
+#   merge-finalization-docs: config/claude/audit/BACKLOG.md, docs/OTHER.md
+EXTRA_DOCS_RE = re.compile(
+  r"^[ \t]*merge-finalization-docs:[ \t]*(.+?)[ \t]*$", re.M
+)
+
 CHECKLIST = (
   "Merge-time finalization (ship-pr Step 4.5 / repo WORKFLOW.md), docs-only:\n"
   " - Prune completed items from TODO.md / ROADMAP.md per the repo's "
@@ -69,11 +81,27 @@ def _enforces(repo: Path) -> bool:
   return False
 
 
+def _extra_docs(repo: Path) -> tuple[str, ...]:
+  """Repo-declared extra planning docs (comma-separated, repo-relative) from a
+  `merge-finalization-docs:` line in the opt-in docs. Empty if none."""
+  for rel in OPT_IN_DOCS:
+    doc = repo / rel
+    try:
+      if not doc.is_file():
+        continue
+      m = EXTRA_DOCS_RE.search(doc.read_text(encoding="utf-8"))
+      if m:
+        return tuple(p.strip() for p in m.group(1).split(",") if p.strip())
+    except Exception:
+      continue
+  return ()
+
+
 def _done_items(repo: Path) -> list[str]:
   """Planning docs under `repo` that still carry completed `- [x]` items,
   reported as "file (N)"."""
   hits: list[str] = []
-  for rel in PLANNING_DOCS:
+  for rel in PLANNING_DOCS + _extra_docs(repo):
     doc = repo / rel
     try:
       if not doc.is_file():

--- a/config/claude/skills/ship-pr/SKILL.md
+++ b/config/claude/skills/ship-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Commit a finished feature branch, push it, and open a pull request,
 
 # Ship PR
 
-**Version:** v1.9.3
+**Version:** v1.9.4
 
 Take a finished branch through the standard landing sequence: **QA check** →
 commit → push → open PR → watch CI → (approval) merge →
@@ -138,11 +138,15 @@ Once CI is green and the branch is judged ready to merge, perform the
 **merge-time documentation finalization** — and **only** this. No code lands
 at merge time; the only changes here are documentation.
 
-- **Remove the completed items** from `TODO.md` and `ROADMAP.md` (and any
-  equivalent planning list). Delete them outright — do **not** leave them
+- **Remove the completed items** from `TODO.md` and `ROADMAP.md` (and **any
+  equivalent planning list** — e.g. this repo's agent-config audit backlog,
+  `config/claude/audit/BACKLOG.md`, whose completion record lives in
+  `audit/decisions-log.md`). Delete them outright — do **not** leave them
   marked `[x]`. Do this **now**, not earlier: an item is pruned exactly when
   the PR that completes it has gone **green**, so the planning docs always
-  track only open work and nothing is removed for a PR that never lands.
+  track only open work and nothing is removed for a PR that never lands. The
+  merge-finalization hook enforces this for any planning doc a repo declares
+  (the generic defaults plus any `merge-finalization-docs:` extras).
 - **Changelog management** — regenerate / write the changelog per the repo (a
   generated changelog mutates the tree, so it is committed here, never in CI;
   see `qa.md` dim 13 and the repo's QA doc), plus any related doc updates.

--- a/tests/python/test_merge_finalization.py
+++ b/tests/python/test_merge_finalization.py
@@ -1,0 +1,90 @@
+"""Tests for the extra-planning-docs mechanism of the merge-finalization hook.
+
+Runs the hook as a subprocess against a throwaway repo with a crafted
+PreToolUse merge event. Covers the per-repo `merge-finalization-docs:`
+declaration that lets a repo enforce the prune on planning docs beyond the
+generic defaults (e.g. the audit BACKLOG.md). See the hook under
+config/claude/hooks/.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "config" / "claude" / "hooks" / "merge-finalization.py"
+
+
+def _make_repo(
+  tmp_path: Path,
+  *,
+  declare_extra: bool = True,
+  extra_has_done: bool = True,
+) -> Path:
+  """A repo opted in to merge-finalization, optionally declaring an extra
+  planning doc, whose extra doc optionally carries a completed `- [x]` item."""
+  repo = tmp_path / "repo"
+  (repo / ".claude").mkdir(parents=True)
+
+  wf = "# Workflow\n\nmerge-finalization: enforce\n"
+  if declare_extra:
+    wf += "\nmerge-finalization-docs: config/audit/BACKLOG.md\n"
+  (repo / ".claude" / "WORKFLOW.md").write_text(wf, encoding="utf-8")
+
+  backlog_dir = repo / "config" / "audit"
+  backlog_dir.mkdir(parents=True)
+  body = "- [ ] still open\n"
+  if extra_has_done:
+    body += "- [x] completed but not pruned\n"
+  (backlog_dir / "BACKLOG.md").write_text(body, encoding="utf-8")
+
+  return repo
+
+
+def _run(repo: Path, command: str = "gh pr merge 1 --squash") -> dict:
+  event = {
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": command
+    },
+    "cwd": str(repo),
+  }
+  env = {k: v for k, v in os.environ.items() if k != "CLAUDE_PROJECT_DIR"}
+  res = subprocess.run(
+    ["python3", str(HOOK)],
+    input=json.dumps(event),
+    capture_output=True,
+    text=True,
+    env=env,
+  )
+  assert res.returncode == 0, res.stderr
+  out = res.stdout.strip()
+  return json.loads(out) if out else {}
+
+
+def _hook_out(out: dict) -> dict:
+  return out.get("hookSpecificOutput", {})
+
+
+def test_blocks_merge_when_declared_extra_doc_has_done_items(tmp_path):
+  out = _hook_out(_run(_make_repo(tmp_path)))
+  assert out.get("permissionDecision") == "deny"
+  assert "BACKLOG.md" in out.get("permissionDecisionReason", "")
+
+
+def test_allows_merge_when_declared_extra_doc_is_clean(tmp_path):
+  out = _hook_out(_run(_make_repo(tmp_path, extra_has_done=False)))
+  assert "permissionDecision" not in out    # reminder-only, not a block
+  assert "additionalContext" in out
+
+
+def test_extra_doc_ignored_without_declaration(tmp_path):
+  # The extra doc still carries a [x], but it is not declared, so the hook
+  # checks only the generic defaults (absent here) and allows.
+  out = _hook_out(_run(_make_repo(tmp_path, declare_extra=False)))
+  assert "permissionDecision" not in out
+
+
+def test_non_merge_command_is_ignored(tmp_path):
+  assert _run(_make_repo(tmp_path), command="git status") == {}


### PR DESCRIPTION
## Summary
Completed `[x]` items were accumulating in the agent-config audit backlog.
ship-pr Step 4.5 and the claude-audit Finalize step both say to prune it, but
the merge-finalization hook only covered `TODO.md`/`ROADMAP.md` and the BACKLOG
header said "retained for continuity" — a contradiction that let the prune be
skipped. Resolve to **prune-at-merge** (the durable record lives in
`decisions-log.md`) and enforce it.

- **BACKLOG.md:** rewrite the header (open work only); delete all **25 stale
  `[x]` items**. Because the hook can't distinguish a done item from a done
  *parent of open children*, promote the open children to standalone `[ ]`
  items (the deferred `pydantic_ai` rule; the pr-review / feature-dev /
  gh-actions vendor-when-needed bits) and reword the Future-categories item —
  leaving **zero `[x]`** so enforcement is coherent.
- **merge-finalization.py:** add a generic `merge-finalization-docs:`
  mechanism so a repo declares extra planning docs in its opt-in `.claude/`
  docs — keeping the dotfiles-specific path out of the global hook.
- **WORKFLOW.md (v1.5.0):** declare `config/claude/audit/BACKLOG.md` as an
  enforced planning doc.
- **ship-pr (v1.9.4):** Step 4.5 names the audit backlog explicitly.
- **decisions-log.md:** records the diagnosis, decision, cleanup, enforcement.

## Test plan
- [ ] `pre-commit run --all-files` green.
- [ ] `pytest tests/python` green (incl. new `test_merge_finalization.py`, 4
      cases: block on a declared doc with `[x]`, allow when clean, ignore when
      undeclared, ignore non-merge).
- [ ] `bats tests/shell/test_*.bats` green.
- [ ] BACKLOG.md now has zero `[x]`; the hook will block any future merge that
      leaves one.