### PR TITLE
docs(extending): codify the language & tool layering

### DIFF
--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -280,18 +280,29 @@ generic**:
   scaffolder) and/or a **patterns** skill (recipe depth). Every language
   rule/skill **references up** to `code-style.md` / this doc; the generic
   layer never lists languages.
-- **A tool** gets the same shape — `rules/<tool>.md`, plus an optional tool
-  **skill** and **patterns**, under the same "only if it makes sense / is
-  available" condition. A tool artifact **must not reference a language file**
-  (tools are language-independent). Instead the tool's **rule declares the
-  language(s) it applies to**, by name, in its *Detection* / applicability
-  section — so the coupling lives on the tool side, pointing out. A tool skill
-  may restate this but defers to the rule.
+- **A language-agnostic tool** (a formatter, linter, VCS, container runtime —
+  something that spans languages) gets the same shape — `rules/<tool>.md`,
+  plus an optional tool **skill** and **patterns**, under the same "only if it
+  makes sense / is available" condition. Such a tool **must not reference a
+  language file**; instead the tool's **rule declares the language(s) it
+  applies to**, by name, in its *Detection* / applicability section — so the
+  coupling lives on the tool side, pointing out. A tool skill may restate this
+  but defers to the rule.
+- **A single-language framework or library** (a web framework, an ORM, a test
+  framework — something whose whole identity is one language) is part of
+  **that language's stack**, *not* the language-agnostic tool axis. Its
+  rule/skill/patterns **may build on the language rule** (e.g. `fastapi.md`
+  builds on `python.md`; `react.md` on `typescript.md`) — that reference is
+  still **specific → less-generic**, never the forbidden generic → specific.
+  The "must not reference a language file" rule above is only for the
+  language-*agnostic* tools; it does not apply here.
 
-Why one-way: a generic doc that enumerates languages, or a tool that points at
-a language file, creates circular, drift-prone coupling — the generic layer
-stops being reusable, and a language/tool can't be added or removed without
-editing the other side. `/claude-audit` verifies this layering.
+Why one-way: a generic doc that enumerates languages, or a *language-agnostic*
+tool that points at a language file, creates circular, drift-prone coupling —
+the generic layer stops being reusable, and a language/tool can't be added or
+removed without editing the other side. (A single-language framework building
+on its one language is **not** that coupling — its language is its substrate,
+not a foreign dependency.) `/claude-audit` verifies this layering.
 
 ### Foreign to the repo → global, and front-loaded
 

--- a/config/claude/EXTENDING.md
+++ b/config/claude/EXTENDING.md
@@ -1,6 +1,6 @@
 # Claude Code Extension Primitives
 
-**Version:** v1.1.0
+**Version:** v1.2.0
 
 A reference for the building blocks used to customize Claude Code — what
 each one is and when to reach for it. They are **not** interchangeable;
@@ -262,6 +262,36 @@ whole**. Lift the generic intent into a thin rule/skill, and re-home (or newly
 write) the stack-specific half as a path-scoped pattern. Often the right form
 is *not* the original's — adopt the idea, then choose the kind (rule/skill)
 that fits, rather than copying the agent verbatim.
