### PR TITLE
docs(audit): resolve commitizen + changelog generation

### DIFF
--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -186,14 +186,6 @@ agent how to use each tool. Already have, among others: bash, perl,
 powershell, pre-commit, python, shellcheck, shfmt, yamllint, markdownlint,
 yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
 
-- [x] **Remaining rules to author — DONE.** The last two (commitizen,
-  changelog generation) were evaluated 2026-06-20 and resolved as **deliberate
-  non-adoptions**: conventional commits are in `git.md` *Commit Messages*; the
-  changelog is manual keep-a-changelog (generation N/A, per `.claude/QA.md`).
-  Both tools (commitizen; the git-cliff / conventional-changelog generators)
-  are deferred to [`ICEBOX.md`](ICEBOX.md) with triggers, to author on first
-  use (ADR-0003). (Earlier sub-items — new-project, git-tagging — landed in
-  their own PRs.)
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -186,15 +186,14 @@ agent how to use each tool. Already have, among others: bash, perl,
 powershell, pre-commit, python, shellcheck, shfmt, yamllint, markdownlint,
 yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
 
-- [ ] Remaining rules to author:
-  - [ ] commitizen — rule and/or skill for conventional commit message
-    formatting; evaluate whether a rule (policy + invocation) is sufficient
-    or whether the multi-step workflow warrants a skill
-  - [ ] changelog generation — rule and/or skill for producing changelogs
-    from git history on version changes; evaluate tools (git-cliff,
-    conventional-changelog, keep-a-changelog manual pattern) and whether
-    changelog generation should be part of a broader release skill alongside
-    tagging and commitizen
+- [x] **Remaining rules to author — DONE.** The last two (commitizen,
+  changelog generation) were evaluated 2026-06-20 and resolved as **deliberate
+  non-adoptions**: conventional commits are in `git.md` *Commit Messages*; the
+  changelog is manual keep-a-changelog (generation N/A, per `.claude/QA.md`).
+  Both tools (commitizen; the git-cliff / conventional-changelog generators)
+  are deferred to [`ICEBOX.md`](ICEBOX.md) with triggers, to author on first
+  use (ADR-0003). (Earlier sub-items — new-project, git-tagging — landed in
+  their own PRs.)
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,

--- a/config/claude/audit/ICEBOX.md
+++ b/config/claude/audit/ICEBOX.md
@@ -55,3 +55,26 @@ path, session duration, output speed, and token totals were skipped by the
 user; the context progress-bar glyph is the `SKIP-until` item on the
 [`mining-census.md`](mining-census.md) Watch list — revisit there if the plain
 `X%` stops being enough.)*
+
+## Commit & changelog tooling (commitizen, git-cliff, conventional-changelog)
+
+**Revisit when** a repo wants tool-driven conventional-commit authoring or
+`cz`-style version bumping (→ commitizen), or a changelog **generated** from
+git history rather than hand-written (→ git-cliff / conventional-changelog).
+
+Evaluated 2026-06-20 and **not adopted** — the agent and the dotfiles repo
+already cover the need without these tools:
+
+- **Conventional commits** are mandated in `rules/git.md` *Commit Messages*
+  and authored directly by the agent; no `commitizen` (`cz`) CLI, config, or
+  hook is used or needed.
+- **The changelog** is **manual** keep-a-changelog, written at merge-time
+  (`ship-pr` Step 4.5), grouped by date because the dotfiles repo isn't
+  release-versioned. `.claude/QA.md` records *Generated changelog: N/A*.
+
+If a repo *does* adopt one — a release-versioned component repo wanting a
+git-history changelog, or a team wanting enforced `cz` commits / `cz bump` —
+author the tool rule **then**, global and on first use (ADR-0003): a
+`commitizen.md` and/or a generator rule (weigh **git-cliff** vs
+**conventional-changelog**), wired into `qa.md` dim 13 (a generated changelog
+is a Format-class prep step) and the release flow (the `release-tag` skill).

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,22 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-20 — **Resolved commitizen + changelog-generation as deliberate
+  non-adoptions; closed "Remaining rules to author" (PR #136).** Worked the
+  last two items of the *Claude Rules Files* list together (they're coupled —
+  `commitizen` is the one tool that spans conventional-commit *authoring* +
+  `cz bump` + `cz changelog`). An inventory found **no functional gap**:
+  conventional commits are mandated in `git.md` *Commit Messages* and authored
+  by the agent (no `cz` CLI/config/hook anywhere), and the changelog is
+  **manual** keep-a-changelog at merge-time (`ship-pr` 4.5), grouped by date
+  since dotfiles isn't release-versioned (`.claude/QA.md` already records
+  *Generated changelog: N/A*). **Decision (user picked the lean path):** do
+  **not** author `commitizen.md` / `git-cliff.md` for tools nothing uses —
+  build-on-first-use (ADR-0003) — and defer them to `ICEBOX.md` with triggers
+  (a repo wanting `cz`-driven commits/bump, or a git-history-generated
+  changelog). With these resolved, the *Remaining rules to author* list is
+  **empty** and closed. No new artifact authored — the right outcome was the
+  evaluation + a recorded deferral, exercising the ICEBOX structure.
 - 2026-06-20 — **Completed the git-tagging rule item; added the missing
   definitions to `git.md` (PR #135).** The core was already covered (`git.md`
   *Versioning & tags*: semver, annotated-only hygiene, repo/subdir methods +


### PR DESCRIPTION
## Summary
The last two "rules to author" items (commitizen, changelog generation) are
**deliberate non-adoptions**, not gaps — an inventory found both already
handled:

- **Conventional commits** are mandated in `git.md` *Commit Messages* and
  authored by the agent; no `cz` CLI / config / hook anywhere.
- **The changelog** is **manual** keep-a-changelog at merge-time (`ship-pr`
  4.5), grouped by date (dotfiles isn't release-versioned); `.claude/QA.md`
  already records *Generated changelog: N/A*.

Per the lean choice (build-on-first-use, ADR-0003):
- Do **not** author `commitizen.md` / `git-cliff.md` for unused tools.
- `ICEBOX.md`: defer commitizen + the changelog generators (git-cliff /
  conventional-changelog) with triggers and the on-first-use plan.
- Close the now-empty "Remaining rules to author" list; record in
  `decisions-log.md`.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] Docs-only — no code/tests changed.
- [ ] ICEBOX.md carries the new deferral with triggers; backlog item pruned at
      finalization.