### PR TITLE
docs(audit): make BACKLOG a pure todo; add ICEBOX register

### DIFF
--- a/config/claude/SETUP-AUDIT.md
+++ b/config/claude/SETUP-AUDIT.md
@@ -22,11 +22,14 @@ The living record lives in sibling files under [`audit/`](audit/):
 
 - [`decisions-log.md`](audit/decisions-log.md) — chronological decisions (the
   "why"), append-only.
-- [`BACKLOG.md`](audit/BACKLOG.md) — open audit follow-ups; a todo file,
-  separate from the repo's own `TODO.md`.
+- [`BACKLOG.md`](audit/BACKLOG.md) — open, **will-do** audit follow-ups; a
+  todo file, separate from the repo's own `TODO.md`.
+- [`ICEBOX.md`](audit/ICEBOX.md) — our **deferred "not now"** decisions
+  (revisit on a trigger or on request); scanned each audit run.
 - [`idea-sources.md`](audit/idea-sources.md) — repos mined for ideas.
 - [`mining-census.md`](audit/mining-census.md) — full per-item
-  ADOPT/CANDIDATE/SKIP disposition of mined repos.
+  ADOPT/CANDIDATE/SKIP disposition of mined repos, plus the `SKIP-until`
+  **Watch list** (mined deferrals, re-promoted on a fired trigger).
 
 ## Baseline — 2026-06-19
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -6,11 +6,17 @@ to avoid confusion. Includes both audit-process follow-ups and config tasks
 migrated from `TODO.md`. **Routing:** a config task lands here; a dotfiles task
 in `TODO.md`; a mixed task is split with a cross-reference unless its parts are
 merely coupled (see `WORKFLOW.md` → *TODO routing*). Read when running
-`/claude-audit`. Audit-only (not context-loaded). Completed items are
-recorded in [`decisions-log.md`](decisions-log.md) (the durable record) and
-**pruned from here once the PR that completes them goes green** — this file
-holds only *open* work. Mined-repo provenance lives in
-[`idea-sources.md`](idea-sources.md) / [`mining-census.md`](mining-census.md).
+`/claude-audit`. Audit-only (not context-loaded). This file holds only
+**actionable, will-do** work — *not* deferred or trigger-gated items:
+
+- **Completed** items are recorded in [`decisions-log.md`](decisions-log.md)
+  (the durable record) and **pruned from here once the PR that completes them
+  goes green**.
+- **Deferred / "not now"** decisions of our own go to
+  [`ICEBOX.md`](ICEBOX.md) (revisit on a trigger or on request) — not here.
+- **Mined external** candidates deferred `SKIP-until <trigger>` live on the
+  [`mining-census.md`](mining-census.md) *Watch list*; mined-repo provenance
+  is in [`idea-sources.md`](idea-sources.md) / `mining-census.md`.
 
 ## Audit dimensions / design
 
@@ -306,11 +312,6 @@ standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
   native one, it would **duplicate** output — not what we want, so skip.
   Ground the answer in the docs + a quick trial (fire a background subagent and
   watch the row) before wiring anything.
-- [ ] **Heavier candidates** (transcript-driven — defer): the tools/agents
-  lines and todos `(2/5)`. *(2026-06-19: project path, session duration, output
-  speed, and token totals were skipped by the user; the context progress-bar
-  glyph is `SKIP-until` on the census watch list — revisit if the plain `X%`
-  stops being enough.)*
 - [ ] **Keybinding cheat-sheet statusline line** (research → build). The user
   wants a second statusline line *below* the current one that displays the
   prompt-input shortcuts worth memorizing. Two parts:
@@ -330,25 +331,6 @@ standard; leads the line). `jarrodwatts/claude-hud` was mined — full matrix in
      the line could show NORMAL keys vs INSERT keys per the active mode).
      Target: `config/claude/bin/statusline.sh`. Keep it terse — a cheat-sheet,
      not a manual; weigh the vertical space it costs against its value.