+
+### The language & tool stacks (style and tooling layering)
+
+The standing application of the two-layer model is how **style and tooling**
+are organized. Keep the generic layer free of any specific language or tool,
+and let specifics extend it — references flowing one way, **specific →
+generic**:
+
+- **Generic layer — names nothing specific.** `rules/code-style.md`
+  (always-on, language-agnostic style) and this doc carry **no** language- or
+  tool-specific content. A guideline that has to name a language or tool does
+  not belong here.
+- **A language** gets a path-scoped `rules/<language>.md` (its
+  language-specific style + idioms), and — *only where it makes sense / is
+  available* — a language **skill** (a multi-step procedure, e.g. a test
+  scaffolder) and/or a **patterns** skill (recipe depth). Every language
+  rule/skill **references up** to `code-style.md` / this doc; the generic
+  layer never lists languages.
+- **A tool** gets the same shape — `rules/<tool>.md`, plus an optional tool
+  **skill** and **patterns**, under the same "only if it makes sense / is
+  available" condition. A tool artifact **must not reference a language file**
+  (tools are language-independent). Instead the tool's **rule declares the
+  language(s) it applies to**, by name, in its *Detection* / applicability
+  section — so the coupling lives on the tool side, pointing out. A tool skill
+  may restate this but defers to the rule.
+
+Why one-way: a generic doc that enumerates languages, or a tool that points at
+a language file, creates circular, drift-prone coupling — the generic layer
+stops being reusable, and a language/tool can't be added or removed without
+editing the other side. `/claude-audit` verifies this layering.
 
 ### Foreign to the repo → global, and front-loaded
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -200,15 +200,6 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
     changelog generation should be part of a broader release skill alongside
     tagging and commitizen
   - [ ] Any other tools discovered during pre-commit or CI work
-- [x] **Codify the code-style / language / tool layering. DONE:** decided
-  **against** the "best-practices" recast (too broad; not just code) — kept
-  `code-style.md` as the generic shared layer. Codified the layering in
-  `EXTENDING.md` *The language & tool stacks* (generic names no
-  language/tool; language gets rule [+ skill] [+ patterns]; tools mirror the
-  shape but declare their applicable language(s) on the **tool rule**, never
-  linking a language file; references flow specific → generic).
-  `code-style.md` *Language-Specific Notes* now names no language and points
-  there; `claude-audit` verifies the layering.
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -214,10 +214,13 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
   *The language & tool stacks*: each language rule (`typescript.md`,
   `perl.md`, `powershell.md`, `html.md`, `css.md`, `react.md`, `bats.md`, …)
   should **reference up** to `code-style.md` / `EXTENDING.md` (several don't
-  yet); and audit **tool** rules for any link to a language *file* (replace
-  with a by-name "applies to <lang>" applicability in the tool rule).
-  Mechanical but multi-file; the `claude-audit` framework check now flags
-  these.
+  yet); and audit **language-agnostic tool** rules for any link to a language
+  *file* (replace with a by-name "applies to <lang>" applicability).
+  **Keep the framework distinction:** a single-language framework/library —
+  `fastapi.md`, `sqlalchemy.md`, `react.md`, and their `*-patterns` skills —
+  is language-axis and **may** reference its language rule; do **not** strip
+  those. Mechanical but multi-file; the `claude-audit` framework check now
+  flags real violations only.
 
 ### 🤖 Claude Code -> local OpenWebUI offload (HIGH IMPORTANCE, LOW PRIORITY)
 

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -200,12 +200,24 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
     changelog generation should be part of a broader release skill alongside
     tagging and commitizen
   - [ ] Any other tools discovered during pre-commit or CI work
