### PR TITLE
docs(code-style): no nested ternaries (+ Perl exception)

### DIFF
--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -189,9 +189,10 @@ yapf, git, gh, bats, docker (plus `.editorconfig` coverage for shfmt).
 - [ ] **Conformance sweep for the language/tool layering** (follow-up to the
   codification above). Bring existing artifacts into line with `EXTENDING.md`
   *The language & tool stacks*: each language rule (`typescript.md`,
-  `perl.md`, `powershell.md`, `html.md`, `css.md`, `react.md`, `bats.md`, …)
-  should **reference up** to `code-style.md` / `EXTENDING.md` (several don't
-  yet); and audit **language-agnostic tool** rules for any link to a language
+  `powershell.md`, `html.md`, `css.md`, `react.md`, `bats.md`, …) should
+  **reference up** to `code-style.md` / `EXTENDING.md` (several don't yet —
+  `perl.md` now does, done 2026-06-20); and audit **language-agnostic tool**
+  rules for any link to a language
   *file* (replace with a by-name "applies to <lang>" applicability).
   **Keep the framework distinction:** a single-language framework/library —
   `fastapi.md`, `sqlalchemy.md`, `react.md`, and their `*-patterns` skills —

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -243,17 +243,18 @@ duplicates / similar setups). Chart each in
 [`mining-census.md`](mining-census.md) and promote useful sources to
 [`idea-sources.md`](idea-sources.md). None below are mined yet.
 
-- [ ] **Anthropic official plugins — text re-mine of `code-simplifier` +
-  `commit-commands`.** Both were dropped at *capability* level (decisions log
-  2026-06-10) **without** a text-level review, and both have our equivalents
-  (`/simplify`; the git rules + `ship-pr` / `git-worktree-workflow`). Review
-  their actual prompt/command text for wording / sectioning worth folding into
-  ours. The other three (`pr-review-toolkit`, `feature-dev`,
-  `security-guidance`) were already content-reviewed — their extractable bits
-  are the vendor-when-needed items under *Plugin-audit follow-ups*; not
-  re-opened.
-  - <https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier>
-  - <https://github.com/anthropics/claude-plugins-official/tree/main/plugins/commit-commands>
+- [x] **Anthropic official plugins — text re-mine of `code-simplifier` +
+  `commit-commands`. DONE (2026-06-20).** Read both from the local marketplace
+  cache. **One fold:** `code-simplifier`'s "avoid nested ternaries / dense
+  one-liners; clarity over brevity" — added to `code-style.md` *Prefer elif*
+  (v1.7.0). **Everything else SKIP** — its stack-specifics (ES modules, React,
+  arrow fns) violate our generic-layer-names-no-language rule; its
+  auto-refine-on-every-edit mode contradicts our scope discipline (don't
+  improve adjacent code). `commit-commands` (`commit`, `commit-push-pr`,
+  `clean_gone`) all SKIP: `git.md` *Commit Messages* + `ship-pr` +
+  `git-worktree-workflow` Op 7 are richer and safer (ours confirms each /
+  skips dirty vs. the plugin's force-delete). Verdict recorded in
+  decisions-log.
 - [ ] **Plugin/skill collection repos (big — one at a time).**
   - <https://github.com/ComposioHQ/awesome-claude-plugins>
   - <https://github.com/jeremylongshore/claude-code-plugins-plus-skills>

--- a/config/claude/audit/BACKLOG.md
+++ b/config/claude/audit/BACKLOG.md
@@ -244,18 +244,6 @@ duplicates / similar setups). Chart each in
 [`mining-census.md`](mining-census.md) and promote useful sources to
 [`idea-sources.md`](idea-sources.md). None below are mined yet.
 