-
-**`ICEBOX:` cannot hide the native below-prompt indicator lines** — the
-**auto-accept / permission-mode** indicator (`⏵⏵ auto mode on`), the
-**running-subagent / task** line, and the **`· PR #N`** badge have **no
-off-switch** (settings, env, or flag) as of 2026-06-19 — verified against the
-Claude Code docs and by re-examining `claude-hud` (which sets no suppression
-key, can't even read the permission mode, and only stacks a transcript-parsed
-agents line *on top of* the native one). The only documented `statusLine` hide
-field is `hideVimModeIndicator`; the full set of `statusLine` sub-fields is
-`type` / `command` / `padding` / `refreshInterval` / `hideVimModeIndicator` /
-`subagentStatusLine` (the last **formats** subagent rows — it does **not** hide
-the native line). Consequence: reconstructing any of these (PR#, permission
-mode, agents) in our own statusline would only **duplicate** the un-hideable
-native badge, so it isn't worth it — the permission mode and PR# are both in
-the data (permission mode in the **transcript** `permission-mode`/`mode`
-entries; `.pr.number` in the **stdin** JSON), they just can't replace the
-native display. Open upstream requests: anthropics/claude-code **#27916**,
-**#48246**. Revisit if either lands a hide option; until then, only the vim
-indicator was controllable (and is done).
 
 ### New rule/skill candidates
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -25,27 +25,6 @@ holds only *open* work. Mined-repo provenance lives in
   **Risk:** false positives on exactly those exemptions — evaluate whether a
   reliable check is even feasible before building; it may not be worth it.
 