-- [ ] Add a "best practices" rules/skills layer. The current
-  `rules/code-style.md` may be better recast as a general best-practices
-  document with language-specific subdocuments — i.e. a shared core that
-  per-language rules files extend. Decide structure: one general
-  best-practices doc + per-language extensions, vs. keeping `code-style.md`
-  as the shared base that the language rules reference.
+- [x] **Codify the code-style / language / tool layering. DONE:** decided
+  **against** the "best-practices" recast (too broad; not just code) — kept
+  `code-style.md` as the generic shared layer. Codified the layering in
+  `EXTENDING.md` *The language & tool stacks* (generic names no
+  language/tool; language gets rule [+ skill] [+ patterns]; tools mirror the
+  shape but declare their applicable language(s) on the **tool rule**, never
+  linking a language file; references flow specific → generic).
+  `code-style.md` *Language-Specific Notes* now names no language and points
+  there; `claude-audit` verifies the layering.
+- [ ] **Conformance sweep for the language/tool layering** (follow-up to the
+  codification above). Bring existing artifacts into line with `EXTENDING.md`
+  *The language & tool stacks*: each language rule (`typescript.md`,
+  `perl.md`, `powershell.md`, `html.md`, `css.md`, `react.md`, `bats.md`, …)
+  should **reference up** to `code-style.md` / `EXTENDING.md` (several don't
+  yet); and audit **tool** rules for any link to a language *file* (replace
+  with a by-name "applies to <lang>" applicability in the tool rule).
+  Mechanical but multi-file; the `claude-audit` framework check now flags
+  these.
 
 ### 🤖 Claude Code -> local OpenWebUI offload (HIGH IMPORTANCE, LOW PRIORITY)
 

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,27 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-20 — **Codified the code-style / language / tool layering in
+  `EXTENDING.md` (PR #134).** Worked the "best-practices layer" BACKLOG item.
+  **Naming decision:** rejected recasting `code-style.md` to a
+  "best-practices" doc — too broad (not just code) — and kept it as the
+  generic shared style layer. **Placement (user chose EXTENDING canonical):**
+  stated the policy once in a new `EXTENDING.md` *The language & tool stacks*
+  subsection under *Layer the generic over the specific*. **The policy:** the
+  generic layer (`code-style.md` / `EXTENDING.md`) names **no** specific
+  language or tool; a language gets a `rules/<lang>.md` rule, plus a **skill**
+  and **patterns** skill *only where it makes sense / is available*; a
+  **tool** mirrors that shape but **must not reference a language file** —
+  instead the
+  **tool rule** declares the language(s) it applies to, by name (its
+  Detection/applicability; a tool skill defers to the rule). References flow
+  one way, **specific → generic** (and tool → language-by-name, never tool →
+  language file), to avoid circular drift-prone coupling.
+  `code-style.md` *Language-Specific Notes* was stripped of its (stale,
+  Bash/Python-only) language list and now points to the codified policy;
+  `claude-audit` step 2 verifies the layering. Follow-up filed: a conformance
+  sweep (several language rules don't yet reference up; audit tool rules for
+  language-file links). code-style.md → v1.6.0, EXTENDING.md → v1.2.0.
 - 2026-06-19 — **Folded the "check prior art before authoring" guidance into
   `EXTENDING.md` (PR #133).** A BACKLOG bullet ("when creating/modifying a
   rule or skill, check known sources for an existing implementation to vendor

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -21,7 +21,13 @@ items) and [`idea-sources.md`](idea-sources.md) (mined repos).
   **tool rule** declares the language(s) it applies to, by name (its
   Detection/applicability; a tool skill defers to the rule). References flow
   one way, **specific → generic** (and tool → language-by-name, never tool →
-  language file), to avoid circular drift-prone coupling.
+  language file), to avoid circular drift-prone coupling. **Caveat caught in
+  review:** the "no language-file reference" rule is only for
+  *language-agnostic* tools — a **single-language framework/library**
+  (`fastapi.md` building on `python.md`, `react.md` on `typescript.md`, the
+  `*-patterns` skills) is language-axis and *may* reference its language; the
+  policy, the `claude-audit` check, and the sweep task all carry that
+  distinction so the sweep doesn't strip legitimate framework references.
   `code-style.md` *Language-Specific Notes* was stripped of its (stale,
   Bash/Python-only) language list and now points to the codified policy;
   `claude-audit` step 2 verifies the layering. Follow-up filed: a conformance

--- a/config/claude/rules/code-style.md
+++ b/config/claude/rules/code-style.md
@@ -4,7 +4,7 @@
 
 # Code Style
 
-**Version:** v1.5.0
+**Version:** v1.6.0
 
 ## General Style
 
@@ -276,9 +276,10 @@ a threshold table with a loop, or a small helper function.
 
 ### Language-Specific Notes
 
