### PR TITLE
docs(extending): fold prior-art sourcing into EXTENDING.md

### DIFF
--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -1,6 +1,6 @@
 # Claude Code Extension Primitives
 
-**Version:** v1.0.0
+**Version:** v1.1.0
 
 A reference for the building blocks used to customize Claude Code — what
 each one is and when to reach for it. They are **not** interchangeable;
@@ -25,14 +25,24 @@ Claude Code itself, not any one repo.
 
 ## Grounding & sourcing (author from docs, not memory)
 
-Before authoring **any** primitive below — and when editing one — two
+Before authoring **any** primitive below — and when editing one — three
 requirements:
 
 1. **Check it doesn't already exist.** Search `config/claude/` (and the
    built-in skills/commands) for a rule/skill/hook that already covers this.
    Authoring a duplicate on the false premise that none existed is a real
    past failure mode.
-2. **Ground the content in authoritative sources where they exist** — the
+2. **Prefer adapting prior art to authoring from scratch.** Before writing a
+   new rule/skill, check known sources for an existing implementation to
+   **vendor-and-adapt** (audit it to fit; keep a `SOURCE.md`, ADR-0002)
+   rather than build blind — a GitHub repo/topic search, the skill
+   aggregators (`VoltAgent/awesome-agent-skills`,
+   <https://officialskills.sh/>), and the running
+   [`audit/idea-sources.md`](audit/idea-sources.md) registry. This is the
+   reactive, at-authoring counterpart to `claude-audit`'s *Mining repos for
+   ideas*; a vendored artifact then needs keeping current with upstream (the
+   dotfiles `TODO.md` *Vendored file / skill update checker*).
+3. **Ground the content in authoritative sources where they exist** — the
    tool/library/API's **official documentation**, its **man page**
    (`man <tool>`, `<tool> --help`), or **local package docs**
    (`/usr/share/doc/<pkg>`) — **not memory**, which goes stale. (Context7, if

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -206,15 +206,6 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
   per-language rules files extend. Decide structure: one general
   best-practices doc + per-language extensions, vs. keeping `code-style.md`
   as the shared base that the language rules reference.
-- [ ] When creating/modifying a rule or skill, check known sources for an
-  existing implementation to adapt (vendor with a `SOURCE.md` and audit to
-  fit) rather than authoring from scratch:
-  - GitHub (search repos/topics)
-  - <https://github.com/VoltAgent/awesome-agent-skills>
-  - <https://officialskills.sh/>
-  - other locations as discovered
-  Ties into the vendored file/skill update checker (see Configuration
-  Enhancements → Dependency Management).
 
 ### 🤖 Claude Code -> local OpenWebUI offload (HIGH IMPORTANCE, LOW PRIORITY)
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,18 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-19 — **Folded the "check prior art before authoring" guidance into
+  `EXTENDING.md` (PR #133).** A BACKLOG bullet ("when creating/modifying a
+  rule or skill, check known sources for an existing implementation to vendor
+  rather than author from scratch") was standing policy, not a task — so it
+  belonged
+  in the authoring doc, not the todo. Added it as a third requirement in
+  `EXTENDING.md` *Grounding & sourcing* (v1.1.0): prefer adapting prior art
+  (GitHub search, the `awesome-agent-skills` / officialskills.sh aggregators,
+  the `idea-sources.md` registry; vendor-and-adapt with a `SOURCE.md`), the
+  reactive counterpart to `claude-audit`'s *Mining repos for ideas*, with the
+  pointer to the dotfiles `TODO.md` *Vendored file / skill update checker*
+  preserved. Removed the bullet from BACKLOG.
 - 2026-06-19 — **Added `audit/ICEBOX.md`; made BACKLOG a pure will-do todo
   (PR #132).** The user wanted the backlog treated strictly as a todo — icebox
   / wait-until-needed entries don't belong in it. **Structure (user chose "two


### PR DESCRIPTION
## Summary
A BACKLOG entry — "when creating/modifying a rule or skill, check known
sources for an existing implementation to adapt rather than author from
scratch" — was standing authoring policy, not a task, so it belongs in the
authoring doc.

- **EXTENDING.md (v1.1.0):** add it as a third *Grounding & sourcing*
  requirement — prefer adapting prior art (GitHub search, the
  `awesome-agent-skills` / officialskills.sh aggregators, the
  `idea-sources.md` registry; vendor-and-adapt with a `SOURCE.md` per
  ADR-0002), the reactive counterpart to `claude-audit`'s *Mining repos for
  ideas*. The pointer to the dotfiles `TODO.md` *Vendored file / skill update
  checker* is preserved.
- Remove the bullet from `BACKLOG.md`; record the move in `decisions-log.md`.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] Docs-only — no code/tests changed.
- [ ] EXTENDING.md renders three Grounding & sourcing requirements; BACKLOG no
      longer carries the bullet.