-- [x] **Anthropic official plugins — text re-mine of `code-simplifier` +
-  `commit-commands`. DONE (2026-06-20).** Read both from the local marketplace
-  cache. **One fold:** `code-simplifier`'s "avoid nested ternaries / dense
-  one-liners; clarity over brevity" — added to `code-style.md` *Prefer elif*
-  (v1.7.0). **Everything else SKIP** — its stack-specifics (ES modules, React,
-  arrow fns) violate our generic-layer-names-no-language rule; its
-  auto-refine-on-every-edit mode contradicts our scope discipline (don't
-  improve adjacent code). `commit-commands` (`commit`, `commit-push-pr`,
-  `clean_gone`) all SKIP: `git.md` *Commit Messages* + `ship-pr` +
-  `git-worktree-workflow` Op 7 are richer and safer (ours confirms each /
-  skips dirty vs. the plugin's force-delete). Verdict recorded in
-  decisions-log.
 - [ ] **Plugin/skill collection repos (big — one at a time).**
   - <https://github.com/ComposioHQ/awesome-claude-plugins>
   - <https://github.com/jeremylongshore/claude-code-plugins-plus-skills>

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -6,6 +6,23 @@ annotated, not rewritten. Audit-only (not context-loaded); written by the
 **claude-audit** skill. Sibling records: [`BACKLOG.md`](BACKLOG.md) (open
 items) and [`idea-sources.md`](idea-sources.md) (mined repos).
 
+- 2026-06-20 — **Text re-mined the Anthropic official `code-simplifier` +
+  `commit-commands` plugins (PR #137).** Both were dropped at *capability*
+  level on 2026-06-10 without reading their prompt/command text; this is the
+  text-level pass (read from the local marketplace cache, no fetch). **One
+  fold:** `code-simplifier`'s "avoid nested ternaries / dense one-liners,
+  clarity over brevity" — a concrete, generic readability rule we lacked —
+  added to `code-style.md` *Prefer elif Over Sequential if Blocks* (v1.7.0).
+  **Rest SKIP, with reasons:** code-simplifier's stack-specifics (ES modules,
+  React, arrow functions) violate the generic-layer-names-no-language rule
+  (`EXTENDING.md`); its "auto-refine proactively after every edit" mode
+  contradicts our scope discipline (`CLAUDE.md` — don't improve adjacent
+  code); "focus on recently-modified code" / "preserve functionality" are
+  already how our review skills work. `commit-commands` (`commit`,
+  `commit-push-pr`, `clean_gone`) all SKIP — `git.md` *Commit Messages* +
+  `ship-pr` + `git-worktree-workflow` Op 7 are richer and **safer** (ours
+  confirms each branch / skips dirty; the plugin force-deletes). Net: the
+  capability-level drops stand; one small wording fold gained.
 - 2026-06-20 — **Resolved commitizen + changelog-generation as deliberate
   non-adoptions; closed "Remaining rules to author" (PR #136).** Worked the
   last two items of the *Claude Rules Files* list together (they're coupled —

--- a/config/claude/audit/decisions-log.md
+++ b/config/claude/audit/decisions-log.md
@@ -22,7 +22,12 @@ items) and [`idea-sources.md`](idea-sources.md) (mined repos).
   `commit-push-pr`, `clean_gone`) all SKIP — `git.md` *Commit Messages* +
   `ship-pr` + `git-worktree-workflow` Op 7 are richer and **safer** (ours
   confirms each branch / skips dirty; the plugin force-deletes). Net: the
-  capability-level drops stand; one small wording fold gained.
+  capability-level drops stand; one small wording fold gained. **Follow-up
+  (user request):** the new no-nested-ternary rule's **Perl exception** was
+  added to `rules/perl.md` — idiomatic terseness (single-line ternaries,
+  statement modifiers) is Perl's character and relaxes the rule, short of
+  golf; perl.md also gained its `code-style.md` reference-up, so it now
+  conforms to the language layering (removed from the conformance-sweep list).
 - 2026-06-20 — **Resolved commitizen + changelog-generation as deliberate
   non-adoptions; closed "Remaining rules to author" (PR #136).** Worked the
   last two items of the *Claude Rules Files* list together (they're coupled —

--- a/config/claude/rules/code-style.md
+++ b/config/claude/rules/code-style.md
@@ -4,7 +4,7 @@
 
 # Code Style
 
-**Version:** v1.6.0
+**Version:** v1.7.0
 
 ## General Style
 
@@ -273,6 +273,11 @@ whatever the language spells it.)*
 When a chain grows to four or more branches testing the same variable,
 consider refactoring: a `case`/`switch` statement for discrete values,
 a threshold table with a loop, or a small helper function.
+
+**Don't compress a conditional into a nested ternary** (a stacked `?:`) or a
+dense one-liner to save lines — that trades clarity for brevity, the wrong
+direction. A reader should be able to scan the branches: prefer an explicit
+`if`/`else` (or `case`/`switch`) chain over a clever one-liner.
 
 ### Language-Specific Notes
 

--- a/config/claude/rules/perl.md
+++ b/config/claude/rules/perl.md
@@ -7,9 +7,25 @@ paths:
 
 # Perl Style
 
+Builds on the generic `code-style.md`; the Perl-specific points below extend
+it — and, for terseness, deliberately **relax** it.
+
+## Tooling
+
 - Format with `perltidy`.
 - Lint with `perlcritic --severity 4` (severity 4 = gentle; lower numbers
   are stricter, 1 = brutal).
+
+## Terseness & idioms
+
+Perl's character is concise, expressive terseness, so it **relaxes**
+`code-style.md`'s *clarity over brevity* / no-nested-ternary guideline (its
+*Prefer elif Over Sequential if Blocks* section). An idiomatic single-line
+ternary — `my $x = foo() ? bar() : baz();` — and statement modifiers
+(`do_x() if $cond;`) are normal, readable Perl: keep them where they read
+cleanly rather than expanding to a full `if`/`else` just to satisfy the
+generic rule. What still holds: **no Perl golf** — deliberately cryptic,
+character-minimizing code for its own sake is out.
 
 ## Agent Behavior
 
@@ -17,6 +33,9 @@ paths:
   1. Run `perltidy -b <file>` to format in place (`-b` backs up the
      original as `<file>.bak`; delete the backup after confirming).
   2. Run `perlcritic --severity 4 <file>` and fix all reported violations.
+- Accept idiomatic Perl terseness (ternaries, statement modifiers) where it
+  reads cleanly — apply `code-style.md`'s clarity-over-brevity rule less
+  strictly here — but never write golf.
 - **Prefer pre-commit** when the repo has it (see `pre-commit.md`):
   `pre-commit run --files <file>` to check, and `pre-commit run --config
   .pre-commit-config-fix.yaml --files <file>` to fix. Fall back to the direct


### PR DESCRIPTION
## Summary
Text re-mine of the Anthropic official `code-simplifier` + `commit-commands`
plugins (read from the local marketplace cache), plus a user-requested Perl
exception to the one bit folded in.

- **`code-style.md` (v1.7.0)** — fold `code-simplifier`'s one useful, generic
  bit: "don't compress a conditional into a nested ternary / dense one-liner —
  clarity over brevity," in the *Prefer elif* section. Everything else SKIP
  (its stack-specifics violate the generic-layer rule; its auto-refine mode
  contradicts scope discipline; `commit-commands` is covered more richly/safely
  by git.md + ship-pr + git-worktree-workflow Op 7).
- **`rules/perl.md`** — Perl **relaxes** that rule: idiomatic single-line
  ternaries / statement modifiers are Perl's character (short of golf). Also
  adds perl.md's "Builds on `code-style.md`" reference-up, bringing it into
  language-layering conformance (dropped from the sweep list).
- decisions-log records both; backlog mining item closed.

## Test plan
- [ ] `pre-commit run --all-files` green (markdownlint incl.); prose ≤ 78 col.
- [ ] Docs-only — no code/tests changed.
- [ ] code-style.md carries the no-nested-ternary rule; perl.md relaxes it +
      references up; backlog item pruned at finalization.