-The general rule above applies to all languages. Per-language tooling
-details — whether auto-formatters enforce or fight this style, and how to
-handle it — live in each language's rules file:
-
-- Bash → `bash.md`
-- Python → `python.md`
+The general rules above apply to **every** language; this document names
+none. A language's own style and tooling specifics — including whether an
+auto-formatter enforces or fights this style — live in its path-scoped
+`rules/<language>.md`, which references back here. The full layering (generic
+→ language/tool rule → optional skill → optional patterns, referenced one way,
+specific → generic) is codified in `EXTENDING.md` *The language & tool
+stacks*.

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -75,7 +75,12 @@ decisions — revisit on a trigger or on request), `mining-census.md`
    flavored "generic" agent that would mislead a Go-only repo. Also check the
    **categories themselves**: has a top-level category grown **too big or too
    spread out** and need **splitting** (e.g. `qa` shedding `documentation` /
-   `troubleshooting`)? Splitting is the counter-move to over-folding.
+   `troubleshooting`)? Splitting is the counter-move to over-folding. Verify
+   the **language/tool layering** specifically (`EXTENDING.md` *The language &
+   tool stacks*): the generic layer (`code-style.md` / `EXTENDING.md`) names
+   **no** language or tool; every language/tool rule references **up** to it;
+   a **tool** rule declares its applicable language(s) by name and never links
+   a language *file*; optional skills/patterns are wired where they exist.
 3. **Recommend** by **cost × (1 − relevance)** — trim weight, never
    guardrails. Apply the placement ladder from `EXTENDING.md` (global+lazy >
    per-repo) and the plugin/MCP rules from `rules/mcp.md` (plugins are global

--- a/config/claude/skills/claude-audit/SKILL.md
+++ b/config/claude/skills/claude-audit/SKILL.md
@@ -79,8 +79,11 @@ decisions — revisit on a trigger or on request), `mining-census.md`
    the **language/tool layering** specifically (`EXTENDING.md` *The language &
    tool stacks*): the generic layer (`code-style.md` / `EXTENDING.md`) names
    **no** language or tool; every language/tool rule references **up** to it;
-   a **tool** rule declares its applicable language(s) by name and never links
-   a language *file*; optional skills/patterns are wired where they exist.
+   a **language-agnostic** tool rule declares its applicable language(s) by
+   name
+   and never links a language *file* (but a **single-language framework** like
+   `fastapi.md` *may* build on its language rule — not a violation); optional
+   skills/patterns are wired where they exist.
 3. **Recommend** by **cost × (1 − relevance)** — trim weight, never
    guardrails. Apply the placement ladder from `EXTENDING.md` (global+lazy >
    per-repo) and the plugin/MCP rules from `rules/mcp.md` (plugins are global


### PR DESCRIPTION
## Summary
Codify the (previously implicit) code-style → language → tool layering as
policy, working the "best-practices layer" backlog item.

- **Decision:** keep `code-style.md` as the generic shared layer; reject the
  "best-practices" recast (too broad — not just code).
- **`EXTENDING.md` (v1.2.0)** — new *The language & tool stacks* subsection:
  the generic layer names **no** language or tool; a language gets a rule
  [+ skill] [+ patterns] *only where it makes sense / is available*; a
  **language-agnostic tool** mirrors that shape but declares its languages
  **by name** on the tool rule (never links a language file); a
  **single-language framework/library** (fastapi, sqlalchemy, react) is
  language-axis and *may* build on its language rule. References flow
  **specific → generic**.
- **`code-style.md` (v1.6.0)** — strip the stale Bash/Python-only
  *Language-Specific Notes* list (the generic layer names no language) and
  point to the policy.
- **`claude-audit`** step 2 verifies the layering (with the framework
  exception).
- BACKLOG: mark the item done; file the conformance-sweep follow-up (which
  carries the framework distinction so it flags real violations only).

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] Docs-only — no code/tests changed.
- [ ] EXTENDING.md renders the new subsection (tool vs framework split);
      code-style.md names no language; BACKLOG pruned at finalization.