-## Plugin-audit follow-ups (from the 2026-06-10/-11 passes)
-
-- [ ] **`pydantic_ai` agent-framework rule (deferred).** Write a path-scoped
-  `rules/pydantic-ai.md` only **when actually building agents with
-  `pydantic_ai`** — the agent framework (provider-prefixed model strings,
-  `@agent.tool`, `TestModel`, Logfire); distinct from pydantic *validation*
-  work, which the `fastapi-patterns` / `sqlalchemy-patterns` skills already
-  cover. Source: `pydantic/skills` `building-pydantic-ai-agents` (+ Logfire).
-  Idea-level until then.
-- [ ] **Vendor-when-needed plugin bits.** From the dropped `pr-review-toolkit`
-  / `feature-dev` / `security-guidance` evaluation (all redundant with
-  built-ins / `qa.md` / `security-scan`) — surface these only when a repo
-  actually needs them, don't build proactively:
-  - [ ] vendor the unique pr-review lenses (silent-failure, comment-rot,
-    type-design) when a repo's review needs them — or fold into `qa.md`'s
-    code-style audit.
-  - [ ] vendor `/feature-dev` as a **skill** driving built-in Explore/Plan
-    agents when a repo wants the phased flow.
-  - [ ] add a tiny path-only GH-Actions-injection hook only if a repo needs
-    it (likely unnecessary — `github-actions.md` covers awareness).
-
 ## Skill ideas & future categories (not from mining)
 
 - [ ] **Rule eval / optimization (analogous to `skill-creator`)** — `skill-

--- a/config/claude/audit/ICEBOX.md
+++ b/config/claude/audit/ICEBOX.md
@@ -1,0 +1,57 @@
+# Audit icebox
+
+Deferred Claude-agent-config decisions — **considered, "not now."** This is
+the audit-scope home for the `ICEBOX:` marker (`rules/code-style.md`): a
+deferred / maybe-someday decision to revisit on a **trigger** or **on
+request**, for cases that have no single code location to pin an in-code
+`ICEBOX:` comment to.
+
+**This is not a todo file.** Items here are *not* open work — the
+[`BACKLOG.md`](BACKLOG.md) holds will-do tasks. The boundary with the other
+"not now" homes:
+
+- **Mined external** candidate deferred `SKIP-until <trigger>` →
+  [`mining-census.md`](mining-census.md) *Watch list* (a terse trigger→adopt
+  table tied to the survey record). **Not here.**
+- **Our own** deferred finding / decision, with its context → **here.**
+- **Will do it** → `BACKLOG.md`.
+
+Each entry states its **revisit condition**: a concrete trigger (an upstream
+issue landing, a feature becoming needed) or "**on request only**" (the
+classic `ICEBOX:` semantics). `claude-audit` scans this file each run —
+alongside the mining files and the Watch list — to surface any fired trigger;
+otherwise it leaves these alone.
+
+## Statusline: the native below-prompt indicator lines can't be hidden
+
+**Revisit if** anthropics/claude-code **#27916** or **#48246** lands a hide
+option for the native indicators.
+
+The **auto-accept / permission-mode** indicator (`⏵⏵ auto mode on`), the
+**running-subagent / task** line, and the **`· PR #N`** badge have **no
+off-switch** (settings, env, or flag) as of 2026-06-19 — verified against the
+Claude Code docs and by re-examining `claude-hud` (which sets no suppression
+key, can't even read the permission mode, and only stacks a transcript-parsed
+agents line *on top of* the native one). The only documented `statusLine` hide
+field is `hideVimModeIndicator`; the full set of `statusLine` sub-fields is
+`type` / `command` / `padding` / `refreshInterval` / `hideVimModeIndicator` /
+`subagentStatusLine` (the last **formats** subagent rows — it does **not**
+hide the native line). Consequence: reconstructing any of these (PR#,
+permission mode, agents) in our own statusline would only **duplicate** the
+un-hideable native badge, so it isn't worth it — the permission mode and PR#
+are both in the data (permission mode in the **transcript**
+`permission-mode`/`mode` entries; `.pr.number` in the **stdin** JSON), they
+just can't replace the native display. Until an upstream hide option lands,
+only the vim indicator was controllable (and is done).
+
+## Statusline: heavier / transcript-driven candidates
+
+**Revisit if** the plain `X%` context gauge stops being enough, or a
+transcript-driven line becomes wanted.
+
+The heavier statusline candidates — the **tools/agents lines** and a **todos
+`(2/5)`** counter — are transcript-driven and deferred. *(2026-06-19: project
+path, session duration, output speed, and token totals were skipped by the
+user; the context progress-bar glyph is the `SKIP-until` item on the
+[`mining-census.md`](mining-census.md) Watch list — revisit there if the plain
+`X%` stops being enough.)*

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,23 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Added `audit/ICEBOX.md`; made BACKLOG a pure will-do todo
+  (PR #132).** The user wanted the backlog treated strictly as a todo — icebox
+  / wait-until-needed entries don't belong in it. **Structure (user chose "two
+  homes by shape"):** three non-overlapping registers — `BACKLOG.md`
+  (actionable will-do), `ICEBOX.md` (**our own** deferred "not now" decisions,
+  free-form, each with a revisit condition: a trigger or "on request"), and
+  the `mining-census.md` Watch list (**mined external** `SKIP-until`
+  candidates, a
+  terse trigger→adopt table). `ICEBOX.md` is the audit-scope home for the
+  in-code `ICEBOX:` marker (`code-style.md`) when a decision has no code
+  location to pin a comment to. **Moved** out of BACKLOG into ICEBOX.md: the
+  "native statusline indicators can't be hidden" finding (revisit if
+  anthropics/claude-code #27916 / #48246 lands a hide option) and the
+  heavier/transcript-driven statusline candidates (revisit if plain `X%` stops
+  being enough). Wired it in: `claude-audit` skill scans `ICEBOX.md` + the
+  Watch list for fired triggers each run and routes follow-ups by kind;
+  `SETUP-AUDIT.md` and the BACKLOG header index the boundary.
 - 2026-06-19 — **Re-homed the "Plugin-audit follow-ups" items to the
   mining-census Watch list; removed the BACKLOG section (PR #132).** After
   the #131 prune, that section held only **trigger-gated `SKIP-until`** items

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,8 +6,20 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
-- 2026-06-19 — **Adopted prune-at-merge for the audit BACKLOG, fixed the
-  doc/enforcement gap, and cleaned out 25 stale `[x]` items (PR #131).** The
+- 2026-06-19 — **Re-homed the "Plugin-audit follow-ups" items to the
+  mining-census Watch list; removed the BACKLOG section (PR #132).** After
+  the #131 prune, that section held only **trigger-gated `SKIP-until`** items
+  (do nothing until a repo needs them / until we build `pydantic_ai` agents) —
+  not actionable work, so they read as confusing open tasks. Worse, the
+  `pydantic_ai` deferred-rule item **duplicated** the existing Watch-list row,
+  and the claude-audit skill's own rule says *every `SKIP-until` lives on the
+  census Watch list*. **Fix:** deleted the BACKLOG `pydantic_ai` item (already
+  on the Watch list) and added the three vendor-when-needed items
+  (`pr-review-toolkit` lenses, `feature-dev` phased flow, a GH-Actions
+  PreToolUse hook) as Watch-list rows with triggers — their drop rationale
+  already lives in this log (2026-06-10). Removed the now-empty "Plugin-audit
+  follow-ups" section. Net: BACKLOG holds only actionable open work;
+  trigger-gated items sit where the re-promote-on-trigger mechanism is.
   user noticed completed items weren't removed at merge and asked whether the
   skill/rule covers the backlog. **Diagnosis:** two of three sources already
   said *prune* — the `claude-audit` Finalize step ("remove the item from

--- a/config/claude/audit/mining-census.md
+++ b/config/claude/audit/mining-census.md
@@ -50,6 +50,9 @@ new dependency or tool; the audit checks it each run.
 | **A new language** (Go/Rust/TS…) in a repo | the matching `claude-tools` language-expert agent (Tier-3) |
 | **A browser UI / e2e need** (Playwright) | `claude-tools` `frontend-qa-tester` → the qa End-to-end (dim 8) tool |
 | **Wanting a richer context gauge** (plain `X%` no longer enough) | `claude-hud` context progress-bar glyph → the Claude statusline |
+| **A code-review lens `qa.md` lacks** (silent-failure / comment-rot / type-design) | `pr-review-toolkit` lenses → vendor as a skill, or fold into the qa code-style audit (drop rationale: decisions log 2026-06-10) |
+| **A phased feature-dev flow wanted** (Explore→Plan→build in a repo) | `feature-dev` → vendor `/feature-dev` as a skill driving built-in Explore/Plan agents (drop rationale: decisions log 2026-06-10) |
+| **A GH-Actions-injection guard needed** (beyond `github-actions.md` awareness) | a tiny path-only GH-Actions PreToolUse hook — likely unnecessary (drop rationale: decisions log 2026-06-10) |
 
 (Tier-3 "build on first use" items are already watch-like by definition; listed
 here so there's one place to scan.)

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -58,8 +58,10 @@ repo** for global changes — but **only audit-relevant files**:
 This procedure **is** the canonical methodology (it used to live in
 `SETUP-AUDIT.md`'s "How to run"; that file is now only the record's index). The
 living record is in `config/claude/audit/` — `decisions-log.md` (the "why"),
-`BACKLOG.md` (open follow-ups), `idea-sources.md` (mined repos) — indexed by
-`SETUP-AUDIT.md`. In short:
+`BACKLOG.md` (open *will-do* follow-ups), `ICEBOX.md` (our deferred "not now"
+decisions — revisit on a trigger or on request), `mining-census.md`
+(mined-item dispositions + the `SKIP-until` Watch list), `idea-sources.md`
+(mined repos) — indexed by `SETUP-AUDIT.md`. In short:
 
 1. **Measure first** — `/context` for the live baseline, then a **read-only
    inventory agent** (rules + sizes, MCP tool counts, plugins, hooks) so the
@@ -83,9 +85,14 @@ living record is in `config/claude/audit/` — `decisions-log.md` (the "why"),
    global → a dotfiles branch (audit files only) → PR; local → in this repo as
    needed.
 5. **Record** decisions in `audit/decisions-log.md` (global) and surface
-   per-repo findings. Convert audit-only "evaluate later" items into
-   `audit/BACKLOG.md`; route repo-specific follow-ups to that repo's `TODO.md`,
-   surfaced by the repo that needs them.
+   per-repo findings. Route follow-ups **by kind**: **will-do** →
+   `audit/BACKLOG.md`; **deferred / "not now" (ours)** → `audit/ICEBOX.md`
+   with a revisit condition (a trigger, or "on request"); **mined
+   `SKIP-until`** →
+   the `mining-census.md` Watch list. Repo-specific follow-ups go to that
+   repo's `TODO.md`, surfaced by the repo that needs them. **Each run, scan
+   `ICEBOX.md` and the Watch list for fired triggers** and re-promote what a
+   trigger unlocks into `BACKLOG.md`.
 
 ## Working the backlog
 


### PR DESCRIPTION
## Summary
Treat the agent-config audit backlog strictly as a todo: deferred and
trigger-gated entries get their own homes, so `BACKLOG.md` holds only
actionable, will-do work.

Three non-overlapping registers (boundary by *shape*):
- **`BACKLOG.md`** — actionable will-do work.
- **`ICEBOX.md`** *(new)* — our own deferred "not now" findings/decisions,
  each with a revisit condition (a trigger or "on request"). The audit-scope
  home for the in-code `ICEBOX:` marker (`code-style.md`) when a decision has
  no code location to pin a comment to.
- **`mining-census.md` Watch list** — mined external `SKIP-until` candidates.

Changes:
- Re-home the (post-prune) "Plugin-audit follow-ups" items: the duplicate
  `pydantic_ai` deferral (already on the Watch list) is dropped, and the 3
  vendor-when-needed items become Watch-list rows; the empty section is
  removed.
- Add `audit/ICEBOX.md` and move the two icebox blocks out of BACKLOG (the
  "native statusline indicators can't be hidden" finding; the
  heavier/transcript-driven statusline candidates).
- Wire it in: `claude-audit` scans `ICEBOX.md` + the Watch list for fired
  triggers each run and routes follow-ups by kind; BACKLOG header +
  `SETUP-AUDIT.md` index the boundary.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] `bats tests/shell/test_*.bats` + `pytest tests/python` green (no code
      changed; docs-only).
- [ ] BACKLOG.md has zero `[x]` and zero icebox content; the three registers
      are cross-referenced.