### PR TITLE
docs(git): add calver, signing & trunk-based tagging notes

### DIFF
--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -190,16 +190,20 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
   - [ ] commitizen — rule and/or skill for conventional commit message
     formatting; evaluate whether a rule (policy + invocation) is sufficient
     or whether the multi-step workflow warrants a skill
-  - [ ] git tagging — rule and/or skill for version tag conventions (semver
-    vs calver, signed vs unsigned, when to tag vs branch, how tags relate
-    to release branches); likely a rule unless the tagging+push+release
-    sequence is complex enough to warrant a skill
+  - [x] git tagging — **DONE.** Already covered by `git.md` *Versioning &
+    tags* (semver, annotated-only hygiene, repo/subdir methods) + the
+    **release-tag** skill (the cut sequence). Added the missing definitions
+    (git.md v1.12.0): **calver** as the declared format alternative to semver;
+    **signing** optional/per-repo (default unsigned); and a **trunk-based**
+    note (tag the merge commit; release branches out of scope). The full
+    release-branch model was deliberately **not** added — speculative, and
+    git.md is always-on (decisions log).
   - [ ] changelog generation — rule and/or skill for producing changelogs
     from git history on version changes; evaluate tools (git-cliff,
     conventional-changelog, keep-a-changelog manual pattern) and whether
     changelog generation should be part of a broader release skill alongside
     tagging and commitizen
-  - [ ] Any other tools discovered during pre-commit or CI work
+  - [x] Any other tools discovered during pre-commit or CI work
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -190,20 +190,11 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
   - [ ] commitizen — rule and/or skill for conventional commit message
     formatting; evaluate whether a rule (policy + invocation) is sufficient
     or whether the multi-step workflow warrants a skill
-  - [x] git tagging — **DONE.** Already covered by `git.md` *Versioning &
-    tags* (semver, annotated-only hygiene, repo/subdir methods) + the
-    **release-tag** skill (the cut sequence). Added the missing definitions
-    (git.md v1.12.0): **calver** as the declared format alternative to semver;
-    **signing** optional/per-repo (default unsigned); and a **trunk-based**
-    note (tag the merge commit; release branches out of scope). The full
-    release-branch model was deliberately **not** added — speculative, and
-    git.md is always-on (decisions log).
   - [ ] changelog generation — rule and/or skill for producing changelogs
     from git history on version changes; evaluate tools (git-cliff,
     conventional-changelog, keep-a-changelog manual pattern) and whether
     changelog generation should be part of a broader release skill alongside
     tagging and commitizen
-  - [x] Any other tools discovered during pre-commit or CI work
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,8 +6,21 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
-- 2026-06-20 — **Codified the code-style / language / tool layering in
-  `EXTENDING.md` (PR #134).** Worked the "best-practices layer" BACKLOG item.
+- 2026-06-20 — **Completed the git-tagging rule item; added the missing
+  definitions to `git.md` (PR #135).** The core was already covered (`git.md`
+  *Versioning & tags*: semver, annotated-only hygiene, repo/subdir methods +
+  the `release-tag` skill), so the item was largely done. Filled the gaps the
+  backlog listed — kept brief because `git.md` is **always-on**. **Added (user
+  chose the lean set):** (1) **calver** as the declared **format** alternative
+  to semver (date-based, e.g. `vYYYY.MM.DD`; format is now a per-repo axis
+  separate from the repo/subdir method; release-tag taught to derive it before
+  first use); (2) **signing** is optional and per-repo — annotated is the
+  baseline, `git tag -s` (GPG/SSH) optional, **default unsigned** (no signing
+  configured); (3) a **trunk-based** note — tag the merge commit on the
+  default branch; release-branch (`release/*`) strategies aren't used.
+  **Deliberately NOT added:** a full release-branch / gitflow model —
+  speculative (trunk-based workflow) and it would bloat always-on `git.md`.
+  git.md → v1.12.0.
   **Naming decision:** rejected recasting `code-style.md` to a
   "best-practices" doc — too broad (not just code) — and kept it as the
   generic shared style layer. **Placement (user chose EXTENDING canonical):**

--- a/config/claude/rules/git.md
+++ b/config/claude/rules/git.md
@@ -4,7 +4,7 @@
 
 # Git Rules
 
-**Version:** v1.11.0
+**Version:** v1.12.0
 
 ## Commit Messages
 
@@ -326,8 +326,9 @@ Both keep the branch a clean continuation; `git merge` does not.
 
 ## Versioning & tags
 
-Two separate things: **what a version *is*** (the `vX.Y.Z` format — universal)
-versus **how it's *applied*** (the tagging *method* — per-repo).
+Two separate things: **what a version *is*** (its **format** — semver by
+default) versus **how it's *applied*** (the tagging **method** — per-repo).
+Both are per-repo declared choices.
 
 ### What `vX.Y.Z` is
 
@@ -347,10 +348,24 @@ The `0 → 1` jump — declaring the project stable — is a **major decision in
 its own right**: give it as much thought and care as any later major bump
 (`1 → 2`, …). Cross it on purpose, never by accident.
 
+**Format is a per-repo choice — semver is the default, calver the
+alternative.** A repo that versions by *date* rather than *compatibility* uses
+**calver** (e.g. `vYYYY.MM.DD` or `vYY.MM`), declared in its
+`.claude/CONVENTIONS.md` beside the method, with the **release-tag** skill
+taught to derive it before first use. The semver rules above (the `0 → 1`
+jump, strict `y.z` once stable) are **semver-only** — a calver number carries
+no compatibility promise in itself.
+
 ### Tag hygiene (independent of method)
 
 - **Annotated** tags only — `git tag -a <tag> -m "<msg>"`, never lightweight.
-- Tag the **merge commit** the release ships from, not a side branch.
+- **Signing is optional and per-repo.** Annotated already records authorship;
+  a repo may additionally **sign** tags (`git tag -s`; GPG or SSH) where
+  provenance matters. Default here is **unsigned** — no signing is configured;
+  declare it per repo if adopted.
+- Tag the **merge commit** the release ships from, on the **default branch** —
+  this workflow is **trunk-based**; release-branch strategies (`release/*`)
+  aren't used, and adopting one is a per-repo config change.
 - A pushed tag is **immutable history**: never move, delete, or re-point it.
   A mistake gets a **new** tag, not a rewrite.
 - Push tags **explicitly** (`git push origin <tag>`); a plain `git push`


### PR DESCRIPTION
## Summary
Complete the "git tagging" rule backlog item. The core was already covered
(`git.md` *Versioning & tags* + the `release-tag` skill); fill the gaps the
backlog listed, kept brief because `git.md` is **always-on**:

- **calver** — separate the version **format** axis (semver default / calver
  date-based alternative, e.g. `vYYYY.MM.DD`) from the tagging **method**;
  declared per-repo; `release-tag` taught to derive it before first use.
- **Signing** — annotated baseline; `git tag -s` (GPG/SSH) optional and
  per-repo; **default unsigned** (no signing configured).
- **Trunk-based note** — tag the merge commit on the default branch;
  release-branch (`release/*`) strategies aren't used.

Deliberately did **not** add a full release-branch/gitflow model (speculative
+ always-on bloat). `git.md` → v1.12.0.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] Docs-only — no code/tests changed.
- [ ] git.md *Versioning & tags* renders the three additions; backlog items
      pruned at finalization.